### PR TITLE
Fixe null pointer exception with nation-delete

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -96,9 +96,10 @@ public class SiegeWarNationEventListener implements Listener {
 		if (SiegeWarSettings.getWarSiegeEnabled() && TownySettings.isUsingEconomy()
 				&& SiegeWarSettings.getWarSiegeRefundInitialNationCostOnDelete()) {
 			int amountToRefund = (int)(TownySettings.getNewNationPrice() * 0.01 * SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete());
-			Messaging.sendMsg(event.getNation().getKing().getPlayer(), Translation.of("msg_err_siege_war_delete_nation_warning", TownyEconomyHandler.getFormattedBalance(amountToRefund)));
+			if(event.getNation().getKing().getPlayer() != null) {
+				Messaging.sendMsg(event.getNation().getKing().getPlayer(), Translation.of("msg_err_siege_war_delete_nation_warning", TownyEconomyHandler.getFormattedBalance(amountToRefund)));
+			}
 		}
-
 	}
 	
 	/*

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
@@ -123,11 +123,14 @@ public class SiegeWarMoneyUtil {
 			int amountToRefund = (int)(TownySettings.getNewNationPrice() * 0.01 * SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete());
 			ResidentMetaDataController.setNationRefundAmount(king, amountToRefund);
 
-			Messaging.sendMsg(
-				king.getPlayer(),
-				String.format(
-					Translation.of("msg_siege_war_nation_refund_available"),
-					TownyEconomyHandler.getFormattedBalance(amountToRefund)));
+			//Send message if the king is online & not an npc
+			if(king.getPlayer() != null) {
+				Messaging.sendMsg(
+						king.getPlayer(),
+						String.format(
+								Translation.of("msg_siege_war_nation_refund_available"),
+								TownyEconomyHandler.getFormattedBalance(amountToRefund)));
+			}
 		}
 	}
 	


### PR DESCRIPTION
#### Description: 
- Currently if there is an NPC king (or maybe just offline) when a nation disbands, you get a null pointer exception  (which may have other knock-on affects too)
- This very small PR fixes the issues by adding an if statement to ensure the king is not an NPC 

__
#### New Nodes/Commands/ConfigOptions: 
NA

____
#### Relevant Issue ticket:
NA

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
