### PR TITLE
Make siegezones cylindrical

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -261,7 +261,8 @@ public enum ConfigNodes {
 			"150",
 			"",
 			"# The radius of the 'siege zone' ",
-		    "# Various siege related effects can apply in this zone e.g. lose points on death, keep inv on death, cannot claim here."),
+			"# This radius applies only horizontally, so players can never get above a siegezone (e.g. to place lava there or something).",
+			"# Various siege related effects can apply in this zone e.g. lose points on death, keep inv on death, cannot claim here."),
 	WAR_SIEGE_BANNER_CONTROL_HORIZONTAL_DISTANCE_BLOCKS(
 			"war.siege.distances.banner_control_horizontal_distance_blocks",
 			"16",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -260,7 +260,7 @@ public enum ConfigNodes {
 			"war.siege.distances.zone_radius_blocks",
 			"150",
 			"",
-			"# The radius of the 'siege zone' ",
+			"# The radius of the 'siege zone'.",
 			"# This radius applies only horizontally, so players can never get above a siegezone (e.g. to place lava there or something).",
 			"# Various siege related effects can apply in this zone e.g. lose points on death, keep inv on death, cannot claim here."),
 	WAR_SIEGE_BANNER_CONTROL_HORIZONTAL_DISTANCE_BLOCKS(

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -141,11 +141,11 @@ public class SiegeWarDistanceUtil {
 	}
 
 	public static boolean isInSiegeZone(Location location, Siege siege) {
-		return areLocationsClose(location, siege.getFlagLocation(), SiegeWarSettings.getWarSiegeZoneRadiusBlocks());
+		return areLocationsCloseHorizontally(location, siege.getFlagLocation(), SiegeWarSettings.getWarSiegeZoneRadiusBlocks());
 	}
 
 	public static boolean isInSiegeZone(Entity entity, Siege siege) {
-		return areLocationsClose(entity.getLocation(), siege.getFlagLocation(), SiegeWarSettings.getWarSiegeZoneRadiusBlocks());
+		return areLocationsCloseHorizontally(entity.getLocation(), siege.getFlagLocation(), SiegeWarSettings.getWarSiegeZoneRadiusBlocks());
 	}
 
 	public static boolean isCloseToLeader(Player player1, Player player2) {
@@ -206,7 +206,17 @@ public class SiegeWarDistanceUtil {
 
 		return true;
 	}
-	
+
+	//Check horizontal distance only
+	private static boolean areLocationsCloseHorizontally(Location location1, Location location2, int radius) {
+		if(!location1.getWorld().getName().equalsIgnoreCase(location2.getWorld().getName()))
+			return false;
+
+		//Check horizontal distance
+		double xzDistance = Math.sqrt(Math.pow(location1.getX() - location2.getX(), 2) + Math.pow(location1.getZ() - location2.getZ(), 2));
+		return xzDistance < radius;
+	}
+
 	private static Location getTopNorthWestCornerLocation(WorldCoord worldCoord) {
 		int locX = worldCoord.getX() * TOWNBLOCKSIZE;
 		int locZ = worldCoord.getZ() * TOWNBLOCKSIZE;


### PR DESCRIPTION
#### Description: 
- Currently an exploit exists where a player can get themselves directly above a siegezone (e.g. like y=250), where they can then drop siege-restricted blocks onto the siegezone (e.g. maybe lava)
- This PR fixes the exploit by making siegezones cylindrical rather than spherical, i.e. ignoring the vertical axis and instead taking in blocks at all heights as long as they are within the horizontal radius.

#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
