### PR TITLE
Remove under a block restriction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.classpath
 /.project
 /.settings
+.idea
+SiegeWar.iml

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/AttackTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/AttackTown.java
@@ -71,9 +71,6 @@ public class AttackTown {
                 throw new TownyException(Translation.of("msg_err_siege_war_cannot_attack_non_enemy_nation"));
         }
 
-        if (!SiegeWarDistanceUtil.isUndergroundBannerControlEnabledInWorld(block.getWorld()) && SiegeWarDistanceUtil.doesLocationHaveANonAirBlockAboveIt(block.getLocation()))
-            throw new TownyException(Translation.of("msg_err_siege_war_banner_must_be_placed_above_ground"));
-
         if(!SiegeWarDistanceUtil.isBannerToTownElevationDifferenceOk(block, townBlock)) {
 			throw new TownyException(Translation.of("msg_err_siege_war_cannot_place_banner_far_above_town"));
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -37,11 +37,6 @@ public enum ConfigNodes {
 			"world, world_nether, world_the_end",
 			"",
 			"# This list specifies the worlds in which siegewar is enabled."),
-	WAR_SIEGE_WORLDS_WITH_UNDERGROUND_BANNER_CONTROL(
-			"war.siege.switches.worlds_with_underground_banner_control",
-			"world_nether",
-			"",
-			"# This list specifies the worlds in which underground-banner-control is enabled."),
 	WAR_SIEGE_ATTACK_ENABLED(
 			"war.siege.switches.attack_enabled",
 			"true",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -21,10 +21,6 @@ public class SiegeWarSettings {
 		return Settings.getString(ConfigNodes.WAR_SIEGE_WORLDS);
 	}
 
-	public static String getWarWorldsWithUndergroundBannerControl() {
-		return Settings.getString(ConfigNodes.WAR_SIEGE_WORLDS_WITH_UNDERGROUND_BANNER_CONTROL);
-	}
-
 	public static boolean getWarSiegeAttackEnabled() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_ATTACK_ENABLED);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -186,10 +186,6 @@ public class SiegeWarBannerControlUtil {
 		if(!SiegeWarPointsUtil.isPlayerInTimedPointZone(player, siege))
 			return false; //player is not in the timed point zone
 
-		if(!SiegeWarDistanceUtil.isUndergroundBannerControlEnabledInWorld(player.getLocation().getWorld())
-			&& SiegeWarDistanceUtil.doesLocationHaveANonAirBlockAboveIt(player.getLocation()))
-			return false; //player has a block above them
-
 		return true;
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -14,7 +14,6 @@ import com.palmergames.bukkit.towny.object.WorldCoord;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
@@ -33,7 +32,6 @@ public class SiegeWarDistanceUtil {
 
 	private static final int TOWNBLOCKSIZE= TownySettings.getTownBlockSize();
 	public static List<String> worldsWithSiegeWarEnabled = null;
-	public static List<String> worldsWithUndergroundBannerControlEnabled = null;
 
 	/**
 	 * This method determines if the difference in elevation between a (attack banner) block, 
@@ -124,26 +122,6 @@ public class SiegeWarDistanceUtil {
 		return false;
 	}
 
-    /**
-     * This method determines if a location has an air block above it
-     *
-     * @param location the location
-     * @return true if location has an air block above it
-     */
-    public static boolean doesLocationHaveANonAirBlockAboveIt(Location location) {
-        location.add(0,1,0);
-
-        while(location.getY() < 256)
-        {
-            if(!(location.getBlock().getType() == Material.AIR || location.getBlock().getType() == Material.CAVE_AIR || location.getBlock().getType() == Material.VOID_AIR))
-            {
-                return true;   //There is a non-air block above them
-            }
-            location.add(0,1,0);
-        }
-        return false;  //There is nothing but air above them
-    }
-
 	/**
 	 * This method determines if a siegewar is enabled in the given world
 	 *
@@ -160,24 +138,6 @@ public class SiegeWarDistanceUtil {
 			}
 		}
 		return worldsWithSiegeWarEnabled.contains(worldToCheck.getName());
-	}
-
-	/**
-	 * This method determines if underground banner control is enabled in the given world
-	 *
-	 * @param worldToCheck the world to check
-	 * @return true if underground banner control is enabled in the given world
-	 */
-	public static boolean isUndergroundBannerControlEnabledInWorld(World worldToCheck) {
-		if (worldsWithUndergroundBannerControlEnabled == null) {
-			worldsWithUndergroundBannerControlEnabled = new ArrayList<>();
-			String[] worldNamesAsArray = SiegeWarSettings.getWarWorldsWithUndergroundBannerControl().split(",");
-			for (String worldName : worldNamesAsArray) {
-				if (Bukkit.getServer().getWorld(worldName.trim()) != null)
-					worldsWithUndergroundBannerControlEnabled.add(Bukkit.getServer().getWorld(worldName.trim()).getName());
-			}
-		}
-		return worldsWithUndergroundBannerControlEnabled.contains(worldToCheck.getName());
 	}
 
 	public static boolean isInSiegeZone(Location location, Siege siege) {

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.06
+version: 0.05
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -50,7 +50,7 @@ msg_siege_war_town_bankrupted_from_plunder: '&b%s has been bankrupted by %s!'
 msg_siege_war_nation_defeated: '&b%s has been defeated!.'
 msg_siege_war_attacking_troops_at_siege_banner: '&bSiege on %s > Attackers are at the siege banner.'
 msg_siege_war_defending_troops_at_siege_banner: '&bSiege on %s > Town defenders are at the siege banner.'
-msg_siege_war_banner_control_session_started: '&bBanner control session started. Remain close to the siege-banner (%d blocks horizonally, %d blocks vertically), outside the town, not flying, and not under a block (world dependant), for %s. If your session succeeds, you will gain banner control for your side (or be added to the banner control list).'
+msg_siege_war_banner_control_session_started: '&bBanner control session started. Remain close to the siege-banner (%d blocks horizonally, %d blocks vertically), outside the town, and not flying, for %s. If your session succeeds, you will gain banner control for your side (or be added to the banner control list).'
 msg_siege_war_banner_control_session_success: '&bBanner control session succeeded!. You have been added to the banner control list.'
 msg_siege_war_banner_control_gained_by_attacker: '&bSiege on %s > The attackers have gained banner control.'
 msg_siege_war_banner_control_gained_by_defender: '&bSiege on %s > The defenders have gained banner control.'
@@ -118,7 +118,7 @@ msg_err_siege_war_banner_support_block_not_stable: "&cYou cannot place the banne
 # Spawn
 msg_err_siege_war_cannot_spawn_into_siegezone_or_besieged_town: '&cOnly town residents can spawn into a besieged town or siege zone (unless the target town is peaceful).'
 #Banner control
-msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: Going into the town, too far from the banner, flying, or under a block (world-dependent).'
+msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: Going into the town, too far from the banner, or flying.'
 msg_war_siege_zone_milk_bucket_forbidden_while_attempting_banner_control: 'You cannot use this item while in a banner control session.'
 
 #Town Info Siege Section

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.05
+version: 0.06
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
- Removed the restrictions of having to place an attack banner above ground, or having to be above ground to get a banner control session
- This feature was a legacy feature which was too exploitable and not fun e.g, the enemy could prevent or interrupt banner control sessions by placeing hard-to-see blocks high above the siege zone
- Also the feature is not needed now that the glow-during-sessions feature has been confirmed to be working fine.

____
#### New Nodes/Commands/ConfigOptions: 
NA

____
#### Relevant Issue ticket:
NA
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
