### PR TITLE
Fixed issue where abandoned sieges were still showing as swords on dynmap

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
@@ -4,6 +4,7 @@ import java.io.InputStream;
 import java.util.*;
 
 import com.gmail.goosius.siegewar.enums.SiegeSide;
+import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.settings.Settings;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -89,15 +90,20 @@ public class DynmapTask {
                     //Delete marker if siege is over
                     marker.deleteMarker();
                     markerMap.remove(marker.getMarkerID());
-                } else if (marker.getMarkerIcon().getMarkerIconID().equals(PEACEFUL_BANNER_ICON_ID)
-                        && (siege.getBannerControllingSide() != SiegeSide.NOBODY || siege.getBannerControlSessions().size() > 0)) {
-                    //Ensure icon is battle icon if players are fighting
-                    marker.setMarkerIcon(markerapi.getMarkerIcon(BATTLE_BANNER_ICON_ID));
-                } else if (marker.getMarkerIcon().getMarkerIconID().equals(BATTLE_BANNER_ICON_ID)
-                        && siege.getBannerControllingSide() == SiegeSide.NOBODY
-                        && siege.getBannerControlSessions().size() == 0) {
-                    //Ensure icon is peaceful icon if nobody is fighting
-                    marker.setMarkerIcon(markerapi.getMarkerIcon(PEACEFUL_BANNER_ICON_ID));
+
+                } else if (marker.getMarkerIcon().getMarkerIconID().equals(PEACEFUL_BANNER_ICON_ID)) {
+                    //Change to battle icon if players are fighting
+                    if (siege.getStatus() == SiegeStatus.IN_PROGRESS
+                            && (siege.getBannerControllingSide() != SiegeSide.NOBODY || siege.getBannerControlSessions().size() > 0)) {
+                        marker.setMarkerIcon(markerapi.getMarkerIcon(BATTLE_BANNER_ICON_ID));
+                    }
+
+                } else if (marker.getMarkerIcon().getMarkerIconID().equals(BATTLE_BANNER_ICON_ID)) {
+                    //Change to peaceful icon if nobody is fighting
+                    if (siege.getStatus() != SiegeStatus.IN_PROGRESS
+                            || (siege.getBannerControllingSide() == SiegeSide.NOBODY && siege.getBannerControlSessions().size() == 0)) {
+                        marker.setMarkerIcon(markerapi.getMarkerIcon(PEACEFUL_BANNER_ICON_ID));
+                    }
                 }
             } catch (NotRegisteredException e) {
                 marker.deleteMarker();


### PR DESCRIPTION
#### Description: 
- With current code, if a siege is abandoned/surrendered while a banner control session is in progress, the session remains in memory (but not accessed) until the siege object is deleted (within a few days). Generally this doesn't seem to have any negative impacts, except for one - the dynmap icon logic does not realize the fighting is over, and continues to show the "battle" icon (i.e. crossed swords) until the active phase of the siege ends (within 24 hours).
- This is not appropriate. If a siege is abandoned/surrendered, it should still show the fire icon (because siege effects still apply), but not the battle icon, because in almost all scenarios there will be no significant battle there.
- This PR fixes the issue

#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
