### PR TITLE
Remove ender pearl and chorus fruit from spawn restriction

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -141,7 +141,11 @@ public class SiegeWarBukkitEventListener implements Listener {
 	
 	@EventHandler(ignoreCancelled = true)
 	public void onPlayerTeleport(PlayerTeleportEvent event) {
-		if (SiegeWarSettings.getWarSiegeEnabled() && SiegeWarSettings.getWarSiegeNonResidentSpawnIntoSiegeZonesOrBesiegedTownsDisabled()) {
+		if (SiegeWarSettings.getWarSiegeEnabled()
+			&& SiegeWarSettings.getWarSiegeNonResidentSpawnIntoSiegeZonesOrBesiegedTownsDisabled()
+			&& !(event.getCause() == PlayerTeleportEvent.TeleportCause.ENDER_PEARL)
+			&& !(event.getCause() == PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT)
+		) {
 			if (TownyAPI.getInstance().isWilderness(event.getTo())) { // The teleport destination is in the wilderness.
 				if (SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getTo())) {
 					Messaging.sendErrorMsg(event.getPlayer(), Translation.of("msg_err_siege_war_cannot_spawn_into_siegezone_or_besieged_town"));


### PR DESCRIPTION
#### Description: 
- With current code the `war.siege.switches.non_resident_spawn_into_siegezones_or_besieged_towns_disabled` config affects short distance teleports such as enderpearls and chorus fruit
- This was never the intention of the config, it is just supposed to limit long distance spawning such a /n spawn, /t spawn, tpa, or /home
- Thus in this PR I remove ender pearls and chorus fruit from being affected by this particular config/

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
