### PR TITLE
Fix nation deletion listener using PreDeleteNationEvent.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -22,7 +22,6 @@ import com.gmail.goosius.siegewar.utils.SiegeWarTimeUtil;
 import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyFormatter;
-import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.event.NationPreAddTownEvent;
 import com.palmergames.bukkit.towny.event.NationPreRemoveEnemyEvent;
 import com.palmergames.bukkit.towny.event.PreDeleteNationEvent;
@@ -230,14 +229,20 @@ public class SiegeWarNationEventListener implements Listener {
 	 */
 	@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
 	public void onDeleteNation(PreDeleteNationEvent event) {
-		//If nation refund is enabled, warn the player that they will get a refund (and indicate how to claim it,) and then make it available.
-		if (TownyEconomyHandler.isActive() && SiegeWarSettings.getWarSiegeRefundInitialNationCostOnDelete() && event.getNation().getKing() != null) {
-			String refund = TownyEconomyHandler.getFormattedBalance(TownySettings.getNewNationPrice() * 0.01 * SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete());
-			Messaging.sendMsg(event.getNation().getKing().getPlayer(), Translation.of("msg_err_siege_war_delete_nation_warning", refund));
+		/*
+		 * If SiegeWar and the Economy are enabled, give the player a nation refund if it is non-zero & enabled.
+		 */
+		if (SiegeWarSettings.getWarSiegeEnabled() 
+				&& TownyEconomyHandler.isActive()
+				&& SiegeWarSettings.getWarSiegeRefundInitialNationCostOnDelete() 
+				&& SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete() > 0 
+				&& event.getNation().getKing() != null) {
 			SiegeWarMoneyUtil.makeNationRefundAvailable(event.getNation().getKing());
 		}
 		
-		// Remove any sieges that the nation had.
+		/*
+		 * Remove any siege if the nation is deleted, regardless of whether SW is currently enabled.
+		 */
 		for (Siege siege : SiegeController.getSiegesByNationUUID(event.getNation().getUUID())) {
 			SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -3,9 +3,8 @@ package com.gmail.goosius.siegewar.listeners;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
-
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 import com.gmail.goosius.siegewar.Messaging;
@@ -24,8 +23,6 @@ import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyFormatter;
 import com.palmergames.bukkit.towny.TownySettings;
-import com.palmergames.bukkit.towny.TownyUniverse;
-import com.palmergames.bukkit.towny.event.DeleteNationEvent;
 import com.palmergames.bukkit.towny.event.NationPreAddTownEvent;
 import com.palmergames.bukkit.towny.event.NationPreRemoveEnemyEvent;
 import com.palmergames.bukkit.towny.event.PreDeleteNationEvent;
@@ -38,7 +35,6 @@ import com.palmergames.bukkit.towny.event.statusscreen.NationStatusScreenEvent;
 import com.palmergames.bukkit.towny.event.townblockstatus.NationZoneTownBlockStatusEvent;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.Nation;
-import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.gmail.goosius.siegewar.settings.Translation;
 import com.palmergames.bukkit.util.ChatTools;
@@ -87,20 +83,6 @@ public class SiegeWarNationEventListener implements Listener {
 			} else 
 				Messaging.sendMsg(event.getTown().getMayor().getPlayer(), Translation.of("msg_war_siege_warning_peaceful_town_should_not_create_nation"));
 		}
-	}
-	
-	/*
-	 * SW will warn a nation about to delete itself that it can claim a refund after the fact.
-	 */
-	@EventHandler
-	public void onNationDeleteEvent(PreDeleteNationEvent event) {
-		//If nation refund is enabled, warn the player that they will get a refund (and indicate how to claim it).
-		if (SiegeWarSettings.getWarSiegeEnabled() && TownySettings.isUsingEconomy()
-				&& SiegeWarSettings.getWarSiegeRefundInitialNationCostOnDelete()) {
-			int amountToRefund = (int)(TownySettings.getNewNationPrice() * 0.01 * SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete());
-			Messaging.sendMsg(event.getNation().getKing().getPlayer(), Translation.of("msg_err_siege_war_delete_nation_warning", TownyEconomyHandler.getFormattedBalance(amountToRefund)));
-		}
-
 	}
 	
 	/*
@@ -243,19 +225,20 @@ public class SiegeWarNationEventListener implements Listener {
 	}
 	
 	/*
-	 * A nation being deleted with a siege means the siege ends.
+	 * A nation being deleted with a siege means the siege ends,
+	 * and a king may receive a refund.
 	 */
-	@EventHandler
-	public void onDeleteNation(DeleteNationEvent event) {
-		UUID kingUUID = event.getNationKing();
-		if (kingUUID == null)
-			return;
+	@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
+	public void onDeleteNation(PreDeleteNationEvent event) {
+		//If nation refund is enabled, warn the player that they will get a refund (and indicate how to claim it,) and then make it available.
+		if (TownyEconomyHandler.isActive() && SiegeWarSettings.getWarSiegeRefundInitialNationCostOnDelete() && event.getNation().getKing() != null) {
+			String refund = TownyEconomyHandler.getFormattedBalance(TownySettings.getNewNationPrice() * 0.01 * SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete());
+			Messaging.sendMsg(event.getNation().getKing().getPlayer(), Translation.of("msg_err_siege_war_delete_nation_warning", refund));
+			SiegeWarMoneyUtil.makeNationRefundAvailable(event.getNation().getKing());
+		}
 		
-		Resident king = TownyUniverse.getInstance().getResident(kingUUID);
-		if (king != null)
-			SiegeWarMoneyUtil.makeNationRefundAvailable(king);
-		
-		for (Siege siege : SiegeController.getSiegesByNationUUID(event.getNationUUID())) {
+		// Remove any sieges that the nation had.
+		for (Siege siege : SiegeController.getSiegesByNationUUID(event.getNation().getUUID())) {
 			SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);
 		}
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
@@ -112,23 +112,19 @@ public class SiegeWarMoneyUtil {
 		}
 	}
 
+	/**
+	 * Refund some of the initial setup cost to the king
+	 * 
+	 * @param king Resident to grant the refund to.
+	 */
 	public static void makeNationRefundAvailable(Resident king) {
-		//Refund some of the initial setup cost to the king
-		if (SiegeWarSettings.getWarSiegeEnabled()
-			&& TownySettings.isUsingEconomy()
-			&& SiegeWarSettings.getWarSiegeRefundInitialNationCostOnDelete()) {
+		int amountToRefund = (int)(TownySettings.getNewNationPrice() * 0.01 * SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete());
+		
+		// Makes the nation refund available. Player can do "/sw nation refund" later to claim money.
+		ResidentMetaDataController.setNationRefundAmount(king, amountToRefund);
 
-			//Make the nation refund available
-			//The player can later do "/n claim refund" to receive the money
-			int amountToRefund = (int)(TownySettings.getNewNationPrice() * 0.01 * SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete());
-			ResidentMetaDataController.setNationRefundAmount(king, amountToRefund);
-
-			Messaging.sendMsg(
-				king.getPlayer(),
-				String.format(
-					Translation.of("msg_siege_war_nation_refund_available"),
-					TownyEconomyHandler.getFormattedBalance(amountToRefund)));
-		}
+		Messaging.sendMsg(king.getPlayer(),
+				Translation.of("msg_siege_war_nation_refund_available", TownyEconomyHandler.getFormattedBalance(amountToRefund)));
 	}
 	
 	public static double getSiegeCost(Town town) {

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -72,7 +72,6 @@ msg_err_siege_besieged_town_cannot_claim: "&cBesieged towns cannot claim new lan
 msg_err_siege_besieged_town_cannot_unclaim: "&cBesieged towns (or towns which recently lost a siege) cannot un-claim land."
 msg_err_war_common_occupied_town_cannot_unclaim: "&cOccupied towns cannot un-claim land."
 #Nation Delete
-msg_err_siege_war_delete_nation_warning: "WARNING!!!: If you delete your nation you will be refunded %s. This can be claimed later by using '/sw nation refund'."
 msg_err_siege_war_nation_refund_unavailable: "There is no nation refund available to you."
 #Revolt
 msg_err_siege_war_town_voluntary_leave_impossible: "&cTowns cannot leave nations without agreement. To leave your nation, persuade the king (or an assistant) to kick your town."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -72,7 +72,6 @@ msg_err_siege_besieged_town_cannot_claim: "&cLes villes assiégées ne peuvent p
 msg_err_siege_besieged_town_cannot_unclaim: "&cLes villes assiégées (ou les villes qui ont récemment perdu un siège) ne peuvent pas claim des terres."
 msg_err_war_common_occupied_town_cannot_unclaim: "&cLes villes occupées ne peuvent pas claim des terres."
 #Nation Delete
-msg_err_siege_war_delete_nation_warning: "ATTENTION !!!: Si vous supprimez votre nation, vous serez remboursé de %s. Cela peut être réclamé plus tard en utilisant '/sw nation refund'."
 msg_err_siege_war_nation_refund_unavailable: "Aucun remboursement de nation n'est disponible pour vous."
 #Revolt
 msg_err_siege_war_town_voluntary_leave_impossible: "&cLes villes ne peuvent pas quitter les nations sans accord. Pour quitter votre nation, persuadez le roi (ou un assistant) d'expulser votre ville."


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR will make it so the nation refund is available under more types
of deletion. Single-town nations being deleted were likely to not
register the king properly. By using the PreDeleteNationEvent, on
monitor priority with canceled events ignored, we will be able to get
the King (probably) every time.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
