### PR TITLE
Adds internal support for Dynmap-Towny features present in Goosius' fork of Dynmap-Towny.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>0.0.5</version>
+  <version>0.0.6</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>
@@ -20,6 +20,10 @@
       <id>jitpack.io</id>
       <url>https://jitpack.io</url>
 	</repository>
+    <repository>
+      <id>dynmap-repo</id>
+      <url>http://repo.mikeprimm.com/</url>
+    </repository>
   </repositories>
   
   <dependencies>
@@ -40,6 +44,11 @@
       <artifactId>annotations</artifactId>
       <version>16.0.2</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>us.dynmap</groupId>
+      <artifactId>dynmap-api</artifactId>
+      <version>2.5</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -4,10 +4,13 @@ import java.io.IOException;
 import java.util.List;
 
 import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.dynmap.DynmapAPI;
 
 import com.gmail.goosius.siegewar.settings.Settings;
+import com.gmail.goosius.siegewar.tasks.DynmapTask;
 import com.palmergames.bukkit.util.Version;
 import com.gmail.goosius.siegewar.command.SiegeWarAdminCommand;
 import com.gmail.goosius.siegewar.command.SiegeWarCommand;
@@ -60,11 +63,20 @@ public class SiegeWar extends JavaPlugin {
         if (Bukkit.getPluginManager().getPlugin("Towny").isEnabled())
         	SiegeController.loadAll();
         
+        Plugin dynmap = Bukkit.getPluginManager().getPlugin("dynmap");
+        if (dynmap != null) {
+        	System.out.println(prefix + "SiegeWar found Dynmap, enabling Dynmap support.");
+        	DynmapTask.setDynmapAPI((DynmapAPI) dynmap);
+        } else {
+        	System.out.println(prefix + "Dynmap not found.");
+        }
+        
         System.out.println(prefix + "SiegeWar loaded successfully.");
     }
     
     @Override
     public void onDisable() {
+    	DynmapTask.endDynmapTask();
     	System.err.println(prefix + "Shutting down....");
     }
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -4,7 +4,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
-import com.gmail.goosius.siegewar.SiegeWarTimerTaskController;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
@@ -18,6 +17,7 @@ import com.palmergames.bukkit.towny.event.time.NewShortTimeEvent;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.gmail.goosius.siegewar.settings.Translation;
+import com.gmail.goosius.siegewar.tasks.SiegeWarTimerTaskController;
 
 /**
  * 

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
@@ -1,0 +1,131 @@
+package com.gmail.goosius.siegewar.tasks;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.dynmap.DynmapAPI;
+import org.dynmap.markers.Marker;
+import org.dynmap.markers.MarkerAPI;
+import org.dynmap.markers.MarkerIcon;
+import org.dynmap.markers.MarkerSet;
+
+import com.gmail.goosius.siegewar.SiegeController;
+import com.gmail.goosius.siegewar.SiegeWar;
+import com.gmail.goosius.siegewar.enums.SiegeStatus;
+import com.gmail.goosius.siegewar.objects.Siege;
+import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.gmail.goosius.siegewar.utils.SiegeWarDynmapUtil;
+import com.palmergames.bukkit.towny.TownyEconomyHandler;
+import com.palmergames.util.StringMgmt;
+import com.palmergames.util.TimeMgmt;
+
+public class DynmapTask {
+
+    static DynmapAPI api;
+    static MarkerAPI markerapi;
+    static boolean stop;
+    static MarkerSet set;
+    static Map<String, Marker> markerMap = new HashMap<String, Marker>();
+
+    public static void setDynmapAPI(DynmapAPI _api) {
+        api = _api;
+        markerapi = api.getMarkerAPI();
+        if (markerapi == null) {
+            System.err.println(SiegeWar.prefix + "Error loading dynmap marker API!");
+            return;
+        }
+
+        set = markerapi.getMarkerSet("siegewar.markerset");
+        if (set == null)
+            set = markerapi.createMarkerSet("siegewar.markerset", "SiegeWar", null, false);
+        else
+            set.setMarkerSetLabel("SiegeWar");
+        if (set == null) {
+            System.err.println(SiegeWar.prefix + "Error creating dynmap marker set");
+            return;
+        }
+
+        startDynmapTask();
+        System.out.println(SiegeWar.prefix + "Dynmap support enabled.");
+    }
+
+    public static void startDynmapTask() {
+        stop = false;
+        Bukkit.getScheduler().runTaskTimerAsynchronously(SiegeWar.getSiegeWar(), () -> {
+            if (!stop) {
+                hideTacticallyInvisiblePlayers();
+                displaySieges();
+            }
+        }, 40l, 300l);
+    }
+
+    public static void endDynmapTask() {
+        stop = true;
+    }
+
+    private static void displaySieges() {
+        for (Siege siege : SiegeController.getSieges()) {
+            String name = "Siege: " + siege.getName().replace("#", " ");
+            try {
+                if (siege.getStatus() == SiegeStatus.IN_PROGRESS) {
+                    MarkerIcon siegeIcon = markerapi.getMarkerIcon("fire");
+                    List<String> lines = new ArrayList<>();
+                    lines.add("Attacker: " + siege.getAttackingNation().getName());
+                    lines.add("Defender: " + siege.getDefendingTown().getName());
+                    lines.add("Points: " + siege.getSiegePoints());
+                    lines.add("Banner Control: " + siege.getBannerControllingSide());
+                    lines.add("Time left: " + TimeMgmt.getFormattedTimeValue(siege.getTimeUntilCompletionMillis()));
+                    lines.add("War Chest: " + TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount()));
+                    String desc = "<b>" + name + "</b><hr>" + StringMgmt.join(lines, "<br>");
+                    Location siegeLoc = siege.getFlagLocation();
+                    double siegeX = siegeLoc.getX();
+                    double siegeZ = siegeLoc.getZ();
+                    String siegeMarkerId = siege.getName();
+                    Marker siegeMarker = markerMap.get(siegeMarkerId);
+                    if (siegeMarker == null) {
+                        siegeMarker = set.createMarker(siegeMarkerId, name, siegeLoc.getWorld().getName(), siegeX, 64,
+                                siegeZ, siegeIcon, false);
+                    } else {
+                        siegeMarker.setLocation(siegeLoc.getWorld().getName(), siegeX, 64, siegeZ);
+                        siegeMarker.setLabel(name);
+                        siegeMarker.setDescription(desc);
+                        siegeMarker.setMarkerIcon(siegeIcon);
+                    }
+
+                    if (siegeMarker != null)
+                        markerMap.put(siegeMarkerId, siegeMarker);
+
+                }
+            } catch (Exception ex) {
+                System.err.println(SiegeWar.prefix + "Problem adding siege marker for siege: " + name);
+                ex.printStackTrace();
+            }
+        }
+
+    }
+
+    /**
+     * This method hides players who have 'tactical invisibility. It also un-hides
+     * players who do not.
+     */
+    private static void hideTacticallyInvisiblePlayers() {
+        if (!SiegeWarSettings.getWarSiegeTacticalVisibilityEnabled())
+            return;
+
+        List<Player> onlinePlayers = new ArrayList<>(Bukkit.getOnlinePlayers());
+
+        for (Player player : onlinePlayers) {
+            if (player.hasMetadata(SiegeWarDynmapUtil.TACTICAL_INVISIBILITY_METADATA_ID)) {
+                // Hide from dynmap if tactically invis
+                api.assertPlayerInvisibility(player, true, SiegeWar.getSiegeWar());
+            } else {
+                // Otherwise don't hide
+                api.assertPlayerInvisibility(player, false, SiegeWar.getSiegeWar());
+            }
+        }
+    }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
@@ -1,5 +1,6 @@
-package com.gmail.goosius.siegewar;
+package com.gmail.goosius.siegewar.tasks;
 
+import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;

--- a/src/main/resources/Changelog.txt
+++ b/src/main/resources/Changelog.txt
@@ -20,3 +20,8 @@
   - Change command: /swa immunity all towns in nation {nationname} {hours}
     to: /swa immunity nation {nationname} {hours}
   - Fix global message spam from /swa immunity {town|nation} sub-commands.
+0.0.6:
+  - Adds internal support for Dynmap-Towny features present in Goosius' fork of Dynmap-Towny.
+    - Sieges will show on your dynmap, if dynmap is installed.
+    - Information can be seen about the siege including points, banner control side, warchest.
+    - Closes #4.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ author: [Goosius,LlmDl]
 website: 'townyadvanced.github.io'
 prefix: ${project.artifactId}
 depend: [Towny]
+softdepend: [dynmap]
 
 description: A war system made by Goosius for Towny.
 


### PR DESCRIPTION
  - Adds internal support for Dynmap-Towny features present in Goosius'
fork of Dynmap-Towny.
    - Sieges will show on your dynmap, if dynmap is installed.
Dynmap-Towny is not required.
    - Information can be seen about the siege including points, banner
control side, warchest.
    - Closes #4.

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #4 
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
