### PR TITLE
Inventory degrade fix.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -154,6 +154,11 @@ public class PlayerDeath {
 				degradeInventory(playerDeathEvent);
 				keepInventory(playerDeathEvent);
 				SiegeHUDManager.updateHUDs();
+
+				if (confirmedCandidateSiege.getBannerControlSessions().containsKey(deadPlayer)) { //If the player that died had an ongoing session, remove it.
+					confirmedCandidateSiege.removeBannerControlSession(confirmedCandidateSiege.getBannerControlSessions().get(deadPlayer));
+					Messaging.sendMsg(deadPlayer, Translation.of("msg_siege_war_banner_control_session_failure"));
+				}
 			}
 		} catch (Exception e) {
 			try {
@@ -174,7 +179,7 @@ public class PlayerDeath {
 		Boolean closeToBreaking = false;
 		if (SiegeWarSettings.getWarSiegeDeathPenaltyDegradeInventoryEnabled()) {
 			for (ItemStack itemStack : playerDeathEvent.getEntity().getInventory().getContents()) {
-				if (itemStack != null && itemStack.getItemMeta() instanceof Damageable) {
+				if (itemStack != null && itemStack.getType().getMaxDurability() != 0 && !itemStack.getItemMeta().isUnbreakable()) {
 					damageable = ((Damageable) itemStack.getItemMeta());
 					maxDurability = itemStack.getType().getMaxDurability();
 					currentDurability = damageable.getDamage();


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR fixes players being given a warning when they die in a siege zone with non-damageable items, and removes their banner control session (if they had any).
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
