### PR TITLE
Prevent Nations from exploiting Peaceful-Town-Mechanics to create too-close battle-towns

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -327,7 +327,7 @@ public class TownPeacefulnessUtil {
 			for(Town candidateTown: candidateTowns) {
 				if(!candidateTown.isNeutral()
 					&& candidateTown.hasNation()
-					&& candidateTown.getNation().isOpen()
+					&& candidateTown.isOpen()
 					&& candidateTown.getTownBlocks().size() >= guardianTownPlotsRequirement
 					&& SiegeWarDistanceUtil.areTownsClose(peacefulTown, candidateTown, guardianTownMaxDistanceRequirementTownblocks)) {
 					validGuardianTowns.add(candidateTown);


### PR DESCRIPTION
#### Description: 
- With current code, guardian towns only qualify if the nation is open
- Therefore on many servers, most of the top nations remain open, in order to pull in peaceful towns.
- Generally speaking, this is ok (if a little messy for nation membership control)
- However, it does open one clear exploit, because if a nation wishes to attack another, then it can found a new battle town close to the target town, have the battle town temporarily join the (open) enemy nation, and then expand the battle town claims right up to the target town, at which point it can rejoin the home nation and a siege can be started.
- Thus by using an exploit, battle towns can be brought much closer to target towns than they should be.

#### Solution: 
- This PR makes guardian towns qualify not on nation-openness, but instead on town-openness.
- This means that normal nations don't have to be open anymore, thus generally ensuring that the exploit is much rarer.
- This also cleans up the general messiness related to nation membership management.
- This also gives individual mayors a little more political power locally and on the nation level (which I think is probably a good thing).
- The side effect of motivating some large towns to open up shouldn't be a problem. Long before the change in this PR, many large towns on servers have already deliberately made themselves open.

**Describe alternatives you've considered**
- Nation publicness as a qualifier ..... no, because on servers without /t spawns, having a public /n spawn is almost a requirement,
- King takes a deliberate action (place block) to add peaceful towns .... no, because its too directly linked to the actions of an enemy player and thus reduces the peaceful feel of the mechanic.

**Additional context**
N/A

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
