### PR TITLE
Fixed revolt feature to apply to all towns

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -125,13 +125,14 @@ public class SiegeWarNationEventListener implements Listener {
 				}
 			}
 
+			//A town cannot leave unless its revolt immunity timer is finished
 			if (SiegeWarSettings.getWarSiegeTownLeaveDisabled()) {
 
 				if (!SiegeWarSettings.getWarSiegeRevoltEnabled()) {
 					event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_err_siege_war_town_voluntary_leave_impossible"));
 					event.setCancelled(true);
 				}
-				if (town.isConquered() && System.currentTimeMillis() < TownMetaDataController.getRevoltImmunityEndTime(town)) {
+				if (System.currentTimeMillis() < TownMetaDataController.getRevoltImmunityEndTime(town)) {
 					event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_err_siege_war_revolt_immunity_active"));
 					event.setCancelled(true);
 				} else {
@@ -146,7 +147,7 @@ public class SiegeWarNationEventListener implements Listener {
 	
 	@EventHandler
 	public void onTownLeavesNation(NationTownLeaveEvent event) {
-		if (SiegeWarSettings.getWarSiegeEnabled() && event.getTown().isConquered()) {
+		if (SiegeWarSettings.getWarSiegeEnabled() && SiegeWarSettings.getWarSiegeRevoltEnabled()) {
 			//Activate revolt immunity
 			SiegeWarTimeUtil.activateRevoltImmunityTimer(event.getTown());
 			event.getTown().setConquered(false);

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -28,7 +28,7 @@ msg_err_command_disable: '&cYou don''t have enough permissions for that command.
 
 #Added in (Siegewar version)
 #Siege war happy-path messages
-msg_siege_war_revolt: '&bThe people of %s, led by %s, have revolted against the occupying power of %s, and declared themselves free to choose their own destiny!'
+msg_siege_war_revolt: '&bThe people of %s, led by %s, have revolted against %s, and declared themselves free to choose their own destiny!'
 msg_siege_war_siege_started_neutral_town: '&bAn army belonging to %s has attacked %s. A siege has begun!'
 msg_siege_war_siege_started_nation_town: '&bAn army belonging to %s has attacked %s at %s. A siege has begun!'
 msg_siege_war_attack_pay_war_chest: '&bA war-chest has been prepared by %s, with a value of %s. Whoever wins the siege will get this money.'


### PR DESCRIPTION
#### Description: 
- With current code, the "revolt" feature is only applied to towns which are officially "occupied"
- But this was never the intention. For example, the state of Texas does not consider itself "occuped", but if it broke away tomorrow from the U.S., it would most certainly be considered a "revolt".
- Perhaps this update went in at some point in the past due to a misleading message in the english.yml, which I have now fixed in this PR, which used to refer to "occupying power", which was only meant in a metaphorical way, not literally occupied=true.
____
#### New Nodes/Commands/ConfigOptions: 
NA

____
#### Relevant Issue ticket:
NA

____
- [ x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
