### PR TITLE
Cannons Integration - Turn town explosions off after siege

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -195,6 +195,8 @@ public class SiegeController {
 		removeSiegedTown(siege);
 
 		SiegeWarTownUtil.setTownPvpFlags(town, false);
+		SiegeWarTownUtil.setTownExplosionFlags(town, false);
+
 		//Save attacking nation
 		siege.getAttackingNation().save();
 		siege = null;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
@@ -27,6 +27,7 @@ public class SiegeWarSiegeCompletionUtil {
 			SiegeWarTimeUtil.activateRevoltImmunityTimer(siege.getDefendingTown()); //Prevent immediate revolt
 		}
 		SiegeWarTownUtil.setTownPvpFlags(siege.getDefendingTown(), false);
+		SiegeWarTownUtil.setTownExplosionFlags(siege.getDefendingTown(), false);
 
 		//Save to db
 		SiegeController.saveSiege(siege);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -76,13 +76,6 @@ public class SiegeWarTownUtil {
 				if (townBlock.getPermissions().explosion != desiredSetting)
 					townBlock.getPermissions().explosion = desiredSetting;
 			}
-			//Set it in all plot groups
-			if (town.getPlotGroups() != null) {
-				for (PlotGroup plotGroup : town.getPlotGroups()) {
-					if (plotGroup.getPermissions().explosion != desiredSetting)
-						plotGroup.getPermissions().explosion = desiredSetting;
-				}
-			}
 			town.save();
 		}
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -67,21 +67,23 @@ public class SiegeWarTownUtil {
 	 * @param desiredSetting The value to set pvp and explosions to.
 	 */
 	public static void setTownExplosionFlags(Town town, boolean desiredSetting) {
-		//Set it in the town
-		if (town.getPermissions().explosion != desiredSetting)
-			town.getPermissions().explosion = desiredSetting;
-		//Set it in all plots
-		for(TownBlock townBlock: town.getTownBlocks()) {
-			if (townBlock.getPermissions().explosion != desiredSetting)
-				townBlock.getPermissions().explosion = desiredSetting;
-		}
-		//Set it in all plot groups
-		if(town.getPlotGroups() != null) {
-			for (PlotGroup plotGroup : town.getPlotGroups()) {
-				if (plotGroup.getPermissions().explosion != desiredSetting)
-					plotGroup.getPermissions().explosion = desiredSetting;
+		if (SiegeWarSettings.isCannonsIntegrationEnabled()) {
+			//Set it in the town
+			if (town.getPermissions().explosion != desiredSetting)
+				town.getPermissions().explosion = desiredSetting;
+			//Set it in all plots
+			for (TownBlock townBlock : town.getTownBlocks()) {
+				if (townBlock.getPermissions().explosion != desiredSetting)
+					townBlock.getPermissions().explosion = desiredSetting;
 			}
+			//Set it in all plot groups
+			if (town.getPlotGroups() != null) {
+				for (PlotGroup plotGroup : town.getPlotGroups()) {
+					if (plotGroup.getPermissions().explosion != desiredSetting)
+						plotGroup.getPermissions().explosion = desiredSetting;
+				}
+			}
+			town.save();
 		}
-		town.save();
 	}
 }


### PR DESCRIPTION
#### Description: 
- With current code, if a town happens to have an active cannon session when the siege ends, the explosions remain on.
- This is not desirable - explosion protections should automatically go back on, just like PVP protections.
- With this PR, I fix the issue.
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
