### PR TITLE
Remove leadership aura feature

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -273,14 +273,6 @@ public enum ConfigNodes {
 			"16",
 			"",
 			"# This is the vertical distance a soldier must be from the banner to get banner control."),
-	WAR_SIEGE_LEADERSHIP_AURA_RADIUS_BLOCKS(
-		"war.siege.distances.leadership_aura_radius_blocks",
-			"50",
-			"",
-			"# This setting determines the size of the 'Military Leadership Aura'.",
-			"# The aura emanates from kings, generals, and captains.",
-			"# The aura decreases death point losses for nearby nation/allied soldiers in a siege.",
-			"# The aura increases death point gains for nearby enemy soldiers in a siege."),
 
 	//Siege points
 	WAR_SIEGE_POINTS_FOR_ATTACKER_OCCUPATION(
@@ -329,17 +321,6 @@ public enum ConfigNodes {
 			"# Configuration Outcomes:",
 			"# Value HIGH --> If the value is high, then PVP will be DISCOURAGED",
 			"# Value LOW --> If the value is low, then PVP will be ENCOURAGED"),	
-	WAR_SIEGE_POINTS_PERCENTAGE_ADJUSTMENT_FOR_LEADER_PROXIMITY(
-			"war.siege.scoring.percentage_adjustment_for_leader_proximity",
-			"10",
-			"",
-			"# If a friendly military leader is nearby when a soldier dies in a siege, then points loss is reduced by this percentage.",
-			"# If an enemy military leader is nearby when a soldier dies in a siege, then points loss is increased by this percentage."),
-	WAR_SIEGE_POINTS_PERCENTAGE_ADJUSTMENT_FOR_LEADER_DEATH(
-			"war.siege.scoring.percentage_adjustment_for_leader_death",
-			"50",
-			"",
-			"# If a military leader dies in a siege, then points loss in increased by this percentage."),
 	WAR_SIEGE_POPULATION_QUOTIENT_FOR_MAX_POINTS_BOOST(
 			"war.siege.scoring.population_quotient_for_max_points_boost",
 			"3.0",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -169,18 +169,6 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_EXTRA_MONEY_PERCENTAGE_PER_TOWN_LEVEL);
 	}
 
-	public static double getWarSiegePointsPercentageAdjustmentForLeaderProximity() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_POINTS_PERCENTAGE_ADJUSTMENT_FOR_LEADER_PROXIMITY);
-	}
-
-	public static double getWarSiegePointsPercentageAdjustmentForLeaderDeath() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_POINTS_PERCENTAGE_ADJUSTMENT_FOR_LEADER_DEATH);
-	}
-
-	public static int getWarSiegeLeadershipAuraRadiusBlocks() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_LEADERSHIP_AURA_RADIUS_BLOCKS);
-	}
-
 	public static boolean getWarSiegeTacticalVisibilityEnabled() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_TACTICAL_VISIBILITY_ENABLED);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -148,10 +148,6 @@ public class SiegeWarDistanceUtil {
 		return areLocationsCloseHorizontally(entity.getLocation(), siege.getFlagLocation(), SiegeWarSettings.getWarSiegeZoneRadiusBlocks());
 	}
 
-	public static boolean isCloseToLeader(Player player1, Player player2) {
-		return areLocationsClose(player1.getLocation(), player2.getLocation(), SiegeWarSettings.getWarSiegeLeadershipAuraRadiusBlocks());
-	}
-
 	public static boolean isInTimedPointZone(Entity entity, Siege siege) {
 		return areLocationsClose(entity.getLocation(), siege.getFlagLocation(), SiegeWarSettings.getBannerControlHorizontalDistanceBlocks(), SiegeWarSettings.getBannerControlVerticalDistanceBlocks());
 	}
@@ -181,13 +177,6 @@ public class SiegeWarDistanceUtil {
 		double distanceTownblocks = Math.sqrt(Math.pow(coord1.getX() - coord2.getX(), 2) + Math.pow(coord1.getZ() - coord2.getZ(), 2));
 
 		return distanceTownblocks < radiusTownblocks;
-	}
-
-	private static boolean areLocationsClose(Location location1, Location location2, int radius) {
-		if(!location1.getWorld().getName().equalsIgnoreCase(location2.getWorld().getName()))
-			return false;
-
-		return location1.distance(location2) < radius;
 	}
 
 	private static boolean areLocationsClose(Location location1, Location location2, int maxHorizontalDistance, int maxVerticalDistance) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarPointsUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarPointsUtil.java
