### PR TITLE
Nation Screen - Remove ended sieges from siege attacks list

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -206,10 +206,9 @@ public class SiegeWarNationEventListener implements Listener {
     
 	public static List<Town> getTownsUnderSiegeAttack(Nation nation) {
 		List<Town> result = new ArrayList<>();
-		for(Siege siege : SiegeController.getSieges()) {
-			if(siege.getAttackingNation().equals(nation)) {				
+		for(Siege siege : SiegeController.getSieges(nation)) {
+			if(siege.getStatus().isActive())
 				result.add(siege.getDefendingTown());
-			}
 		}
 		return result;
 	}


### PR DESCRIPTION
#### Description: 
- Currently on the nation screen, ended sieges show up on the attacks list (but not on the defences list)
- Originally both lists showed all sieges, in order to remind nations of recent attack sieges so they wouldn't forget to capture and plunder if they win.
- But it turns out this is not-intuitive to look at - players only expect to see the active ones. 
- Also those nations are probably generally unlikely to forget, and they usually have more than a week's allowance to remember before the ended sieges disappear.
- In this PR I adjust the attacks list to show only active sieges.
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
