### PR TITLE
Adjusted default config for map sneak combos

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -452,7 +452,7 @@ public enum ConfigNodes {
 			"# * Player's in banner control sessions cannot map-sneak"),
 	WAR_SIEGE_MAP_SNEAKING_ITEMS(
 			"war.siege.items.map_sneaking_items",
-			"compass|diamond_sword, compass|bow",
+			"diamond_sword|diamond_sword, diamond_axe|diamond_axe, diamond_shovel|diamond_shovel, bow|bow",
 			"",
 			"# This list specifies the item combinations which allow players to map-sneak.",
 			"# Each list entry is in the form of <off-hand>|<main-hand>.",


### PR DESCRIPTION
#### Description:
- The default configuration for map-sneak items is problematic, because it excludes resource gatherers, which discourages servers from turning off the dynmap setting for invis-if-underground, which is bad for sieges.
- Thus in this PR I adjust the map-sneak items so that resource gatherers can use them

#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
