### PR TITLE
Changed terminology of "tactical invisibility" to "map sneaking"

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -75,7 +75,7 @@ public class SiegeWarTownyEventListener implements Listener {
             SiegeWarTimerTaskController.punishPeacefulPlayersInActiveSiegeZones();
             SiegeWarTimerTaskController.evaluateBattleSessions();
             SiegeWarTimerTaskController.evaluateBannerControl();
-            SiegeWarTimerTaskController.evaluateTacticalVisibility();
+            SiegeWarTimerTaskController.evaluateMapSneaking();
             SiegeWarTimerTaskController.evaluateTimedSiegeOutcomes();
             SiegeHUDManager.updateHUDs();
         }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -445,30 +445,28 @@ public enum ConfigNodes {
 			"",
 			"# This setting is used to indicate the list of forbidden buckets"),
 
-	//Tactical Visibility
+	//Map Sneaking
 	//Todo - Eventually move this to another location as it works regardless of war system, or without.
-	WAR_SIEGE_TACTICAL_VISIBILITY_ENABLED(
-			"war.siege.switches.tactical_visibility_enabled",
+	WAR_SIEGE_MAP_SNEAKING_ENABLED(
+			"war.siege.switches.map_sneaking_enabled",
 			"true",
 			"",
-			"# If this setting is true, then the tactical invisibility feature is enabled",
+			"# If this setting is true, then the map sneaking feature is enabled",
 			"# PREREQUISITES: ",
-			"# * You must have deployed a dynmap jar containing support for tactical invisibility.",
-			"# * In your dynmap config, tactical-invisibility must be enabled.",
+			"# * You must have deployed a standard dynmap jar.",
 			"# ",
 			"# DESCRIPTION",
 			"# * This feature is critical to enable normal military tactics such as ambushing.",
 			"# * The feature works as follows:",	
-			"# * Player in a banner control session - Always visible on map.",
-			"# * Player with certain items in their hands (configured below) - Invisible on map.",
-			"# * ",
-			"# * NOTE: Any additional dynmap config settings for map invisibility will override the 'always visible' scenarios above."),
-	WAR_SIEGE_TACTICAL_VISIBILITY_ITEMS(
-			"war.siege.items.tactical_visibility_items",
+			"# * if a player wishes to 'map sneak', they equip a specific combination of items in their hands (configured below).",
+			"# * Then in a few seconds they will disappear from the dynmap, and are then considered to be 'map sneaking'.",
+			"# * Player's in banner control sessions cannot map-sneak"),
+	WAR_SIEGE_MAP_SNEAKING_ITEMS(
+			"war.siege.items.map_sneaking_items",
 			"compass|diamond_sword, compass|bow",
 			"",
-			"# This list specifies the items which make players tactically invisible. ",
-			"# Each list entry is in the format of <off-hand>|<main-hand>.",
+			"# This list specifies the item combinations which allow players to map-sneak.",
+			"# Each list entry is in the form of <off-hand>|<main-hand>.",
 			"# ",
 			"# To specify that both items are required - e.g. 'compass|painting'" + 
 			"# To specify that only one item is required - e.g. 'compass|any'",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -9,7 +9,7 @@ import com.gmail.goosius.siegewar.objects.HeldItemsCombination;
 
 public class SiegeWarSettings {
 	
-	private static final List<HeldItemsCombination> tacticalVisibilityItems = new ArrayList<>();
+	private static final List<HeldItemsCombination> mapSneakingItems = new ArrayList<>();
 	private static List<Material> battleSessionsForbiddenBlockMaterials = null;
 	private static List<Material> battleSessionsForbiddenBucketMaterials = null;
 	
@@ -181,14 +181,14 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_LEADERSHIP_AURA_RADIUS_BLOCKS);
 	}
 
-	public static boolean getWarSiegeTacticalVisibilityEnabled() {
-		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_TACTICAL_VISIBILITY_ENABLED);
+	public static boolean getWarSiegeMapSneakingEnabled() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_MAP_SNEAKING_ENABLED);
 	}
 
