### PR TITLE
Add free nation choice for isolated peaceful towns

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -111,7 +111,7 @@ public class SiegeWarNationEventListener implements Listener {
 			//A peaceful town might not be able to leave
 			if (SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
 					&& town.isNeutral()
-					&& TownPeacefulnessUtil.canPeacefulTownLeaveNation(town)) {
+					&& !TownPeacefulnessUtil.canPeacefulTownLeaveNation(town)) {
 
 				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_war_siege_peaceful_town_cannot_revolt_nearby_guardian_towns_one",
 						SiegeWarSettings.getPeacefulTownsGuardianTownMinDistanceRequirement(),

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -113,7 +113,7 @@ public class SiegeWarNationEventListener implements Listener {
 					&& town.isNeutral()
 					&& !TownPeacefulnessUtil.canPeacefulTownLeaveNation(town)) {
 
-				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_war_siege_peaceful_town_cannot_revolt_nearby_guardian_towns_one",
+				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_war_siege_peaceful_town_cannot_revolt_zero_or_one_unsieged_guardian_towns_nearby",
 						SiegeWarSettings.getPeacefulTownsGuardianTownMinDistanceRequirement(),
 						SiegeWarSettings.getPeacefulTownsGuardianTownPlotsRequirement()));
 				event.setCancelled(true);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -60,7 +60,7 @@ public class SiegeWarNationEventListener implements Listener {
 	@EventHandler
 	public void onNationAddTownEvent(NationPreAddTownEvent event) {
 		if(SiegeWarSettings.getWarSiegeEnabled() && SiegeWarSettings.getWarCommonPeacefulTownsEnabled() && event.getTown().isNeutral()) {
-			if(!TownPeacefulnessUtil.isPeacefulTownAllowedToBeInNation(event.getTown(), event.getNation())) {
+			if(!TownPeacefulnessUtil.canPeacefulTownJoinNation(event.getTown(), event.getNation())) {
 				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_war_siege_peaceful_town_cannot_join_nation",
 						event.getTown().getName(),
 						event.getNation().getName(),
@@ -101,27 +101,23 @@ public class SiegeWarNationEventListener implements Listener {
 	}
 	
 	/*
-	 * SW will prevent towns leaving their nations.
+	 * SW can prevent towns leaving their nations.
 	 */
 	@EventHandler
 	public void onTownTriesToLeaveNation(NationPreTownLeaveEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
-
 			Town town = event.getTown();
-			//If a peaceful town has no options, we don't let it revolt
-			if(SiegeWarSettings.getWarCommonPeacefulTownsEnabled() && town.isNeutral()) {
-				Set<Nation> validGuardianNations = TownPeacefulnessUtil.getValidGuardianNations(town);
-				if(validGuardianNations.size() == 0) {
-					event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_war_siege_peaceful_town_cannot_revolt_nearby_guardian_towns_zero", 
+
+			//A peaceful town might not be able to leave
+			if (SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
+					&& town.isNeutral()
+					&& TownPeacefulnessUtil.canPeacefulTownLeaveNation(town)) {
+
+				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_war_siege_peaceful_town_cannot_revolt_nearby_guardian_towns_one",
 						SiegeWarSettings.getPeacefulTownsGuardianTownMinDistanceRequirement(),
 						SiegeWarSettings.getPeacefulTownsGuardianTownPlotsRequirement()));
-					event.setCancelled(true);
-				} else if(validGuardianNations.size() == 1) {
-					event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_war_siege_peaceful_town_cannot_revolt_nearby_guardian_towns_one", 
-						SiegeWarSettings.getPeacefulTownsGuardianTownMinDistanceRequirement(),
-						SiegeWarSettings.getPeacefulTownsGuardianTownPlotsRequirement()));
-					event.setCancelled(true);
-				}
+				event.setCancelled(true);
+				return;
 			}
 
 			//A town cannot leave unless its revolt immunity timer is finished
@@ -143,7 +139,7 @@ public class SiegeWarNationEventListener implements Listener {
 			}
 		}
 	}
-	
+
 	@EventHandler
 	public void onTownLeavesNation(NationTownLeaveEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled() && SiegeWarSettings.getWarSiegeRevoltEnabled()) {

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -60,9 +60,8 @@ public class SiegeWarNationEventListener implements Listener {
 	@EventHandler
 	public void onNationAddTownEvent(NationPreAddTownEvent event) {
 		if(SiegeWarSettings.getWarSiegeEnabled() && SiegeWarSettings.getWarCommonPeacefulTownsEnabled() && event.getTown().isNeutral()) {
-			Set<Nation> validGuardianNations = TownPeacefulnessUtil.getValidGuardianNations(event.getTown());
-			if(!validGuardianNations.contains(event.getNation())) {
-				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_war_siege_peaceful_town_cannot_join_nation", 
+			if(!TownPeacefulnessUtil.isPeacefulTownAllowedToBeInNation(event.getTown(), event.getNation())) {
+				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_war_siege_peaceful_town_cannot_join_nation",
 						event.getTown().getName(),
 						event.getNation().getName(),
 						SiegeWarSettings.getPeacefulTownsGuardianTownMinDistanceRequirement(),

--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -236,7 +236,6 @@ public class TownPeacefulnessUtil {
 				} catch (NotRegisteredException e) {}
 				TownyMessaging.sendPrefixedNationMessage(previousNation, Translation.of("msg_war_siege_peaceful_town_left_nation", peacefulTown.getFormattedName(), previousNation.getFormattedName()));
 				peacefulTown.removeNation();
-				peacefulTown.save();
 				return true;
 			}
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -242,9 +242,11 @@ public class TownPeacefulnessUtil {
 		}
 
 		//Check if the town is already in one of the eligible nations
-		for (Town guardianTown : eligibleGuardianTowns) {
-			if (peacefulTown.getNation() == guardianTown.getNation())
-			return false;
+		if(peacefulTown.hasNation()) {
+			for (Town guardianTown : eligibleGuardianTowns) {
+				if (peacefulTown.getNation() == guardianTown.getNation())
+					return false;
+			}
 		}
 
 		//Transfer town to the nation with the largest guardian town

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -166,7 +166,7 @@ msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident: '&cUnable to
 msg_war_siege_peaceful_player_punished_for_being_in_siegezone: '&cWar-allergy active. To remove this effect, leave the siege-zone immediately.'
 msg_war_siege_err_cannot_attack_peaceful_town: '&cYou cannot attack a peaceful town.'
 msg_war_siege_peaceful_town_cannot_join_nation: 'c%s [PEACEFUL] cannot join %s, because the nation has no unsieged guardian towns nearby (within %d chunks). A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
-msg_war_siege_peaceful_town_cannot_revolt_zero_or_one_unsieged_guardian_towns_nearby:  '&cYou cannot revolt at this time, because although here are guardian towns nearby (within %d chunks), less than 2 of them are unsieged. A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
+msg_war_siege_peaceful_town_cannot_revolt_zero_or_one_unsieged_guardian_towns_nearby:  '&cYou cannot revolt at this time, because there are less than 2 unsieged guardian towns nearby (within %d chunks), less than 2 of them are unsieged. A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
 msg_war_siege_peaceful_town_changed_nation: "&b%s has peacefully changed hands, moving from %s to %s."
 msg_war_siege_peaceful_town_joined_nation: "&b%s has peacefully joined %s."
 msg_war_siege_peaceful_town_left_nation: "&b%s has peacefully left %s."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -166,7 +166,7 @@ msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident: '&cUnable to
 msg_war_siege_peaceful_player_punished_for_being_in_siegezone: '&cWar-allergy active. To remove this effect, leave the siege-zone immediately.'
 msg_war_siege_err_cannot_attack_peaceful_town: '&cYou cannot attack a peaceful town.'
 msg_war_siege_peaceful_town_cannot_join_nation: 'c%s [PEACEFUL] cannot join %s, because the nation has no unsieged guardian towns nearby (within %d chunks). A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
-msg_war_siege_peaceful_town_cannot_revolt_zero_or_one_unsieged_guardian_towns_nearby:  '&cYou cannot revolt at this time, because there are less than 2 unsieged guardian towns nearby (within %d chunks), less than 2 of them are unsieged. A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
+msg_war_siege_peaceful_town_cannot_revolt_zero_or_one_unsieged_guardian_towns_nearby:  '&cYou cannot revolt at this time, because there are less than 2 unsieged guardian towns nearby (within %d chunks). A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
 msg_war_siege_peaceful_town_changed_nation: "&b%s has peacefully changed hands, moving from %s to %s."
 msg_war_siege_peaceful_town_joined_nation: "&b%s has peacefully joined %s."
 msg_war_siege_peaceful_town_left_nation: "&b%s has peacefully left %s."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.06
+version: 0.07
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -165,9 +165,8 @@ msg_war_siege_town_became_non_peaceful: '&b%s has been confirmed as Not-Peaceful
 msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident: '&cUnable to add military rank to resident, because they are in a peaceful town.'
 msg_war_siege_peaceful_player_punished_for_being_in_siegezone: '&cWar-allergy active. To remove this effect, leave the siege-zone immediately.'
 msg_war_siege_err_cannot_attack_peaceful_town: '&cYou cannot attack a peaceful town.'
-msg_war_siege_peaceful_town_cannot_join_nation: 'c%s [PEACEFUL] cannot join %s, because the nation does not have a guardian town nearby (within %d chunks). A guardian town is a non-peaceful nation town with at least %d plots.'
-msg_war_siege_peaceful_town_cannot_revolt_nearby_guardian_towns_zero: '&cYou cannot revolt at this time, because there are no guardian towns nearby (within %d chunks). A guardian town is a non-peaceful nation town with at least %d plots.'
-msg_war_siege_peaceful_town_cannot_revolt_nearby_guardian_towns_one:  '&cYou cannot revolt at this time, because there is only 1 guardian town nearby (within %d chunks). A guardian town is a non-peaceful nation town with at least %d plots.'
+msg_war_siege_peaceful_town_cannot_join_nation: 'c%s [PEACEFUL] cannot join %s, because the nation has no unsieged guardian towns nearby (within %d chunks). A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
+msg_war_siege_peaceful_town_cannot_revolt_zero_or_one_unsieged_guardian_towns_nearby:  '&cYou cannot revolt at this time, because although here are guardian towns nearby(within %d chunks), less than 2 of them are unsieged. A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
 msg_war_siege_peaceful_town_changed_nation: "&b%s has peacefully changed hands, moving from %s to %s."
 msg_war_siege_peaceful_town_joined_nation: "&b%s has peacefully joined %s."
 msg_war_siege_peaceful_town_left_nation: "&b%s has peacefully left %s."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -166,7 +166,7 @@ msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident: '&cUnable to
 msg_war_siege_peaceful_player_punished_for_being_in_siegezone: '&cWar-allergy active. To remove this effect, leave the siege-zone immediately.'
 msg_war_siege_err_cannot_attack_peaceful_town: '&cYou cannot attack a peaceful town.'
 msg_war_siege_peaceful_town_cannot_join_nation: 'c%s [PEACEFUL] cannot join %s, because the nation has no unsieged guardian towns nearby (within %d chunks). A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
-msg_war_siege_peaceful_town_cannot_revolt_zero_or_one_unsieged_guardian_towns_nearby:  '&cYou cannot revolt at this time, because although here are guardian towns nearby(within %d chunks), less than 2 of them are unsieged. A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
+msg_war_siege_peaceful_town_cannot_revolt_zero_or_one_unsieged_guardian_towns_nearby:  '&cYou cannot revolt at this time, because although here are guardian towns nearby (within %d chunks), less than 2 of them are unsieged. A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
 msg_war_siege_peaceful_town_changed_nation: "&b%s has peacefully changed hands, moving from %s to %s."
 msg_war_siege_peaceful_town_joined_nation: "&b%s has peacefully joined %s."
 msg_war_siege_peaceful_town_left_nation: "&b%s has peacefully left %s."


### PR DESCRIPTION
#### Description: 
- With the current code, peaceful towns which are isolated on the map (i.e. far away from any other towns), cannot join a nation at all.  (or are kicked at each new day).
- This is a pointless restriction, which doesn't benefit anyone (i.e. with or without the restriction, a conqueror must do the same thing to capture it i.e. build a colony town nearby), and keeps these towns from closer integration with the server community.
- With this PR I allow peaceful towns to freely join nations if there are no guardian towns nearby
- The peaceful town allegiance rules then become:
```
* If there are no guardian towns nearby - Town has free choice of nation
* If there are guardian town(s) nearby, and 1 or more are NOT under siege - Town must choose the nation of one of those towns
* If there are guardian town(s) nearby, and all are under siege - Town must be nationless
```
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 
(Yes plenty of testing of the peaceful towns feature)

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
