### PR TITLE
Disable nation perms when town is invaded

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -21,7 +21,6 @@ import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.metadata.SiegeMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
-import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarTimeUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarTownUtil;

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -24,6 +24,7 @@ import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarTimeUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarTownUtil;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -194,7 +195,7 @@ public class SiegeController {
 		townSiegeMap.remove(town.getUUID());
 		removeSiegedTown(siege);
 
-		setTownFlags(town, false);
+		SiegeWarTownUtil.setTownFlags(town, false);
 		//Save town
 		town.save();
 		//Save attacking nation
@@ -305,18 +306,5 @@ public class SiegeController {
 			}
 		}
 		return siegesAtLocation;
-	}
-	
-	/**
-	 * Sets pvp and explosions in a town to the desired setting, if enabled in the config.
-	 * 
-	 * @param town The town to set the flags for.
-	 * @param desiredSetting The value to set pvp and explosions to.
-	 */
-	public static void setTownFlags(Town town, boolean desiredSetting) {
-		if (town.getPermissions().pvp != desiredSetting && SiegeWarSettings.getWarSiegePvpAlwaysOnInBesiegedTowns())
-			town.getPermissions().pvp = desiredSetting;
-		if (town.getPermissions().explosion != desiredSetting && SiegeWarSettings.getWarSiegeExplosionsAlwaysOnInBesiegedTowns())
-			town.getPermissions().explosion = desiredSetting;
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -18,7 +18,7 @@ import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.settings.Translation;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarPermissionUtil;
-import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarTownUtil;
 import com.palmergames.bukkit.towny.TownyFormatter;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
@@ -156,7 +156,7 @@ public class SiegeWarTownEventListener implements Listener {
 			TownMetaDataController.setDesiredPeacefulnessSetting(town, event.getFutureState());
 			TownMetaDataController.setPeacefulnessChangeDays(town, 0);
 			if (event.getFutureState() == true)
-				TownPeacefulnessUtil.disableTownPVP(town);
+				SiegeWarTownUtil.disableTownPVP(town);
 			return;
 		} else {
 			int days;

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/AttackTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/AttackTown.java
@@ -9,6 +9,7 @@ import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarTownUtil;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
@@ -119,7 +120,7 @@ public class AttackTown {
 		SiegeController.putTownInSiegeMap(defendingTown, siege);
 
 		//Set town pvp and explosions to true.
-		SiegeController.setTownFlags(defendingTown, true);
+		SiegeWarTownUtil.setTownFlags(defendingTown, true);
 		
 		//Pay into warchest
 		if (TownySettings.isUsingEconomy()) {

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/AttackTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/AttackTown.java
@@ -13,7 +13,6 @@ import com.gmail.goosius.siegewar.utils.SiegeWarTownUtil;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
-import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.EconomyException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Coord;

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -101,7 +101,7 @@ public class InvadeTown {
 		SiegeWarTownUtil.disableNationPerms(defendingTown);
 
 		//Save to db
-    SiegeController.saveSiege(siege);
+    	SiegeController.saveSiege(siege);
 		defendingTown.save();
 		attackingNation.save();
 		if(nationTown && !nationDefeated) {
@@ -109,7 +109,7 @@ public class InvadeTown {
 		}
 		
 		//Messaging
-		if (nationTown) {
+		if(nationTown) {
 			Messaging.sendGlobalMessage(
 				Translation.of("msg_siege_war_nation_town_captured",
 				defendingTown.getFormattedName(),
@@ -123,7 +123,7 @@ public class InvadeTown {
 				attackingNation.getFormattedName()
 			));
 		}
-		if (nationDefeated) {
+		if(nationDefeated) {
 			Messaging.sendGlobalMessage(
 				Translation.of("msg_siege_war_nation_defeated",
 				nationOfDefendingTown.getFormattedName()

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -12,6 +12,7 @@ import com.palmergames.bukkit.towny.object.Coord;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.gmail.goosius.siegewar.settings.Translation;
+import com.gmail.goosius.siegewar.utils.SiegeWarTownUtil;
 
 /**
  * This class is responsible for processing requests to invade towns
@@ -96,18 +97,20 @@ public class InvadeTown {
         
         //Set flags to indicate success
 		siege.setTownInvaded(true);
-        defendingTown.setConquered(true);
+		defendingTown.setConquered(true);
+		
+		SiegeWarTownUtil.disableNationPerms(defendingTown);
 
 		//Save to db
         SiegeController.saveSiege(siege);
 		defendingTown.save();
 		TownyUniverse.getInstance().getDataSource().saveNation(attackingNation);
-		if(nationTown && !nationDefeated) {
+		if (nationTown && !nationDefeated) {
 			TownyUniverse.getInstance().getDataSource().saveNation(nationOfDefendingTown);
 		}
 		
 		//Messaging
-		if(nationTown) {
+		if (nationTown) {
 			Messaging.sendGlobalMessage(
 				Translation.of("msg_siege_war_nation_town_captured",
 				defendingTown.getFormattedName(),
@@ -121,7 +124,7 @@ public class InvadeTown {
 				attackingNation.getFormattedName()
 			));
 		}
-		if(nationDefeated) {
+		if (nationDefeated) {
 			Messaging.sendGlobalMessage(
 				Translation.of("msg_siege_war_nation_defeated",
 				nationOfDefendingTown.getFormattedName()

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
@@ -26,7 +26,7 @@ public class SiegeWarSiegeCompletionUtil {
 		if (siegeStatus == SiegeStatus.DEFENDER_SURRENDER || siegeStatus == SiegeStatus.ATTACKER_WIN) {
 			SiegeWarTimeUtil.activateRevoltImmunityTimer(siege.getDefendingTown()); //Prevent immediate revolt
 		}
-		SiegeController.setTownFlags(siege.getDefendingTown(), false);
+		SiegeWarTownUtil.setTownFlags(siege.getDefendingTown(), false);
 
 		//Save to db
 		SiegeController.saveSiege(siege);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
@@ -30,6 +30,5 @@ public class SiegeWarSiegeCompletionUtil {
 
 		//Save to db
 		SiegeController.saveSiege(siege);
-		siege.getDefendingTown().save();
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -1,5 +1,6 @@
 package com.gmail.goosius.siegewar.utils;
 
+import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockType;
@@ -8,7 +9,7 @@ import com.palmergames.bukkit.towny.object.TownyPermission.PermLevel;
 import com.palmergames.bukkit.towny.object.TownyPermissionChange.Action;
 
 /**
- * Util class containing useful methods for town permissions etc.
+ * Util class containing methods related to town flags/permssions.
  */
 public class SiegeWarTownUtil {
     public static void disableTownPVP(Town town) {
@@ -52,4 +53,17 @@ public class SiegeWarTownUtil {
         }
         town.save();
     }
+
+    /**
+	 * Sets pvp and explosions in a town to the desired setting, if enabled in the config.
+	 * 
+	 * @param town The town to set the flags for.
+	 * @param desiredSetting The value to set pvp and explosions to.
+	 */
+	public static void setTownFlags(Town town, boolean desiredSetting) {
+		if (town.getPermissions().pvp != desiredSetting && SiegeWarSettings.getWarSiegePvpAlwaysOnInBesiegedTowns())
+			town.getPermissions().pvp = desiredSetting;
+		if (town.getPermissions().explosion != desiredSetting && SiegeWarSettings.getWarSiegeExplosionsAlwaysOnInBesiegedTowns())
+			town.getPermissions().explosion = desiredSetting;
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -1,0 +1,55 @@
+package com.gmail.goosius.siegewar.utils;
+
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.TownBlockType;
+import com.palmergames.bukkit.towny.object.TownyPermission;
+import com.palmergames.bukkit.towny.object.TownyPermission.PermLevel;
+import com.palmergames.bukkit.towny.object.TownyPermissionChange.Action;
+
+/**
+ * Util class containing useful methods for town permissions etc.
+ */
+public class SiegeWarTownUtil {
+    public static void disableTownPVP(Town town) {
+		if (town.isPVP())
+				town.setPVP(false);
+
+		for (TownBlock plot : town.getTownBlocks()) {
+			if (plot.hasPlotObjectGroup()) {
+				TownyPermission groupPermissions = plot.getPlotObjectGroup().getPermissions();
+				if (groupPermissions.pvp) {
+					groupPermissions.pvp = false;
+					plot.getPlotObjectGroup().setPermissions(groupPermissions);
+				}
+			} 	
+			if (plot.getPermissions().pvp) {
+				if (plot.getType() == TownBlockType.ARENA)
+					plot.setType(TownBlockType.RESIDENTIAL);
+			
+				plot.getPermissions().pvp = false;
+				plot.setChanged(true);
+			}
+		}
+		town.save();
+    }
+    
+    public static void disableNationPerms(Town town) {
+        town.getPermissions().change(Action.PERM_LEVEL, false, PermLevel.NATION);
+
+        for (TownBlock plot : town.getTownBlocks()) {
+            if (plot.hasResident())
+                continue;
+
+            if (plot.hasPlotObjectGroup()) {
+                TownyPermission groupPermission = plot.getPlotObjectGroup().getPermissions();
+                groupPermission.change(Action.PERM_LEVEL, false, PermLevel.NATION);
+                plot.getPlotObjectGroup().setPermissions(groupPermission);
+            }
+
+            plot.getPermissions().change(Action.PERM_LEVEL, false, PermLevel.NATION);
+            plot.save();
+        }
+        town.save();
+    }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -45,7 +45,8 @@ public class SiegeWarTownUtil {
             if (plot.hasPlotObjectGroup()) {
                 TownyPermission groupPermission = plot.getPlotObjectGroup().getPermissions();
                 groupPermission.change(Action.PERM_LEVEL, false, PermLevel.NATION);
-                plot.getPlotObjectGroup().setPermissions(groupPermission);
+				plot.getPlotObjectGroup().setPermissions(groupPermission);
+				plot.getPlotObjectGroup().save();
             }
 
             plot.getPermissions().change(Action.PERM_LEVEL, false, PermLevel.NATION);
@@ -65,5 +66,6 @@ public class SiegeWarTownUtil {
 			town.getPermissions().pvp = desiredSetting;
 		if (town.getPermissions().explosion != desiredSetting && SiegeWarSettings.getWarSiegeExplosionsAlwaysOnInBesiegedTowns())
 			town.getPermissions().explosion = desiredSetting;
+		town.save();
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -16,8 +16,6 @@ import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
-import com.palmergames.bukkit.towny.object.TownBlockType;
-import com.palmergames.bukkit.towny.object.TownyPermission;
 import com.gmail.goosius.siegewar.settings.Translation;
 import com.palmergames.bukkit.util.BukkitTools;
 import com.palmergames.util.TimeTools;
@@ -67,7 +65,7 @@ public class TownPeacefulnessUtil {
 		town.setNeutral(!town.isNeutral());
 
 		if (town.isNeutral() && !SiegeWarSettings.getWarCommonPeacefulTownsAllowedToTogglePVP()) 
-			disableTownPVP(town);	
+			SiegeWarTownUtil.disableTownPVP(town);
 
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			if (town.isNeutral()) {
@@ -355,28 +353,5 @@ public class TownPeacefulnessUtil {
 				guardianTownsNotUnderSiege.add(guardianTown);
 		}
 		return guardianTownsNotUnderSiege;
-	}
-
-	public static void disableTownPVP(Town town) {
-		if (town.isPVP())
-				town.setPVP(false);
-
-		for (TownBlock plot : town.getTownBlocks()) {
-			if (plot.hasPlotObjectGroup()) {
-				TownyPermission groupPermissions = plot.getPlotObjectGroup().getPermissions();
-				if (groupPermissions.pvp) {
-					groupPermissions.pvp = false;
-					plot.getPlotObjectGroup().setPermissions(groupPermissions);
-				}
-			} 	
-			if (plot.getPermissions().pvp) {
-				if (plot.getType() == TownBlockType.ARENA)
-					plot.setType(TownBlockType.RESIDENTIAL);
-			
-				plot.getPermissions().pvp = false;
-				plot.setChanged(true);
-			}
-		}
-		town.save();
 	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes attacking nations being able to steal from towns that use nation perms, by disabling them
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
