### PR TITLE
Fix hud permission node not being give to everyone by default.

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -42,7 +42,7 @@ permissions:
 
     siegewar.command.siegewar.hud.*:
         description: User is able to do all /siegewar hud commands.
-        default: false
+        default: true
         children:
             siegewar.command.siegewar.hud: true
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
