### PR TITLE
Adjusted default config value of max sieges per nation to 3

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -199,9 +199,9 @@ public enum ConfigNodes {
 	//Non-Monetary Quantities
 	WAR_SIEGE_MAX_ACTIVE_SIEGE_ATTACKS_PER_NATION(
 		"war.siege.quantities.max_active_siege_attacks_per_nation",
-		"999",
+		"3",
 		"",
-		"# The value specifies the maximum number of active/in-progress sieges allowed per nation." +
+		"# The value specifies the maximum number of active attack sieges allowed per nation." +
 			"# A low setting will generally reduce the aggression level on the server.",
 			"# A low setting will also rebalance the system in favour of smaller nations.",
 		 	"# This is because it will prevent larger nations from conducting as many sieges as their resources would otherwise allow."),


### PR DESCRIPTION
#### Description: 
- I know of no server which actually leaves the default attacks per nation config at 999
- This value is way too high for a sensible default
- To achieve a more useful default I have updated the default value to around where servers tend to set it, at 3

#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
