### PR TITLE
Spawn firework rocket when a player dies inside siege zone

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -16,10 +16,15 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.permissions.TownyPermissionSource;
 import com.gmail.goosius.siegewar.settings.Translation;
 
+import org.bukkit.Color;
+import org.bukkit.FireworkEffect;
+import org.bukkit.block.Banner;
+import org.bukkit.entity.Firework;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 
 /**
@@ -137,6 +142,15 @@ public class PlayerDeath {
 
 				//Award penalty points w/ notification if siege is in progress
 				if(confirmedCandidateSiege.getStatus() == SiegeStatus.IN_PROGRESS) {
+					if (SiegeWarSettings.getWarSiegeDeathSpawnFireworkEnabled()) {
+						Firework redFirework = deadPlayer.getWorld().spawn(deadPlayer.getLocation().add(0, 2, 0), Firework.class);
+						FireworkMeta fireworkMeta = (FireworkMeta) redFirework.getFireworkMeta();
+						Color bannerColor = ((Banner) confirmedCandidateSiege.getFlagLocation().getBlock().getState()).getBaseColor().getColor();
+						fireworkMeta.addEffects(FireworkEffect.builder().withColor(Color.RED).withFade(bannerColor).build());
+						redFirework.setFireworkMeta(fireworkMeta);
+						redFirework.detonate();
+					}
+
 					if (confirmedCandidateSiegePlayerSide == SiegeSide.DEFENDERS) {
 						SiegeWarPointsUtil.awardPenaltyPoints(
 								false,

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -487,7 +487,7 @@ public enum ConfigNodes {
 			"war.siege.death.spawn_firework",
 			"true",
 			"",
-			"# If enabled, a firework will get spawned whenever a siege participant dies."),
+			"# If enabled, a firework will get spawned whenever a player dies inside a siege zone."),
 
 	PEACEFUL_TOWNS(
 		"peaceful_towns",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -483,6 +483,11 @@ public enum ConfigNodes {
 			"# A low value will keep battles fast paced.",
 			"# A high value will slow down battles (as players take time to repair items),",
 			"# and will also exclude some casual players from war (as they cannot afford to keep repairing/replacing/mending degraded items)"),
+	WAR_SIEGE_DEATH_SPAWN_FIREWORK(
+			"war.siege.death.spawn_firework",
+			"true",
+			"",
+			"# If enabled, a firework will get spawned whenever a siege participant dies."),
 
 	PEACEFUL_TOWNS(
 		"peaceful_towns",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -363,4 +363,8 @@ public class SiegeWarSettings {
 	public static boolean getWarSiegeNationStatisticsEnabled() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_NATION_STATISTICS_ENABLED);
 	}
+
+	public static boolean getWarSiegeDeathSpawnFireworkEnabled() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_DEATH_SPAWN_FIREWORK);
+	}
 }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds a new option for spawning a firework rocket at the location of a player when they die inside a siege zone
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Adds WAR_SIEGE_DEATH_SPAWN_FIREWORK

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
