### PR TITLE
Fix resident nation-refund-amount not being set properly all of the time.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -21,22 +21,23 @@ public class ResidentMetaDataController {
 	}
 	
 	public static int getNationRefundAmount(Resident resident) {
-		int nationRefundAmount = 0;
 		IntegerDataField idf = (IntegerDataField) refundAmount.clone();
 		if (resident.hasMeta(idf.getKey())) {
 			CustomDataField<?> cdf = resident.getMetadata(idf.getKey());
 			if (cdf instanceof IntegerDataField) {
 				IntegerDataField amount = (IntegerDataField) cdf; 
-				nationRefundAmount = amount.getValue();
+				return amount.getValue();
 			}
 		}
-		return nationRefundAmount;
+		return 0;
 	}
 
 	public static void setNationRefundAmount(Resident resident, int nationRefundAmount) {
 		IntegerDataField idf = (IntegerDataField) refundAmount.clone();
 		if (resident.hasMeta(idf.getKey())) {
 			resident.removeMetaData(idf);
+			if (nationRefundAmount != 0)
+				resident.addMetaData(new IntegerDataField("siegewar_nationrefund", nationRefundAmount, "Nation Refund"));
 		} else {
 			resident.addMetaData(new IntegerDataField("siegewar_nationrefund", nationRefundAmount, "Nation Refund"));			
 		}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes resident metadata not being set if the resident has the refundamount metadata
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