-	public static List<HeldItemsCombination> getWarSiegeTacticalVisibilityItems() {
+	public static List<HeldItemsCombination> getWarSiegeMapSneakingItems() {
 		try {
-			if (tacticalVisibilityItems.isEmpty()) {
-				String itemsListAsString = Settings.getString(ConfigNodes.WAR_SIEGE_TACTICAL_VISIBILITY_ITEMS);
+			if (mapSneakingItems.isEmpty()) {
+				String itemsListAsString = Settings.getString(ConfigNodes.WAR_SIEGE_MAP_SNEAKING_ITEMS);
 				String[] itemsListAsArray = itemsListAsString.split(",");
 				String[] itemPair;
 				boolean ignoreOffHand;
@@ -221,15 +221,15 @@ public class SiegeWarSettings {
 						mainHandItem = Material.matchMaterial(itemPair[1]);
 					}
 
-					tacticalVisibilityItems.add(
+					mapSneakingItems.add(
 						new HeldItemsCombination(offHandItem,mainHandItem,ignoreOffHand,ignoreMainHand));
 				}
 			}
 		} catch (Exception e) {
-			System.out.println("Problem reading tactical visibility items list. The list is config.yml may be misconfigured.");
+			System.out.println("Problem reading map sneaking items list. The list is config.yml may be misconfigured.");
 			e.printStackTrace();
 		}
-		return tacticalVisibilityItems;
+		return mapSneakingItems;
 	}
 
 	public static int getWarSiegeBannerControlSessionDurationMinutes() {

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
@@ -57,7 +57,7 @@ public class DynmapTask {
         stop = false;
         Bukkit.getScheduler().runTaskTimerAsynchronously(SiegeWar.getSiegeWar(), () -> {
             if (!stop) {
-                hideTacticallyInvisiblePlayers();
+                hideMapSneakingPlayers();
                 displaySieges();
             }
         }, 40l, 300l);
@@ -107,18 +107,18 @@ public class DynmapTask {
     }
 
     /**
-     * This method hides players who have 'tactical invisibility. It also un-hides
-     * players who do not.
+     * This method hides players who are 'map sneaking'.
+     * It also un-hides players who are not.
      */
-    private static void hideTacticallyInvisiblePlayers() {
-        if (!SiegeWarSettings.getWarSiegeTacticalVisibilityEnabled())
+    private static void hideMapSneakingPlayers() {
+        if (!SiegeWarSettings.getWarSiegeMapSneakingEnabled())
             return;
 
         List<Player> onlinePlayers = new ArrayList<>(Bukkit.getOnlinePlayers());
 
         for (Player player : onlinePlayers) {
-            if (player.hasMetadata(SiegeWarDynmapUtil.TACTICAL_INVISIBILITY_METADATA_ID)) {
-                // Hide from dynmap if tactically invis
+            if (player.hasMetadata(SiegeWarDynmapUtil.MAP_SNEAK_METADATA_ID)) {
+                // Hide from dynmap if map sneaking
                 api.assertPlayerInvisibility(player, true, SiegeWar.getSiegeWar());
             } else {
                 // Otherwise don't hide

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
@@ -80,11 +80,11 @@ public class SiegeWarTimerTaskController {
 
 	/**
 	 * Evaluate the visibility of players on the dynmap
-	 * when using the 'tactical visibility' feature
+	 * when using the 'map sneaking' feature
 	 */
-	public static void evaluateTacticalVisibility() {
-		if (SiegeWarSettings.getWarSiegeTacticalVisibilityEnabled()) {
-			SiegeWarDynmapUtil.evaluatePlayerTacticalInvisibility();
+	public static void evaluateMapSneaking() {
+		if (SiegeWarSettings.getWarSiegeMapSneakingEnabled()) {
+			SiegeWarDynmapUtil.evaluatePlayerMapSneaking();
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDynmapUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDynmapUtil.java
@@ -15,19 +15,19 @@ import org.bukkit.metadata.FixedMetadataValue;
  */
 public class SiegeWarDynmapUtil {
 
-	public static String TACTICAL_INVISIBILITY_METADATA_ID = "tacticallyInvisible";
-	public static FixedMetadataValue TACTICAL_INVISIBILITY_FIXED_METADATA_VALUE = new FixedMetadataValue(Towny.getPlugin(), true);
+	public static String MAP_SNEAK_METADATA_ID = "tacticallyInvisible";
+	public static FixedMetadataValue MAP_SNEAK_FIXED_METADATA_VALUE = new FixedMetadataValue(Towny.getPlugin(), true);
 	
 	/**
-	 * Evaluate players to see if they are 'tactically' invisible
+	 * Evaluate players to see if they are 'map sneaking'
 	 * 
-	 * Tactical invisibility makes a player invisible on the dynmap
+	 * Map-sneaking makes a player invisible on the dynmap
 	 * It is triggered if the player sets their main/off hand combinations 
 	 * to one of the specified combinations (set in config file).
 	 *
-	 * Players in banner control sessions cannot be tactically invisible
+	 * Players in banner control sessions cannot map-sneak
 	 */
-	public static void evaluatePlayerTacticalInvisibility() {
+	public static void evaluatePlayerMapSneaking() {
 		boolean invisibleOnDynmap;
 
 		for(Player player: BukkitTools.getOnlinePlayers()) {
@@ -39,7 +39,7 @@ public class SiegeWarDynmapUtil {
 				if (!SiegeController.getPlayersInBannerControlSessions().contains(player)) {
 
 					//Check item combinations
-					for(HeldItemsCombination heldItemsCombination: SiegeWarSettings.getWarSiegeTacticalVisibilityItems()) {
+					for(HeldItemsCombination heldItemsCombination: SiegeWarSettings.getWarSiegeMapSneakingItems()) {
 
 						//Off Hand
 						if(!heldItemsCombination.isIgnoreOffHand() && player.getInventory().getItemInOffHand().getType() != heldItemsCombination.getOffHandItemType())
@@ -56,20 +56,20 @@ public class SiegeWarDynmapUtil {
 				}
 
 				if(invisibleOnDynmap) {
-					if(!player.hasMetadata(TACTICAL_INVISIBILITY_METADATA_ID)) {
-						player.setMetadata(TACTICAL_INVISIBILITY_METADATA_ID, TACTICAL_INVISIBILITY_FIXED_METADATA_VALUE);
+					if(!player.hasMetadata(MAP_SNEAK_METADATA_ID)) {
+						player.setMetadata(MAP_SNEAK_METADATA_ID, MAP_SNEAK_FIXED_METADATA_VALUE);
 					}
 				} else {
-					if (player.hasMetadata(TACTICAL_INVISIBILITY_METADATA_ID)) {
-						player.removeMetadata(TACTICAL_INVISIBILITY_METADATA_ID, Towny.getPlugin());
+					if (player.hasMetadata(MAP_SNEAK_METADATA_ID)) {
+						player.removeMetadata(MAP_SNEAK_METADATA_ID, Towny.getPlugin());
 					}
 				}
 
 			} catch (Exception e) {
 				try {
-					System.out.println("Problem evaluating tactical invisibility for player " + player.getName());
+					System.out.println("Problem evaluating map sneaking for player " + player.getName());
 				} catch (Exception e2) {
-					System.out.println("Problem evaluating tactical invisibility for a player (could not read player name)");
+					System.out.println("Problem evaluating map sneaking for a player (could not read player name)");
 				}
 				e.printStackTrace();
 			}


### PR DESCRIPTION
#### Description: 
- The "Tactical Invisibility" feature is simple to use, and essential for standard military tactics like ambushes.
- However the terminology is a real mouthful, which may explain why it is a less popularly discussed tactic than it should be. 
- Thus in this PR I change the terminology to "Map Sneaking"
- I have also updated the relevant wiki documentation
- This PR was all refactor-renames of variables/methods, and renames in configs/comments. No functionality was changed (and I even left the metadata name unchanged)
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
