### PR TITLE
Fixed horizontal distance to Towny TownyBlock size

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -296,16 +296,12 @@ public enum ConfigNodes {
 			"# The radius of the 'siege zone'.",
 			"# This radius applies only horizontally, so players can never get above a siegezone (e.g. to place lava there or something).",
 			"# Various siege related effects can apply in this zone e.g. lose points on death, keep inv on death, cannot claim here."),
-	WAR_SIEGE_BANNER_CONTROL_HORIZONTAL_DISTANCE_BLOCKS(
-			"war.siege.distances.banner_control_horizontal_distance_blocks",
-			"16",
-			"",
-			"# This is the horizontal distance a soldier must be from the banner to get banner control."),
 	WAR_SIEGE_BANNER_CONTROL_VERTICAL_DISTANCE_BLOCKS(
 			"war.siege.distances.banner_control_vertical_distance_blocks",
 			"16",
 			"",
-			"# This is the vertical distance a soldier must be from the banner to get banner control."),
+			"# This is the vertical distance a soldier must be from the banner to get banner control.",
+			"# Note that the horizontal distance is always the same as the Towny townblock size."),
 
 	//Siege points
 	WAR_SIEGE_POINTS_FOR_ATTACKER_OCCUPATION(

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -340,10 +340,6 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.PEACEFUL_TOWNS_NEW_TOWN_CONFIRMATION_REQUIREMENT_DAYS);
 	}
 
-	public static int getBannerControlHorizontalDistanceBlocks() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_BANNER_CONTROL_HORIZONTAL_DISTANCE_BLOCKS);
-	}
-
 	public static int getBannerControlVerticalDistanceBlocks() {
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_BANNER_CONTROL_VERTICAL_DISTANCE_BLOCKS);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/BookUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/BookUtil.java
@@ -88,7 +88,7 @@ public class BookUtil {
 		 * Scoring info
 		 */
 		text += "\nSIEGE SCORING\n\n";
-		text += "Players win sieges by holding the ground within " + SiegeWarSettings.getBannerControlHorizontalDistanceBlocks() + " blocks of the siege banner (the 'timed point zone'), and/or by killing enemy soldiers within " + SiegeWarSettings.getWarSiegeZoneRadiusBlocks() + " blocks of the siege banner (the 'siege zone').\n\n";
+		text += "Players win sieges by holding the ground within " + TownySettings.getTownBlockSize() + " blocks of the siege banner (the 'timed point zone'), and/or by killing enemy soldiers within " + SiegeWarSettings.getWarSiegeZoneRadiusBlocks() + " blocks of the siege banner (the 'siege zone').\n\n";
 		text += "Attackers gain " + SiegeWarSettings.getWarSiegePointsForAttackerOccupation() + " base points every 20 seconds for holding the banner. ";
 		text += "Defenders gain " + SiegeWarSettings.getWarSiegePointsForDefenderOccupation() + " base points every 20 seconds for holding the banner. ";
 		text += "Attackers gain " + SiegeWarSettings.getWarSiegePointsForAttackerDeath() + " base points if an attacker is killed in the siege zone. ";

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -123,8 +123,8 @@ public class SiegeWarBannerControlUtil {
 
 		//Notify Player
 		Messaging.sendMsg(player, String.format(
-			Translation.of("msg_siege_war_banner_control_session_started"), 
-			SiegeWarSettings.getBannerControlHorizontalDistanceBlocks(),
+			Translation.of("msg_siege_war_banner_control_session_started"),
+			TownySettings.getTownBlockSize(),
 			SiegeWarSettings.getBannerControlVerticalDistanceBlocks(),
 			TimeMgmt.getFormattedTimeValue(sessionDurationMillis)));
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -124,7 +124,7 @@ public class SiegeWarDistanceUtil {
 	}
 
 	public static boolean isInTimedPointZone(Entity entity, Siege siege) {
-		return areLocationsClose(entity.getLocation(), siege.getFlagLocation(), SiegeWarSettings.getBannerControlHorizontalDistanceBlocks(), SiegeWarSettings.getBannerControlVerticalDistanceBlocks());
+		return areLocationsClose(entity.getLocation(), siege.getFlagLocation(), TownySettings.getTownBlockSize(), SiegeWarSettings.getBannerControlVerticalDistanceBlocks());
 	}
 
 	public static boolean areTownsClose(Town town1, Town town2, int radiusTownblocks) {


### PR DESCRIPTION
#### Description: 
- With current SiegeWar configs, a critical, yet not-initially-noticeable problem can be introduced
- The problem occurs if a server owner sets the banner-control-horizontal distance to greater than the Towny tonwnblock size
- This allows defenders to safely cap from behind their own walls, breaking a core mechanic
- This PR solves the issue by simply linking the horizontal cap distance to the Towny townblock size, which is probably what 99.9% of server owners need anyway, while also making is impossible for server admins to trigger the indicated problem.
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
