### PR TITLE
Adjustment to default equipment-degrade config

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -496,7 +496,7 @@ public enum ConfigNodes {
 			"# If this setting is false, battles will be more 'arcade-like', with low death cost."),
 	WAR_SIEGE_DEATH_PENALTY_DEGRADE_INVENTORY_PERCENTAGE(
 			"war.siege.death_penalty.degrade_inventory.percentage",
-			"10.0",
+			"20.0",
 			"",
 			"# This values specifies the percentage equipment degradation that occurs to a soldiers equipment,",
 			"# when they die in a siege zone.",


### PR DESCRIPTION
#### Description: 
- Adjusted default config for equipment degrade
- With current value, soldiers have effectively 9 lives per god set. This is too high and sometimes results in overlong battles  (Unlike first person shooters Siegewar does not have real battle ending every 30 mins or so.  Battle sessions help but are not a full break for players because the battle is still ongoing while they are away).
- With adjusted value, soldiers have effectively 4 lives per god set.  This strikes a balance between giving up-and-coming nations a chance, and preventing battles going on too long.

#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
