### PR TITLE
Add Siegewar statistics to nation status screens

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -1,6 +1,7 @@
 package com.gmail.goosius.siegewar.listeners;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -10,6 +11,7 @@ import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
+import com.gmail.goosius.siegewar.metadata.NationMetaDataController;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
@@ -209,6 +211,11 @@ public class SiegeWarNationEventListener implements Listener {
 	        out.addAll(ChatTools.listArr(formattedSiegeDefences, Translation.of("status_nation_siege_defences", siegeDefences.size())));
 	        
 	        event.addLines(out);
+
+			if (SiegeWarSettings.getWarSiegeNationStatisticsEnabled()) {
+				event.addLines(Arrays.asList(Translation.of("status_nation_wins_losses", NationMetaDataController.getLifetimeWins(nation), NationMetaDataController.getLifetimeLosses(nation)),
+											Translation.of("status_nation_enemy_nations_defeated", NationMetaDataController.getNationsDefeated(nation))));
+			}	
 		}
 	}
     

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/MetaDataUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/MetaDataUtil.java
@@ -1,5 +1,6 @@
 package com.gmail.goosius.siegewar.metadata;
 
+import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.metadata.BooleanDataField;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
@@ -93,6 +94,22 @@ class MetaDataUtil {
 			DecimalDataField value = (DecimalDataField) cdf;
 			value.setValue(num);
 			town.save();
+		}
+	}
+
+	static int getInt(Nation nation, IntegerDataField idf) {
+		CustomDataField<?> cdf = nation.getMetadata(idf.getKey());
+		if (cdf instanceof IntegerDataField) 
+			return ((IntegerDataField) cdf).getValue();
+		return 0;	
+	}
+
+	static void setInt(Nation nation, IntegerDataField idf, int num) {
+		CustomDataField<?> cdf = nation.getMetadata(idf.getKey());
+		if (cdf instanceof IntegerDataField) {
+			IntegerDataField value = (IntegerDataField) cdf;
+			value.setValue(num);
+			nation.save();
 		}
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/NationMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/NationMetaDataController.java
@@ -1,0 +1,92 @@
+package com.gmail.goosius.siegewar.metadata;
+
+import com.gmail.goosius.siegewar.SiegeWar;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.metadata.IntegerDataField;
+
+public class NationMetaDataController {
+    @SuppressWarnings("unused")
+    private SiegeWar plugin;
+
+    private static IntegerDataField lifetimeWins = new IntegerDataField("siegewar_lifetimewins", 0);
+    private static IntegerDataField lifetimeLosses = new IntegerDataField("siegewar_lifetimelosses", 0);
+    private static IntegerDataField nationsDefeated = new IntegerDataField("siegewar_nationsdefeated", 0);
+
+    public NationMetaDataController(SiegeWar plugin) {
+        this.plugin = plugin;
+    }
+
+    public static int getLifetimeWins(Nation nation) {
+        IntegerDataField idf = (IntegerDataField) lifetimeWins.clone();
+        if (nation.hasMeta(idf.getKey()))
+            return MetaDataUtil.getInt(nation, idf);
+        else
+            return 0;
+    }
+
+    public static int getLifetimeLosses(Nation nation) {
+        IntegerDataField idf = (IntegerDataField) lifetimeLosses.clone();
+        if (nation.hasMeta(idf.getKey()))
+            return MetaDataUtil.getInt(nation, idf);
+        else
+            return 0;
+    }
+
+    public static int getNationsDefeated(Nation nation) {
+        IntegerDataField idf = (IntegerDataField) nationsDefeated.clone();
+        if (nation.hasMeta(idf.getKey()))
+            return MetaDataUtil.getInt(nation, idf);
+        else
+            return 0;
+    }
+
+    public static void setLifetimeWins(Nation nation, int num) {
+        IntegerDataField idf = (IntegerDataField) lifetimeWins.clone();
+        if (nation.hasMeta(idf.getKey()))
+            if (num == 0)
+                nation.removeMetaData(idf);
+            else
+                MetaDataUtil.setInt(nation, idf, num);
+        else if (num != 0)
+            nation.addMetaData(new IntegerDataField("siegewar_lifetimewins", num));
+    }
+
+    public static void setLifetimeLosses(Nation nation, int num) {
+        IntegerDataField idf = (IntegerDataField) lifetimeLosses.clone();
+        if (nation.hasMeta(idf.getKey()))
+            if (num == 0)
+                nation.removeMetaData(idf);
+            else
+                MetaDataUtil.setInt(nation, idf, num);
+        else if (num != 0)
+            nation.addMetaData(new IntegerDataField("siegewar_lifetimelosses", num));
+    }
+
+    public static void setNationsDefeated(Nation nation, int num) {
+        IntegerDataField idf = (IntegerDataField) nationsDefeated.clone();
+        if (nation.hasMeta(idf.getKey()))
+            if (num == 0)
+                nation.removeMetaData(idf);
+            else
+                MetaDataUtil.setInt(nation, idf, num);
+        else if (num != 0)
+            nation.addMetaData(new IntegerDataField("siegewar_nationsdefeated", num));
+    }
+
+    /**
+     * Adds a win or a loss to a nation
+     * 
+     * @param nation The nation to update.
+     * @param siegeWon Whether the nation won or lost.
+     */
+    public static void addWinOrLoss(Nation nation, boolean siegeWon) {
+        if (siegeWon)
+            setLifetimeWins(nation, getLifetimeWins(nation) + 1);
+        else
+            setLifetimeLosses(nation, getLifetimeLosses(nation) + 1);
+    }
+
+    public static void incrementDefeatedNations(Nation nation) {
+        setNationsDefeated(nation, getNationsDefeated(nation) + 1);
+        }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
@@ -5,10 +5,12 @@ import org.bukkit.block.Block;
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
+import com.gmail.goosius.siegewar.metadata.NationMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarSiegeCompletionUtil;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.gmail.goosius.siegewar.settings.Translation;
@@ -53,6 +55,12 @@ public class AbandonAttack {
 
     private static void attackerAbandon(Siege siege) {
 		long timeUntilOfficialAbandon = siege.getTimeUntilAbandonConfirmationMillis();
+
+		NationMetaDataController.addWinOrLoss(siege.getAttackingNation(), false);
+		if (siege.getDefendingTown().hasNation())
+			try {
+				NationMetaDataController.addWinOrLoss(siege.getDefendingTown().getNation(), true);
+			} catch (NotRegisteredException ignored) {}
 
 		if(timeUntilOfficialAbandon > 0) {
 			//Pending abandon

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -2,6 +2,7 @@ package com.gmail.goosius.siegewar.playeractions;
 
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
+import com.gmail.goosius.siegewar.metadata.NationMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.exceptions.AlreadyRegisteredException;
@@ -82,7 +83,8 @@ public class InvadeTown {
 
             // This will delete the Nation when it loses its last town, mark them defeated.
             if(nationOfDefendingTown.getTowns().size() == 1) {
-               	nationDefeated = true;
+				nationDefeated = true;
+				NationMetaDataController.incrementDefeatedNations(attackingNation);   
             }
             
 			//Remove town from nation (and nation itself if empty)

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderTown.java
@@ -3,10 +3,12 @@ package com.gmail.goosius.siegewar.playeractions;
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
+import com.gmail.goosius.siegewar.metadata.NationMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarSiegeCompletionUtil;
 import com.gmail.goosius.siegewar.settings.Translation;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.util.TimeMgmt;
 
 /**
@@ -19,6 +21,12 @@ public class SurrenderTown {
     public static void defenderSurrender(Siege siege) {
 
 		long timeUntilSurrenderConfirmation = siege.getTimeUntilSurrenderConfirmationMillis();
+
+		NationMetaDataController.addWinOrLoss(siege.getAttackingNation(), true);
+		if (siege.getDefendingTown().hasNation())
+			try {
+				NationMetaDataController.addWinOrLoss(siege.getDefendingTown().getNation(), false);
+			} catch (NotRegisteredException ignored) {}
 
 		if(timeUntilSurrenderConfirmation > 0) {
 			//Pending surrender

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -149,6 +149,11 @@ public enum ConfigNodes {
 			"# The attacking side population consists of the residents of the attacking nation, and allies.",
 			"# The defending side population consists of the residents of the defending town, and nation + allies if applicable.",
 			"# The level of the boost is configured in separate configs. See the scoring section of this file."),
+	WAR_SIEGE_NATION_STATISTICS_ENABLED(
+			"war.siege.switches.nation_statistics_enabled",
+			"true",
+			"",
+			"# If this setting is true, then Siegewar statistics will be shown on nation status screens."),
 
 	//Monetary Values
 	WAR_SIEGE_ATTACKER_COST_UPFRONT_PER_PLOT(

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -359,4 +359,8 @@ public class SiegeWarSettings {
 	public static boolean getWarCommonPeacefulTownsPublicSpawning() {
 		return Settings.getBoolean(ConfigNodes.PEACEFUL_TOWNS_PUBLIC_SPAWNING);
 	}
+
+	public static boolean getWarSiegeNationStatisticsEnabled() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_NATION_STATISTICS_ENABLED);
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerWin.java
@@ -2,9 +2,11 @@ package com.gmail.goosius.siegewar.timeractions;
 
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
+import com.gmail.goosius.siegewar.metadata.NationMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarSiegeCompletionUtil;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.gmail.goosius.siegewar.settings.Translation;
 
@@ -22,7 +24,13 @@ public class AttackerWin {
 	 * @param winnerNation the winning nation
 	 */
 	public static void attackerWin(Siege siege, Nation winnerNation) {
-        SiegeWarSiegeCompletionUtil.updateSiegeValuesToComplete(siege, SiegeStatus.ATTACKER_WIN);
+		SiegeWarSiegeCompletionUtil.updateSiegeValuesToComplete(siege, SiegeStatus.ATTACKER_WIN);
+		
+		NationMetaDataController.addWinOrLoss(winnerNation, true);
+		if (siege.getDefendingTown().hasNation())
+			try {
+				NationMetaDataController.addWinOrLoss(siege.getDefendingTown().getNation(), false);
+			} catch (NotRegisteredException ignored) {}
 
 		Messaging.sendGlobalMessage(Translation.of("msg_siege_war_attacker_win", 
 		    winnerNation.getFormattedName(),

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
@@ -2,9 +2,11 @@ package com.gmail.goosius.siegewar.timeractions;
 
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
+import com.gmail.goosius.siegewar.metadata.NationMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarSiegeCompletionUtil;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.Town;
 import com.gmail.goosius.siegewar.settings.Translation;
 
@@ -22,7 +24,13 @@ public class DefenderWin
 	 * @param winnerTown the winning town
 	 */
     public static void defenderWin(Siege siege, Town winnerTown) {
-        SiegeWarSiegeCompletionUtil.updateSiegeValuesToComplete(siege, SiegeStatus.DEFENDER_WIN);
+		SiegeWarSiegeCompletionUtil.updateSiegeValuesToComplete(siege, SiegeStatus.DEFENDER_WIN);
+		
+		if (winnerTown.hasNation())
+			try {
+				NationMetaDataController.addWinOrLoss(winnerTown.getNation(), true);
+			} catch (NotRegisteredException ignored) {}
+		NationMetaDataController.addWinOrLoss(siege.getAttackingNation(), false);
 
 		Messaging.sendGlobalMessage(Translation.of("msg_siege_war_defender_win", winnerTown.getFormattedName()));
 

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -257,8 +257,8 @@ msg_you_will_get_sickness: '&c&cYou are not a participant of this siege and cann
 msg_war_siege_peaceful_town_cannot_revolt_zero_or_one_unsieged_guardian_towns_nearby:  '&cYou cannot revolt at this time, because there are less than 2 unsieged guardian towns nearby (within %d chunks). A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
 
 #Added in 0.08:
-status_nation_wins_losses: '§2Siege Wins/Losses: §a%d§2/§a%d'
-status_nation_enemy_nations_defeated: '§2Enemy Nations Defeated: §a%d'
+status_nation_wins_losses: '&2Siege Wins/Losses: &a%d&2/&a%d'
+status_nation_enemy_nations_defeated: '&2Enemy Nations Defeated: &a%d'
 
 msg_swa_set_wins_success: '&bSuccessfully set wins to %d for %s.'
 msg_swa_set_losses_success: '&bSuccessfully set losses to %d for %s.'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.07
+version: 0.08
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -255,3 +255,12 @@ msg_you_will_get_sickness: '&c&cYou are not a participant of this siege and cann
 
 #Added in 0.07:
 msg_war_siege_peaceful_town_cannot_revolt_zero_or_one_unsieged_guardian_towns_nearby:  '&cYou cannot revolt at this time, because there are less than 2 unsieged guardian towns nearby (within %d chunks). A guardian town is a non-peaceful town in an open nation, with at least %d plots.'
+
+#Added in 0.08:
+status_nation_wins_losses: '§2Siege Wins/Losses: §a%d§2/§a%d'
+status_nation_enemy_nations_defeated: '§2Enemy Nations Defeated: §a%d'
+
+msg_swa_set_wins_success: '&bSuccessfully set wins to %d for %s.'
+msg_swa_set_losses_success: '&bSuccessfully set losses to %d for %s.'
+msg_swa_set_nationdefeats_success: '&bSuccessfully set nation defeats to %d for %s.'
+msg_err_nation_not_registered: '&cNation %s is not registered.'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -32,6 +32,7 @@ permissions:
             siegewar.command.siegewaradmin.reload: true
             siegewar.command.siegewaradmin.siege: true
             siegewar.command.siegewaradmin.town: true
+            siegewar.command.siegewaradmin.nation: true
 
     siegewar.command.siegewar.*:
         description: User is able to do all /siegewar commands.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds siege wins/losses and enemy nations defeated statistics to /n's
Example: 
![image](https://user-images.githubusercontent.com/50800980/106640037-db588780-6585-11eb-9389-e02f0f8855ac.png)
Also adds some admin commands to change these statistics manually.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
