### PR TITLE
Add more "unstable" blocks which the banner can't be placed on

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBlockUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBlockUtil.java
@@ -160,13 +160,29 @@ public class SiegeWarBlockUtil {
 			case JUNGLE_LOG:
 			case OAK_LOG:
 			case SPRUCE_LOG:
+			case CRIMSON_STEM:
+			case WARPED_STEM:
+			case CRIMSON_HYPHAE:
+			case WARPED_HYPHAE:
 			case STRIPPED_ACACIA_LOG:
 			case STRIPPED_BIRCH_LOG:
 			case STRIPPED_DARK_OAK_LOG:
 			case STRIPPED_JUNGLE_LOG:
 			case STRIPPED_OAK_LOG:
 			case STRIPPED_SPRUCE_LOG:
+			case STRIPPED_CRIMSON_STEM:
+			case STRIPPED_WARPED_STEM:
+			case STRIPPED_CRIMSON_HYPHAE:
+			case STRIPPED_WARPED_HYPHAE:
 			case CACTUS:
+			case OAK_LEAVES:
+			case SPRUCE_LEAVES:
+			case BIRCH_LEAVES:
+			case ACACIA_LEAVES:
+			case DARK_OAK_LEAVES:
+			case JUNGLE_LEAVES:
+			case NETHER_WART_BLOCK:
+			case WARPED_WART_BLOCK:
 				return true;
 			default:
 				return false;


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds leaves and 1.16 tree blocks as unstable blocks, to make sure the banner isn't destroyed (either via other plugins, or leaves disappearing).
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #98 

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
