### PR TITLE
Fix config not properly reloading 4 variables.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -188,7 +188,7 @@ public class PlaceBlock {
 	private static void evaluatePlaceColouredBannerInWilderness(Block block, Player player, Resident resident, Town attackingTown, Nation nation) throws TownyException {
 
 		// Fail early if this is not a siege-enabled world.
-		if(!SiegeWarDistanceUtil.isSiegeWarEnabledInWorld(block.getWorld()))
+		if(!SiegeWarSettings.getWarSiegeWorlds().contains(block.getWorld().getName()))
 			throw new TownyException(Translation.of("msg_err_siege_war_not_enabled_in_world"));
 		
 		List<TownBlock> nearbyCardinalTownBlocks = SiegeWarBlockUtil.getCardinalAdjacentTownBlocks(block);

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -51,7 +51,7 @@ public class PlayerDeath {
 	 */
 	public static void evaluateSiegePlayerDeath(Player deadPlayer, PlayerDeathEvent playerDeathEvent)  {
 		try {
-			if (!SiegeWarDistanceUtil.isSiegeWarEnabledInWorld(playerDeathEvent.getEntity().getWorld()))
+			if (!SiegeWarSettings.getWarSiegeWorlds().contains(playerDeathEvent.getEntity().getWorld().getName()))
 				return;
 
 			TownyPermissionSource tps = TownyUniverse.getInstance().getPermissionSource();

--- a/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
@@ -20,6 +20,9 @@ public class Settings {
             return false;
         }
 
+		// Some list variables do not reload upon loadConfig.
+		SiegeWarSettings.resetSpecialCaseVariables();
+		
 		try {
 			Translation.loadLanguage(sw.getDataFolder().getPath() + File.separator, "english.yml");
 		} catch (IOException e) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -3,22 +3,38 @@ package com.gmail.goosius.siegewar.settings;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
 import com.gmail.goosius.siegewar.objects.HeldItemsCombination;
 
 public class SiegeWarSettings {
 	
-	private static final List<HeldItemsCombination> mapSneakingItems = new ArrayList<>();
-	private static List<Material> battleSessionsForbiddenBlockMaterials = null;
-	private static List<Material> battleSessionsForbiddenBucketMaterials = null;
+	private static List<HeldItemsCombination> mapSneakingItems = new ArrayList<>();
+	private static List<String> worldsWithSiegeWarEnabled = new ArrayList<>();
+	private static List<Material> battleSessionsForbiddenBlockMaterials = new ArrayList<>();
+	private static List<Material> battleSessionsForbiddenBucketMaterials = new ArrayList<>();
 	
+	protected static void resetSpecialCaseVariables() {
+		mapSneakingItems.clear();
+		worldsWithSiegeWarEnabled.clear();
+		battleSessionsForbiddenBlockMaterials.clear();
+		battleSessionsForbiddenBucketMaterials.clear();
+	}
+
 	public static boolean getWarSiegeEnabled() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_ENABLED);
 	}
 
-	public static String getWarSiegeWorlds() {
-		return Settings.getString(ConfigNodes.WAR_SIEGE_WORLDS);
+	public static List<String> getWarSiegeWorlds() {
+		if (worldsWithSiegeWarEnabled.isEmpty()) {
+			String[] worldNamesAsArray = Settings.getString(ConfigNodes.WAR_SIEGE_WORLDS).split(",");
+			for (String worldName : worldNamesAsArray) {
+				if (Bukkit.getServer().getWorld(worldName.trim()) != null)
+					worldsWithSiegeWarEnabled.add(Bukkit.getServer().getWorld(worldName.trim()).getName());
+			}
+		}
+		return worldsWithSiegeWarEnabled;
 	}
 
 	public static boolean getWarSiegeAttackEnabled() {
@@ -273,8 +289,7 @@ public class SiegeWarSettings {
 	}
 
 	public static List<Material> getWarSiegeZoneBlockPlacementRestrictionsMaterials() {
-		if(battleSessionsForbiddenBlockMaterials == null) {
-			battleSessionsForbiddenBlockMaterials = new ArrayList<>();
+		if(battleSessionsForbiddenBlockMaterials.isEmpty()) {
 			String listAsString = Settings.getString(ConfigNodes.WAR_SIEGE_ZONE_BLOCK_PLACEMENT_RESTRICTIONS_MATERIALS);
 			String[] listAsStringArray = listAsString.split(",");
 			for (String blockTypeAsString : listAsStringArray) {
@@ -290,8 +305,7 @@ public class SiegeWarSettings {
 	}
 
 	public static List<Material> getWarSiegeZoneBucketEmptyingRestrictionsMaterials() {
-		if(battleSessionsForbiddenBucketMaterials == null) {
-			battleSessionsForbiddenBucketMaterials = new ArrayList<>();
+		if(battleSessionsForbiddenBucketMaterials.isEmpty()) {
 			String listAsString = Settings.getString(ConfigNodes.WAR_SIEGE_ZONE_BUCKET_EMPTYING_RESTRICTIONS_MATERIALS);
 			String[] listAsStringArray = listAsString.split(",");
 			for (String blockTypeAsString : listAsStringArray) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -12,15 +12,10 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This class contains utility functions related to calculating and validating distances
@@ -30,7 +25,6 @@ import java.util.List;
 public class SiegeWarDistanceUtil {
 
 	private static final int TOWNBLOCKSIZE= TownySettings.getTownBlockSize();
-	public static List<String> worldsWithSiegeWarEnabled = null;
 
 	/**
 	 * This method determines if the difference in elevation between a (attack banner) block, 
@@ -119,24 +113,6 @@ public class SiegeWarDistanceUtil {
 			}
 		}
 		return false;
-	}
-
-	/**
-	 * This method determines if a siegewar is enabled in the given world
-	 *
-	 * @param worldToCheck the world to check
-	 * @return true if siegewar is enabled in the given world
-	 */
-	public static boolean isSiegeWarEnabledInWorld(World worldToCheck) {
-		if (worldsWithSiegeWarEnabled == null) {
-			worldsWithSiegeWarEnabled = new ArrayList<>();
-			String[] worldNamesAsArray = SiegeWarSettings.getWarSiegeWorlds().split(",");
-			for (String worldName : worldNamesAsArray) {
-				if (Bukkit.getServer().getWorld(worldName.trim()) != null)
-					worldsWithSiegeWarEnabled.add(Bukkit.getServer().getWorld(worldName.trim()).getName());
-			}
-		}
-		return worldsWithSiegeWarEnabled.contains(worldToCheck.getName());
 	}
 
 	public static boolean isInSiegeZone(Location location, Siege siege) {


### PR DESCRIPTION
Notably, the enabled-worlds-list but also including the forbidden
blocks/buckets and map-sneaking-combinations lists.

Does away with the enabled-worlds method in SiegeWarDistanceUtil, and
queries SiegeWarSettings directly in the two places where the world was
being tested for.

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
