### PR TITLE
Negative item durability fix

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -1,5 +1,6 @@
 package com.gmail.goosius.siegewar.playeractions;
 
+import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
@@ -170,18 +171,27 @@ public class PlayerDeath {
 		int currentDurability;
 		int damageToInflict;
 		int newDurability;
-		if(SiegeWarSettings.getWarSiegeDeathPenaltyDegradeInventoryEnabled()) {
-			for(ItemStack itemStack: playerDeathEvent.getEntity().getInventory().getContents()) {
+		Boolean closeToBreaking = false;
+		if (SiegeWarSettings.getWarSiegeDeathPenaltyDegradeInventoryEnabled()) {
+			for (ItemStack itemStack : playerDeathEvent.getEntity().getInventory().getContents()) {
 				if (itemStack != null && itemStack.getItemMeta() instanceof Damageable) {
 					damageable = ((Damageable) itemStack.getItemMeta());
 					maxDurability = itemStack.getType().getMaxDurability();
 					currentDurability = damageable.getDamage();
 					damageToInflict = (int)(maxDurability / 100 * SiegeWarSettings.getWarSiegeDeathPenaltyDegradeInventoryPercentage());
 					newDurability = currentDurability + damageToInflict;
-					damageable.setDamage(newDurability);
+					if (newDurability >= maxDurability) {
+						damageable.setDamage(Math.max((int)maxDurability-10, currentDurability));
+						closeToBreaking = true;
+					}
+					else {
+						damageable.setDamage(newDurability);
+					}
 					itemStack.setItemMeta((ItemMeta)damageable);
 				}
 			}
+			if (closeToBreaking) //One or more items are close to breaking, send warning.
+				Messaging.sendMsg(playerDeathEvent.getEntity(), Translation.of("inventory_degrade_warning"));
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -191,7 +191,7 @@ public class PlayerDeath {
 				}
 			}
 			if (closeToBreaking) //One or more items are close to breaking, send warning.
-				Messaging.sendMsg(playerDeathEvent.getEntity(), Translation.of("inventory_degrade_warning"));
+				Messaging.sendMsg(playerDeathEvent.getEntity(), Translation.of("msg_inventory_degrade_warning"));
 		}
 	}
 

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.05
+version: 0.06
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -247,3 +247,6 @@ dynmap_siege_status_pending_surrender: 'Pending Surrender'
 dynmap_siege_status_pending_abandon: 'Pending Abandon'
 dynmap_siege_time_left: 'Time Left: %s'
 dynmap_siege_war_chest: 'War Chest: %s'
+
+#Added in 0.06:
+inventory_degrade_warning: '&4WARNING: &cSome of your gear is close to breaking due to inventory degradation.'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -249,4 +249,4 @@ dynmap_siege_time_left: 'Time Left: %s'
 dynmap_siege_war_chest: 'War Chest: %s'
 
 #Added in 0.06:
-inventory_degrade_warning: '&4WARNING: &cSome of your gear is close to breaking due to inventory degradation.'
+msg_inventory_degrade_warning: '&4WARNING: &cSome of your gear is close to breaking due to inventory degradation.'


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes items being able to go into negative durability. Instead of items going into negative durability or breaking, durability will be set to 10 or the current durability (whichever is lowest), and send a warning message to the player.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
