### PR TITLE
Stop nations from removing nations they're sieging as enemies

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -304,4 +304,24 @@ public class SiegeController {
 		}
 		return siegesAtLocation;
 	}
+
+	/**
+	 * Gets a list of towns with an active siege that have a certain nation
+	 * 
+	 * @param nation The nation that the town must be in.
+	 * @return The list of towns that are under siege in that nation.
+	 */
+	public static List<Town> getSiegedTowns(Nation nation) {
+		List<Town> siegedTowns = new ArrayList<Town>();
+		for (Town town : getSiegedTowns()) {
+			if (!town.hasNation() || !getSiege(town).getStatus().isActive())
+				continue;
+			try {
+				if (town.getNation().equals(nation));
+					siegedTowns.add(town);
+			} catch (NotRegisteredException ignored) {}
+			
+		}
+		return siegedTowns;
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -266,7 +266,7 @@ public class SiegeWarNationEventListener implements Listener {
 		for (Siege siege : SiegeController.getSieges(nation)) {
 			if (enemyTownsUnderSiege.contains(siege.getDefendingTown())) {
 				event.setCancelled(true);
-				event.setCancelMessage(Translation.of("msg_err_cannot_remove_enemy"));
+				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_err_cannot_remove_enemy"));
 			}
 		}
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -25,6 +25,7 @@ import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.event.DeleteNationEvent;
 import com.palmergames.bukkit.towny.event.NationPreAddTownEvent;
+import com.palmergames.bukkit.towny.event.NationPreRemoveEnemyEvent;
 import com.palmergames.bukkit.towny.event.PreDeleteNationEvent;
 import com.palmergames.bukkit.towny.event.RenameNationEvent;
 import com.palmergames.bukkit.towny.event.nation.NationPreTownLeaveEvent;
@@ -252,5 +253,21 @@ public class SiegeWarNationEventListener implements Listener {
 		}
 	}
 
+	@EventHandler
+	public void onPreNationEnemyRemove(NationPreRemoveEnemyEvent event) {
+		Nation nation = event.getNation();
+		Nation enemyNation = event.getEnemy();
 
+		if (!SiegeController.hasSieges(nation))	
+			return;
+		
+		List<Town> enemyTownsUnderSiege = SiegeController.getSiegedTowns(enemyNation);
+
+		for (Siege siege : SiegeController.getSieges(nation)) {
+			if (enemyTownsUnderSiege.contains(siege.getDefendingTown())) {
+				event.setCancelled(true);
+				event.setCancelMessage(Translation.of("msg_err_cannot_remove_enemy"));
+			}
+		}
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/FileMgmt.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/FileMgmt.java
@@ -208,6 +208,7 @@ public class FileMgmt {
 				fileOutputStream.close();
 			}
 		}
+		zipFile.close();
 		return fileOnServer;
 	}
 }

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -264,3 +264,5 @@ msg_swa_set_wins_success: '&bSuccessfully set wins to %d for %s.'
 msg_swa_set_losses_success: '&bSuccessfully set losses to %d for %s.'
 msg_swa_set_nationdefeats_success: '&bSuccessfully set nation defeats to %d for %s.'
 msg_err_nation_not_registered: '&cNation %s is not registered.'
+
+msg_err_cannot_remove_enemy: '&cYou cannot remove a nation as enemy if you have an active siege against them!'


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Fixes nations being able to remove nations as enemies while they're sieging them. 
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
