### PR TITLE
Change counter-attack booster default to active

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -132,6 +132,15 @@ public enum ConfigNodes {
 			"",
 			"# If this value is true, then a town under active siege cannot unclaim.",
 			"#  This setting is recommended if invasion/occupation is enabled, to avoid occupation escape exploits."),
+	WAR_SIEGE_COUNTERATTACK_BOOSTER_DISABLED(
+			"war.siege.switches.counterattack_booster_disabled",
+			"false",
+			"",
+			"# If this setting is false, and a player from the banner controlling side dies,",
+			"# then the death points are increased by a certain percentage. (see points section below)",
+			"# This setting is very important as it prevents large unskilled armies from dominating small pvp-skilled armies during sieges.",
+			"# However, this is not an instant-win for the pvp-skilled side",
+			"# To fully even the odds, they may have to employ military tactics such as map-sneaking/ambushes to close with the enemy army."),
 	WAR_SIEGE_POPULATION_BASED_POINT_BOOSTS_ENABLED(
 			"war.siege.switches.population_based_point_boosts_enabled",
 			"false",
@@ -140,13 +149,6 @@ public enum ConfigNodes {
 			"# The attacking side population consists of the residents of the attacking nation, and allies.",
 			"# The defending side population consists of the residents of the defending town, and nation + allies if applicable.",
 			"# The level of the boost is configured in separate configs. See the scoring section of this file."),
-	WAR_SIEGE_COUNTERATTACK_BOOSTER_ENABLED(
-			"war.siege.switches.counterattack_booster_enabled",
-			"false",
-			"",
-			"# If this setting is true, and a player from the banner controlling side dies,",
-			"# then the death points are increased by a certain percentage. (see points section below)",
-			"# This setting gives smaller and weaker towns/nations a better chance, as they will tend to be the counter-attackers."),
 
 	//Monetary Values
 	WAR_SIEGE_ATTACKER_COST_UPFRONT_PER_PLOT(
@@ -320,7 +322,14 @@ public enum ConfigNodes {
 			"# ",
 			"# Configuration Outcomes:",
 			"# Value HIGH --> If the value is high, then PVP will be DISCOURAGED",
-			"# Value LOW --> If the value is low, then PVP will be ENCOURAGED"),	
+			"# Value LOW --> If the value is low, then PVP will be ENCOURAGED"),
+	WAR_SIEGE_COUNTERATTACK_BOOSTER_EXTRA_DEATH_POINTS_PER_PLAYER_PERCENT(
+			"war.siege.scoring.counterattack_booster_extra_death_points_per_player_percent",
+			"10.0",
+			"",
+			"# As long as the counterattack booster feature is not disabled, then this setting determines the strength of the boost.",
+			"# Example: If this setting is 10.0, and there are 3 players on the banner control list, and a player from the banner-controlling side dies,",
+			"# then the death points will be increased by 30%."),
 	WAR_SIEGE_POPULATION_QUOTIENT_FOR_MAX_POINTS_BOOST(
 			"war.siege.scoring.population_quotient_for_max_points_boost",
 			"3.0",
@@ -341,13 +350,6 @@ public enum ConfigNodes {
 			"# 2. Assume that a siege attacker greatly outnumbers a siege defender in population. (also counting allies)",
 			"# 3. In this example, if the siege defender scores any siege points, the points will be multiplied by 2.",
 			"# 4. In this example, the siege attacker will not get any points boosts."),
-	WAR_SIEGE_COUNTERATTACK_BOOSTER_EXTRA_DEATH_POINTS_PER_PLAYER_PERCENT(
-			"war.siege.scoring.counterattack_booster_extra_death_points_per_player_percent",
-			"5.0",
-			"",
-			"# If the counterattack booster feature is enabled, then this setting determines the strength of the boost.",
-			"# Example: If this setting is 5.0, and there are 3 players on the banner control list, and a player from the controlling side dies,",
-			"# then the death points will be increased by 15%."),
 
 	//Siege-war specific peaceful towns
 	WAR_SIEGE_PEACEFUL_TOWNS_GUARDIAN_TOWN_PLOTS_REQUIREMENT(

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -240,8 +240,8 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.OCCUPIED_TOWN_UNCLAIMING_DISABLED);
 	}
 
-	public static boolean isWarSiegeCounterattackBoosterEnabled() {
-		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_COUNTERATTACK_BOOSTER_ENABLED);
+	public static boolean isWarSiegeCounterattackBoosterDisabled() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_COUNTERATTACK_BOOSTER_DISABLED);
 	}
 
 	public static double getWarSiegeCounterattackBoosterExtraDeathPointsPerPlayerPercent() {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarPointsUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarPointsUtil.java
@@ -197,7 +197,7 @@ public class SiegeWarPointsUtil {
 	}
 
 	public static int adjustSiegePointPenaltyForBannerControl(boolean residentIsAttacker, int siegePoints, Siege siege) {
-		if(!SiegeWarSettings.isWarSiegeCounterattackBoosterEnabled())
+		if(SiegeWarSettings.isWarSiegeCounterattackBoosterDisabled())
 			return siegePoints;
 
 		if(


### PR DESCRIPTION
#### Description: 
- There exists today a big siege balance problem, which many servers are facing.
- It relates to the fact that, with the default death/timed points, large unskilled armies can completely dominate smaller pvp-skilled armies during sieges

EXAMPLE 1
- The following chart shows how much time it takes for 2 siege sides to recover the points from each soldier death, using the default death/timed-point settings (Death points 150, Timed points 10):
```
Player_on_bc	1_Def_Death	Def_Recovery_Time(If BC holds) 	1_Att_death	Att_Recovery_Time(If they switch BC) 	
1		+150		5 mins				-150		5 mins
2  		+150  		2.5 mins			-150		2.5 mins
5  		+150  		1 min				-150		1 min
10  		+150  		0.5 mins			-150		0.5 mins
20  		+150  		0.25 mins			-150		0.25 mins
30  		+150  		0.16 mins			-150		0.16 mins
```
- The problem here is that when one sides gets BC, and gets a large number of players on the BC list, then their timed points take off like a rocket.  In the above example, if the side defending the banner got 30 people on the list, then the side attacking the banner would have to kill 6 defenders each minute, and not incur any deaths themselves, just to avoid falling behind on siege points!.

EXAMPLE 2
- Many servers today (Datblock is a notable example), combat this problem by configuring a huge difference between timed and death points, as follows (death points 500, timed points 2):
```
Player_on_bc	1_Def_Death	Def_Recovery_Time(If BC holds) 	1_Att_death	Att_Recovery_Time(If they switch BC) 	
1		+500		16.7 mins			+500		16.7 mins
2  		+500  		8.3 mins			+500  		8.3 mins
5  		+500  		3.33 min			+500  		3.33 min
10  		+500  		1.67 mins			+500  		1.67 mins
20  		+500  		0.83 mins			+500  		0.83 mins
30  		+500  		0.55 mins			+500  		0.55 mins
```
- There are 2 key problems here:
   - Casual/Low-Skill players become less important for gaining siege points. Whereas before, these players could contribute to a siege by getting banner control and seeing the timed points go up at a good rate, now if they get banner control, the points go up at a measly rate of 6 per minute. Compared with the death point of 500, such player will justifiably feel that their contributions to siege points are quite worthless compared to what the PVP-gods in the team can accomplish.
   - Casual/Low-Skill players are discouraged from entering battles. To understand this, look at the value for 20 players -> If you are in a battle with your army, and you die, then it will take the team almost 1 minute to recover from your death. This is actually not too bad if your army has the banner control, however if your army is attacking the banner, there is no guarantee that your side will retake the banner, and say the attack peters off soon after, leaving just 2 attackers, then even if they succeed, you will have cost your team 8.3 minutes of time. Thus casual/low-skill players, having a generally poor K/D ration will be discouraged from even entering battles (Although they may be invited later after the professional pvp-ers have done the fun stuff of capturing the banner).

EXAMPLE 3
- The solution is already implemented and available in the plugin, it is the "counterattack_booster" feature. Here is what the table looks like with the value set at 10%:
```
Player_on_bc	1_Def_Death	Def_Recovery_Time(If BC holds) 	1_Att_death	Att_Recovery_Time(If they switch BC) 	
1		+160		5.5 mins			-150		5 mins
2  		+180  		3 mins				-150		2.5 mins
5  		+225  		1.5 min				-150		1 min
10  		+300  		1 mins				-150		0.5 mins
20  		+450  		0.75 mins			-150		0.25 mins
30  		+600  		0.66 mins			-150		0.16 mins
```
- Here we see that neither side is punished severely for any death.  The defender, having BC, can always recover the points, and the attacker incurs a 75% lower penalty than example-2, allowing the attacker to take risks and make much better use of casual/low-skill players in the attack. Also the attacker only has to kill 1-2 defenders per minute in order to stay in the battle in terms of points.
- After the battle is won and control is gained, death points do increase for the defender, but as noted, that is not too bad as the defender can gain them back automatically.
- An interesting battle dynamic also emerges, that the more the defender is ahead, the more cautious they will get, and the more aggressive the attacker can get.
- This feature solves the issue, however it is is currently disabled by default
- New users of the feature don't notice it until they inevitably hit the problem, and current users have been slow to turn this on, despite often encountering the balance problem, receiving the advise to enable it, and often ignoring that advice and putting the death points up way too high, sometimes inadvertently turning their sieges into PVP-pro only zones.
- Thus in this PR I am renaming the config so that it gets enabled for everyone when the next release is deployed. Docs also updated. Servers will of course still be able to configure it on/off afterwards, should they so choose.
 
#### New Nodes/Commands/ConfigOptions: 
- Node renamed from `war.siege.switches.counterattack_booster_enabled` to `war.siege.switches.counterattack_booster_disabled`

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
