### PR TITLE
Adjusted guardian town requirement

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -267,7 +267,7 @@ public class TownPeacefulnessUtil {
 			List<Town> candidateTowns = new ArrayList<>(townyUniverse.getDataSource().getTowns());
 			for(Town candidateTown: candidateTowns) {
 				if(!candidateTown.isNeutral()
-					&& !SiegeController.hasSiege(candidateTown)
+					&& !SiegeController.hasActiveSiege(candidateTown)
 					&& candidateTown.hasNation()
 					&& candidateTown.getNation().isOpen()
 					&& candidateTown.getTownBlocks().size() >= guardianTownPlotsRequirement


### PR DESCRIPTION
#### Description: 
- Generally, guardian towns must not be allowed to hold onto peaceful towns if they get sieged
- This is because, it would allow the exploit of a nation setting up multiple peaceful towns with a dummy guardian town nearby, then getting a friend nation to constantly attack the dummy town, giving it immunity, thus giving the peaceful towns constant immunity
- The current code addresses this exploit by releasing the peaceful towns for both the active siege AND inactive part of the guardian-town siege.
- I think this is overly harsh on the peaceful towns though, and also gives enemies too much leverage
- Thus in this PR, I adjust the code so that peaceful towns are released only for the ACTIVE part of the siege, and can rejoin the guardian town's nation if the defenders are victorious.
- This should certainly discourage the exploit, while also not being too harsh on the peaceful towns.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
