### PR TITLE
Data interaction fixes

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -2,7 +2,6 @@ package com.gmail.goosius.siegewar;
 
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.SiegeWarTownUtil;
-import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Town;
 import org.bukkit.Bukkit;

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -1,6 +1,10 @@
 package com.gmail.goosius.siegewar;
 
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.gmail.goosius.siegewar.utils.SiegeWarTownUtil;
+import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.object.Town;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
@@ -77,6 +81,13 @@ public class SiegeWar extends JavaPlugin {
 			cannonsPluginDetected = true;
 			if(SiegeWarSettings.isCannonsIntegrationEnabled()) {
 				System.out.println(prefix + "SiegeWar found Cannons plugin, enabling Cannons support.");
+				/*
+				 * Turn off explosions in all towns, in case the server shut down while towns had active cannon sessions
+				 * This includes towns without active sieges, in case a server manually adjusted data before startup
+				 */
+				for(Town town: TownyUniverse.getInstance().getTowns()) {
+					SiegeWarTownUtil.setTownExplosionFlags(town, false);
+				}
 				System.out.println(prefix + "Cannons support enabled.");
 			}
 		} else {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -71,7 +71,7 @@ public class SiegeWarTownUtil {
 			//Set it in the town
 			if (town.getPermissions().explosion != desiredSetting)
 				town.getPermissions().explosion = desiredSetting;
-			//Set it in all townblocks
+			//Set it in all plots
 			for (TownBlock townBlock : town.getTownBlocks()) {
 				if (townBlock.getPermissions().explosion != desiredSetting) {
 					townBlock.getPermissions().explosion = desiredSetting;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -71,10 +71,12 @@ public class SiegeWarTownUtil {
 			//Set it in the town
 			if (town.getPermissions().explosion != desiredSetting)
 				town.getPermissions().explosion = desiredSetting;
-			//Set it in all plots
+			//Set it in all townblocks
 			for (TownBlock townBlock : town.getTownBlocks()) {
-				if (townBlock.getPermissions().explosion != desiredSetting)
+				if (townBlock.getPermissions().explosion != desiredSetting) {
 					townBlock.getPermissions().explosion = desiredSetting;
+					townBlock.save();
+				}
 			}
 			town.save();
 		}


### PR DESCRIPTION
#### Description: 
This PR contains 2 fixes:
1. With current code, when explosions are switched via the new function, the switch does not occur in the data source. This PR adds the save, to keep memory &  data source in sync.
2. With current code, if a server is shutdown while a cannon session is in effect, then when the server comes back, explosions will be on in the town, and will stay on unless manually turned off.
   - This is not good. Many defenders will assume that the explosion protections will return to normal if the server has been down for longer than the standard cannon session duration, and even if they are aware of what will happen, may not have capacity to be online at the time the server restarts.
   - Similarly, it would also not be good to simply transfer the permissions and the cannon session to the next restart. Because an attacker (but not defender) may be online after restart, allowing for unopposed destruction of their town for an arbitrary duration (depending on whatever the server has setup).
   - In this PR I resolve the issue by -if the cannons integration is enabled- resetting all towns to have explosions off when the server restarts.
 ___
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
