### PR TITLE
Fixed null pointers on message npc's/offline_players

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/Messaging.java
+++ b/src/main/java/com/gmail/goosius/siegewar/Messaging.java
@@ -15,11 +15,15 @@ public class Messaging {
 	final static String prefix = Translation.of("plugin_prefix");
 	
 	public static void sendErrorMsg(CommandSender sender, String message) {
-		sender.sendMessage(prefix + Colors.Red + message);
+		//Ensure the sender is not null (i.e. is an online player who is not an npc)
+        if(sender != null)
+	        sender.sendMessage(prefix + Colors.Red + message);
 	}
 
 	public static void sendMsg(CommandSender sender, String message) {
-		sender.sendMessage(prefix + Colors.White + message);
+        //Ensure the sender is not null (i.e. is an online player who is not an npc)
+        if(sender != null)
+    		sender.sendMessage(prefix + Colors.White + message);
 	}
 	
 	public static void sendGlobalMessage(String message) {


### PR DESCRIPTION
<!--- Describe your Pull Request's purpose here please. --->
- With current code null pointer exceptions can occur when the recipient of a message is an NPC or offline player
- This small PR fixes the problem by checking for a live player before sending the message

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [ x] I have tested this pull request for defects on a server. 
- 
By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