@@ -80,13 +80,11 @@ public class SiegeWarPointsUtil {
 		if (residentIsAttacker) {
 			siegePoints = -SiegeWarSettings.getWarSiegePointsForAttackerDeath();
 			siegePoints = adjustSiegePointPenaltyForBannerControl(true, siegePoints, siege);
-			siegePoints = adjustSiegePenaltyPointsForMilitaryLeadership(true, siegePoints, player, resident, siege);
 			siegePoints = adjustSiegePointsForPopulationQuotient(false, siegePoints, siege);
 			siege.adjustSiegePoints(siegePoints);
 		} else {
 			siegePoints = SiegeWarSettings.getWarSiegePointsForDefenderDeath();
 			siegePoints = adjustSiegePointPenaltyForBannerControl(false, siegePoints, siege);
-			siegePoints = adjustSiegePenaltyPointsForMilitaryLeadership(false, siegePoints, player, resident, siege);
 			siegePoints = adjustSiegePointsForPopulationQuotient(true, siegePoints, siege);
 			siege.adjustSiegePoints(siegePoints);
 		}
@@ -101,100 +99,6 @@ public class SiegeWarPointsUtil {
 			Math.abs(siegePoints));
 
 		SiegeWarNotificationUtil.informSiegeParticipants(siege, message);
-	}
-
-	private static int adjustSiegePenaltyPointsForMilitaryLeadership(boolean residentIsAttacker,
-																	 double siegePoints,
-																	 Player player,
-																	 Resident resident,
-																	 Siege siege) {
-		try {
-			TownyUniverse universe = TownyUniverse.getInstance();
-
-			//Resident town has nation
-			if(resident.getTown().hasNation()) {
-
-				if(universe.getPermissionSource().testPermission(resident.getPlayer(), SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_LEADERSHIP.getNode())) {
-					//Player is Leader. Apply points increase
-					double modifier = 1 + (SiegeWarSettings.getWarSiegePointsPercentageAdjustmentForLeaderDeath() / 100);
-					return (int)(siegePoints * modifier);
-
-				} else {
-					//Player is not leader
-					if(player == null) {
-						//Player is null. Apply points increase regardless of player location/online/offline, to avoid exploits
-						double modifier = 1 + (SiegeWarSettings.getWarSiegePointsPercentageAdjustmentForLeaderProximity() / 100);
-						return (int)(siegePoints * modifier);
-					} else {
-						//Player is online. Look for nearby friendly/hostile leaders
-						Resident otherResident;
-						boolean friendlyLeaderNearby = false;
-						boolean hostileLeaderNearby = false;
-
-						for (Player otherPlayer : BukkitTools.getOnlinePlayers()) {
-							if (friendlyLeaderNearby && hostileLeaderNearby)
-								break;
-
-							otherResident = universe.getResident(otherPlayer.getUniqueId());
-							if (otherResident == null)
-								continue;
-							
-							//Look for friendly military leader 
-							if (!friendlyLeaderNearby) {
-								if (otherResident.hasTown()
-									&& otherResident.hasNation()
-									&& universe.getPermissionSource().testPermission(otherResident.getPlayer(), SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_LEADERSHIP.getNode())
-									&& (otherResident.getTown().getNation() == resident.getTown().getNation() || otherResident.getTown().getNation().hasMutualAlly(resident.getTown().getNation()))
-									&& SiegeWarDistanceUtil.isCloseToLeader(player, otherPlayer)) {
-									friendlyLeaderNearby = true;
-									continue;
-								}
-							}
-
-							//As attacker, look for hostile military leader
-							if (!hostileLeaderNearby && residentIsAttacker) {
-								if (otherResident.hasTown()
-									&& otherResident.getTown().hasNation()
-									&& siege.getDefendingTown().hasNation()
-									&& universe.getPermissionSource().testPermission(otherResident.getPlayer(), SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_LEADERSHIP.getNode())
-									&& (otherResident.getTown().getNation() == siege.getDefendingTown().getNation() || otherResident.getTown().getNation().hasMutualAlly(siege.getDefendingTown().getNation()))
-									&& SiegeWarDistanceUtil.isCloseToLeader(player, otherPlayer)) {
-									hostileLeaderNearby = true;
-									continue;
-								}
-							}
-
-							//As defender, look for hostile military leader
-							if (!hostileLeaderNearby && !residentIsAttacker) {
-								if (otherResident.hasTown()
-									&& otherResident.getTown().hasNation()
-									&& universe.getPermissionSource().testPermission(otherResident.getPlayer(), SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_LEADERSHIP.getNode())
-									&& (otherResident.getTown().getNation() == siege.getAttackingNation() || otherResident.getTown().getNation().hasMutualAlly(siege.getAttackingNation()))
-									&& SiegeWarDistanceUtil.isCloseToLeader(player, otherPlayer)) {
-									hostileLeaderNearby = true;
-									continue;
-								}
-							}
-						}
-
-						if (friendlyLeaderNearby && !hostileLeaderNearby) {
-							//Friendly leader nearby. Apply points decrease
-							double modifier = 1 - (SiegeWarSettings.getWarSiegePointsPercentageAdjustmentForLeaderProximity() / 100);
-							return (int) (siegePoints * modifier);
-						} else if (hostileLeaderNearby && !friendlyLeaderNearby) {
-							//Enemy leader nearby. Apply points increase
-							double modifier = 1 + (SiegeWarSettings.getWarSiegePointsPercentageAdjustmentForLeaderProximity() / 100);
-							return (int) (siegePoints * modifier);
-						}
-					}
-				}
-			}
-		} catch (Exception e) {
-			System.out.println("Problem adjusting siege point penalty for military leadership");
-			e.printStackTrace();
-		}
-
-		return (int)siegePoints;
 	}
 
 	public static void updatePopulationBasedSiegePointModifiers() {


### PR DESCRIPTION
#### Description: 
- The "leadership aura" feature is extra complexity without any added value
- There is already an implicit leadership aura at work during battles, i.e. when players with actual leadership qualities are doing their thing, so an explicit dynamic points change is unnecessary to get the required effect. 
- By removing the feature, it also makes space for servers to enable much more usefully complex features such as the counterratack booster. 
- I checked with the testers channel and confirmed that this feature is not generally considered useful, and is already turned off on multiple servers.
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
