### PR TITLE
Fix NPE when invading a town with a plot group

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -5,6 +5,7 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockType;
 import com.palmergames.bukkit.towny.object.TownyPermission;
+import com.palmergames.bukkit.towny.object.TownyPermission.ActionType;
 import com.palmergames.bukkit.towny.object.TownyPermission.PermLevel;
 import com.palmergames.bukkit.towny.object.TownyPermissionChange.Action;
 
@@ -35,15 +36,13 @@ public class SiegeWarTownUtil {
             if (plot.hasResident())
                 continue;
 
-            if (plot.hasPlotObjectGroup()) {
-                TownyPermission groupPermission = plot.getPlotObjectGroup().getPermissions();
-                groupPermission.change(Action.PERM_LEVEL, false, PermLevel.NATION);
-				plot.getPlotObjectGroup().setPermissions(groupPermission);
-				plot.getPlotObjectGroup().save();
-            }
-
-            plot.getPermissions().change(Action.PERM_LEVEL, false, PermLevel.NATION);
-            plot.save();
+			TownyPermission plotPerm = plot.getPermissions();
+			if (plotPerm.getNationPerm(ActionType.BUILD) || plotPerm.getNationPerm(ActionType.DESTROY)
+				|| plotPerm.getNationPerm(ActionType.ITEM_USE) || plotPerm.getNationPerm(ActionType.SWITCH)) {
+			
+				plot.getPermissions().change(Action.PERM_LEVEL, false, PermLevel.NATION);
+				plot.save();
+			}
         }
         town.save();
     }


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Similar to #117, but I forgot that disableNationPerms was also using plot group stuff.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
