### PR TITLE
Removed peaceful towns attack validation check when peaceful.towns=disabled

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/AttackTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/AttackTown.java
@@ -51,7 +51,7 @@ public class AttackTown {
 		if (SiegeController.hasActiveSiege(defendingTown))
 			throw new TownyException(Translation.of("msg_err_siege_war_cannot_join_siege"));
 
-		if (defendingTown.isNeutral())
+		if (SiegeWarSettings.getWarCommonPeacefulTownsEnabled() && defendingTown.isNeutral())
 			throw new TownyException(Translation.of("msg_war_siege_err_cannot_attack_peaceful_town"));
 
 		if (!(SiegeController.hasActiveSiege(defendingTown))


### PR DESCRIPTION
#### Description: 
- With current code, on siege attack the system checks for peaceful towns even if the peaceful towns feature is disabled
- It should not do this
- This PR removes that validation

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
