### PR TITLE
Add beacon markers for sieges

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.gmail.goosius.siegewar.utils.CosmeticUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -195,6 +196,7 @@ public class SiegeController {
 		removeSiegedTown(siege);
 
 		SiegeWarTownUtil.setTownPvpFlags(town, false);
+		CosmeticUtil.removeFakeBeacons(siege);
 
 		//Save attacking nation
 		siege.getAttackingNation().save();

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -78,7 +78,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 
 	private void showPreferenceHelp(CommandSender sender) {
 		sender.sendMessage(ChatTools.formatTitle("/siegewar preference"));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/sw", "preference capturecolor [color", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/sw", "preference capturecolor [color]", ""));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/sw", "preference allycolor [color]", ""));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/sw", "preference enemycolor [color]", ""));
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/enums/GlassColor.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/GlassColor.java
@@ -1,0 +1,48 @@
+package com.gmail.goosius.siegewar.enums;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Material;
+
+public enum GlassColor {
+    WHITE(Material.WHITE_STAINED_GLASS, "White"),
+    ORANGE(Material.ORANGE_STAINED_GLASS, "Orange"),
+    MAGENTA(Material.MAGENTA_STAINED_GLASS, "Magenta"),
+    LIGHTBLUE(Material.LIGHT_BLUE_STAINED_GLASS, "LightBlue"),
+    YELLOW(Material.YELLOW_STAINED_GLASS, "Yellow"),
+    LIME(Material.LIME_STAINED_GLASS, "Lime"),
+    PINK(Material.PINK_STAINED_GLASS, "Pink"),
+    GRAY(Material.GRAY_STAINED_GLASS, "Gray"),
+    LIGHTGRAY(Material.LIGHT_GRAY_STAINED_GLASS, "LightGray"),
+    CYAN(Material.CYAN_STAINED_GLASS, "Cyan"),
+    PURPLE(Material.PURPLE_STAINED_GLASS, "Purple"),
+    BLUE(Material.BLUE_STAINED_GLASS, "Blue"),
+    BROWN(Material.BROWN_STAINED_GLASS, "Brown"),
+    GREEN(Material.GREEN_STAINED_GLASS, "Green"),
+    RED(Material.RED_STAINED_GLASS, "Red"),
+    BLACK(Material.BLACK_STAINED_GLASS, "Black");
+
+    private Material material;
+    private String name;
+
+    GlassColor(Material material, String name) {
+        this.material = material;
+        this.name = name;
+    }
+
+    public Material getMaterial() {
+        return material;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static List<String> getNamesArray() {
+        List<String> names = new ArrayList<>();
+        for (GlassColor color : GlassColor.values())
+            names.add(color.getName().toLowerCase());
+        return names;
+    }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
@@ -26,6 +26,7 @@ public enum SiegeWarPermissionNodes {
 		SIEGEWAR_COMMAND_SIEGEWAR_COLLECT("siegewar.command.siegewar.collect"),
 		SIEGEWAR_COMMAND_SIEGEWAR_HUD("siegewar.command.siegewar.hud"),
 		SIEGEWAR_COMMAND_SIEGEWAR_GUIDE("siegewar.command.siegewar.guide"),
+		SIEGEWAR_COMMAND_SIEGEWAR_PREFERENCE("siegewar.command.siegewar.preference"),
 
 	SIEGEWAR_COMMAND_SIEGEWARADMIN("siegewar.command.siegewaradmin.*"),
 		SIEGEWAR_COMMAND_SIEGEWARADMIN_IMMUNITY("siegewar.command.siegewaradmin.immunity"),

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarPlotEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarPlotEventListener.java
@@ -1,6 +1,5 @@
 package com.gmail.goosius.siegewar.listeners;
 
-import com.palmergames.bukkit.towny.event.plot.toggle.PlotToggleExplosionEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -32,7 +32,6 @@ import com.palmergames.bukkit.towny.event.time.dailytaxes.PreTownPaysNationTaxEv
 import com.palmergames.bukkit.towny.event.town.TownPreUnclaimCmdEvent;
 import com.palmergames.bukkit.towny.event.town.TownRuinedEvent;
 import com.palmergames.bukkit.towny.event.town.TownUnconquerEvent;
-import com.palmergames.bukkit.towny.event.town.toggle.TownToggleExplosionEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownToggleNeutralEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownToggleOpenEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownTogglePVPEvent;

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -87,6 +87,7 @@ public class SiegeWarTownyEventListener implements Listener {
             SiegeWarTimerTaskController.punishNonSiegeParticipantsInSiegeZone();
             SiegeHUDManager.updateHUDs();
             SiegeWarTimerTaskController.evaluateCannonSessions();
+            SiegeWarTimerTaskController.evaluateBeacons();
         }
 
     }

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -4,6 +4,7 @@ import com.gmail.goosius.siegewar.SiegeWar;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.object.metadata.IntegerDataField;
+import com.palmergames.bukkit.towny.object.metadata.StringDataField;
 
 /**
  * 
@@ -17,6 +18,11 @@ public class ResidentMetaDataController {
 	private static IntegerDataField refundAmount = new IntegerDataField("siegewar_nationrefund", 0, "Nation Refund");
 	private static IntegerDataField plunderAmount = new IntegerDataField("siegewar_plunder", 0, "Plunder");
 	private static IntegerDataField militarySalaryAmount = new IntegerDataField("siegewar_militarysalary", 0, "Military Salary");
+
+	static String
+		captureColorPreference = "siegewar_capturecolor",
+		allyColorPreference = "siegewar_allycolor",
+		enemyColorPreference = "siegewar_enemycolor";
 
 
 	public ResidentMetaDataController(SiegeWar plugin) {
@@ -117,5 +123,54 @@ public class ResidentMetaDataController {
 				resident.addMetaData(new IntegerDataField("siegewar_militarysalary", amountToAdd, "Military Salary"));
 			}
 		}
+	}
+
+	public static void setString(Resident resident, String key, String string) {
+		if (resident.hasMeta(key)) {
+			if (string.equals(""))
+				resident.removeMetaData(resident.getMetadata(key));
+			else {
+				CustomDataField<?> cdf = resident.getMetadata(key);
+				if (cdf instanceof StringDataField) {
+					((StringDataField) cdf).setValue(string);
+					resident.save();
+				}
+				return;
+			}
+		} else if (!string.equals(""))
+			resident.addMetaData(new StringDataField(key, string));
+	}
+
+	public static String getString(Resident resident, String key) {
+		if (resident.hasMeta(key)) {
+			CustomDataField<?> cdf = resident.getMetadata(key);
+			if (cdf instanceof StringDataField)
+				return ((StringDataField) cdf).getValue();
+		}
+		return "";
+	}
+
+	public static void setCaptureColorPreference(Resident resident, String materialName) {
+		setString(resident, captureColorPreference, materialName);
+	}
+
+	public static void setAllyColorPreference(Resident resident, String materialName) {
+		setString(resident, allyColorPreference, materialName);
+	}
+
+	public static void setEnemyColorPreference(Resident resident, String materialName) {
+		setString(resident, enemyColorPreference, materialName);
+	}
+
+	public static String getCaptureColorPreference(Resident resident) {
+		return getString(resident, captureColorPreference);
+	}
+
+	public static String getAllyColorPreference(Resident resident) {
+		return getString(resident, allyColorPreference);
+	}
+
+	public static String getEnemyColorPreference(Resident resident) {
+		return getString(resident, enemyColorPreference);
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -2,9 +2,9 @@ package com.gmail.goosius.siegewar.metadata;
 
 import com.gmail.goosius.siegewar.SiegeWar;
 import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.metadata.BooleanDataField;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
 import com.palmergames.bukkit.towny.object.metadata.IntegerDataField;
-import com.palmergames.bukkit.towny.object.metadata.StringDataField;
 
 /**
  * 
@@ -20,9 +20,7 @@ public class ResidentMetaDataController {
 	private static IntegerDataField militarySalaryAmount = new IntegerDataField("siegewar_militarysalary", 0, "Military Salary");
 
 	static String
-		captureColorPreference = "siegewar_capturecolor",
-		allyColorPreference = "siegewar_allycolor",
-		enemyColorPreference = "siegewar_enemycolor";
+		beaconsDisabled = "siegewar_beaconsdisabled";
 
 
 	public ResidentMetaDataController(SiegeWar plugin) {
@@ -125,52 +123,36 @@ public class ResidentMetaDataController {
 		}
 	}
 
-	public static void setString(Resident resident, String key, String string) {
+	public static void setBoolean(Resident resident, String key, boolean bool) {
 		if (resident.hasMeta(key)) {
-			if (string.equals(""))
+			if (bool == false)
 				resident.removeMetaData(resident.getMetadata(key));
 			else {
 				CustomDataField<?> cdf = resident.getMetadata(key);
-				if (cdf instanceof StringDataField) {
-					((StringDataField) cdf).setValue(string);
+				if (cdf instanceof BooleanDataField) {
+					((BooleanDataField) cdf).setValue(bool);
 					resident.save();
 				}
 				return;
 			}
-		} else if (!string.equals(""))
-			resident.addMetaData(new StringDataField(key, string));
+		} else if (bool)
+			resident.addMetaData(new BooleanDataField(key, bool));
 	}
 
-	public static String getString(Resident resident, String key) {
+	public static boolean getBoolean(Resident resident, String key) {
 		if (resident.hasMeta(key)) {
 			CustomDataField<?> cdf = resident.getMetadata(key);
-			if (cdf instanceof StringDataField)
-				return ((StringDataField) cdf).getValue();
+			if (cdf instanceof BooleanDataField)
+				return ((BooleanDataField) cdf).getValue();
 		}
-		return "";
+		return false;
 	}
 
-	public static void setCaptureColorPreference(Resident resident, String materialName) {
-		setString(resident, captureColorPreference, materialName);
+	public static void setBeaconsDisabled(Resident resident, boolean disabled) {
+		setBoolean(resident, beaconsDisabled, disabled);
 	}
 
-	public static void setAllyColorPreference(Resident resident, String materialName) {
-		setString(resident, allyColorPreference, materialName);
-	}
-
-	public static void setEnemyColorPreference(Resident resident, String materialName) {
-		setString(resident, enemyColorPreference, materialName);
-	}
-
-	public static String getCaptureColorPreference(Resident resident) {
-		return getString(resident, captureColorPreference);
-	}
-
-	public static String getAllyColorPreference(Resident resident) {
-		return getString(resident, allyColorPreference);
-	}
-
-	public static String getEnemyColorPreference(Resident resident) {
-		return getString(resident, enemyColorPreference);
+	public static boolean getBeaconsDisabled(Resident resident) {
+		return getBoolean(resident, beaconsDisabled);
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -142,7 +142,7 @@ public class PlayerDeath {
 				if(confirmedCandidateSiege.getStatus() == SiegeStatus.IN_PROGRESS) {
 					if (SiegeWarSettings.getWarSiegeDeathSpawnFireworkEnabled()) {
 						Color bannerColor = ((Banner) confirmedCandidateSiege.getFlagLocation().getBlock().getState()).getBaseColor().getColor();
-						CosmeticUtil.spawnFirework(deadPlayer.getLocation().add(0, 2, 0), bannerColor, Color.RED, true);
+						CosmeticUtil.spawnFirework(deadPlayer.getLocation().add(0, 2, 0), Color.RED, bannerColor, true);
 					}
 
 					if (confirmedCandidateSiegePlayerSide == SiegeSide.DEFENDERS) {

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -8,6 +8,7 @@ import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.hud.SiegeHUDManager;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.gmail.goosius.siegewar.utils.CosmeticUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarPointsUtil;
 import com.palmergames.bukkit.towny.TownyUniverse;
@@ -17,14 +18,11 @@ import com.palmergames.bukkit.towny.permissions.TownyPermissionSource;
 import com.gmail.goosius.siegewar.settings.Translation;
 
 import org.bukkit.Color;
-import org.bukkit.FireworkEffect;
 import org.bukkit.block.Banner;
-import org.bukkit.entity.Firework;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
-import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 
 /**
@@ -143,12 +141,8 @@ public class PlayerDeath {
 				//Award penalty points w/ notification if siege is in progress
 				if(confirmedCandidateSiege.getStatus() == SiegeStatus.IN_PROGRESS) {
 					if (SiegeWarSettings.getWarSiegeDeathSpawnFireworkEnabled()) {
-						Firework redFirework = deadPlayer.getWorld().spawn(deadPlayer.getLocation().add(0, 2, 0), Firework.class);
-						FireworkMeta fireworkMeta = (FireworkMeta) redFirework.getFireworkMeta();
 						Color bannerColor = ((Banner) confirmedCandidateSiege.getFlagLocation().getBlock().getState()).getBaseColor().getColor();
-						fireworkMeta.addEffects(FireworkEffect.builder().withColor(Color.RED).withFade(bannerColor).build());
-						redFirework.setFireworkMeta(fireworkMeta);
-						redFirework.detonate();
+						CosmeticUtil.spawnFirework(deadPlayer.getLocation().add(0, 2, 0), bannerColor, Color.RED, true);
 					}
 
 					if (confirmedCandidateSiegePlayerSide == SiegeSide.DEFENDERS) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -154,10 +154,6 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# If this setting is true, then Siegewar statistics will be shown on nation status screens."),
-	WAR_SIEGE_BEACONS_ENABLED(
-			"war.siege.switches.beacons_enabled",
-			"true",
-			"# If enabled, client-side beacons will be shown for players while they are in a siege zone."),
 
 	//Monetary Values
 	WAR_SIEGE_ATTACKER_COST_UPFRONT_PER_PLOT(
@@ -666,8 +662,43 @@ public enum ConfigNodes {
 			"cannons_integration.max_cannon_session_duration",
 			"9",
 			"# This value determines the max duration of each cannon session,",
-			"# The duration is 'in short ticks', typically a short tick is 20 seconds."
-	);
+			"# The duration is 'in short ticks', typically a short tick is 20 seconds."),
+	
+	BEACON_MARKERS(
+			"beacon_markers",
+			"",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |                   Beacon Markers                     | #",
+			"# +------------------------------------------------------+ #",
+			"############################################################",
+			""),
+	BEACON_MARKERS_ENABLED(
+			"beacon_markers.enabled",
+			"true",
+			"",
+			"# If enabled, client-side beacons will be shown for players at the siege banner while they are in a siege zone."),
+	BEACON_MARKERS_CAPTURE_COLOR(
+			"beacon_markers.capture_color",
+			"yellow",
+			"",
+			"# The color that the beacon will be while a player is capturing it. Only visible to the player.",
+			"# Accepts any of the following colors (case insensitive): White, Orange, Magenta, LightBlue, Yellow, Lime, Pink, Gray, LightGray, Cyan, Purple, Blue, Brown, Green, Red & Black.",
+			"# Defaults to yellow if no valid color is entered."),
+	BEACON_MARKERS_CAPTURED_COLOR(
+			"beacon_markers.captured_color",
+			"green",
+			"",
+			"# The color that the beacon will be for a player when their side has control of the banner.",
+			"# See above for valid colors.",
+			"# Defaults to green if no valid color is entered."),
+	BEACON_MARKERS_ENEMY_COLOR(
+			"beacon_markers.enemy_color",
+			"red",
+			"",
+			"# The color that the beacon will be for a player when the enemy side has control of the banner.",
+			"# See above for valid colors.",
+			"# Defaults to red if no valid color is entered.");
 
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -154,6 +154,10 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# If this setting is true, then Siegewar statistics will be shown on nation status screens."),
+	WAR_SIEGE_BEACONS_ENABLED(
+			"war.siege.switches.beacons_enabled",
+			"true",
+			"# If enabled, client-side beacons will be shown for players while they are in a siege zone."),
 
 	//Monetary Values
 	WAR_SIEGE_ATTACKER_COST_UPFRONT_PER_PLOT(

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -376,7 +376,19 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.CANNONS_INTEGRATION_MAX_CANNON_SESSION_DURATION);
 	}
 
-	public static boolean getWarSiegeBeaconsEnabled() {
-		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_BEACONS_ENABLED);
+	public static boolean getBeaconsEnabled() {
+		return Settings.getBoolean(ConfigNodes.BEACON_MARKERS_ENABLED);
+	}
+
+	public static String getBeaconCaptureColor() {
+		return Settings.getString(ConfigNodes.BEACON_MARKERS_CAPTURE_COLOR);
+	}
+
+	public static String getBeaconCapturedColor() {
+		return Settings.getString(ConfigNodes.BEACON_MARKERS_CAPTURED_COLOR);
+	}
+
+	public static String getBeaconEnemyColor() {
+		return Settings.getString(ConfigNodes.BEACON_MARKERS_ENEMY_COLOR);
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -375,4 +375,8 @@ public class SiegeWarSettings {
 	public static int getMaxCannonSessionDuration() {
 		return Settings.getInt(ConfigNodes.CANNONS_INTEGRATION_MAX_CANNON_SESSION_DURATION);
 	}
+
+	public static boolean getWarSiegeBeaconsEnabled() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_BEACONS_ENABLED);
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
@@ -126,4 +126,9 @@ public class SiegeWarTimerTaskController {
 			SiegeWarCannonsUtil.evaluateCannonSessions();
 		}
 	}
+
+	public static void evaluateBeacons() {
+		if (SiegeWarSettings.getWarSiegeBeaconsEnabled())
+			CosmeticUtil.evaluateBeacons();
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
@@ -128,7 +128,7 @@ public class SiegeWarTimerTaskController {
 	}
 
 	public static void evaluateBeacons() {
-		if (SiegeWarSettings.getWarSiegeBeaconsEnabled())
+		if (SiegeWarSettings.getBeaconsEnabled())
 			CosmeticUtil.evaluateBeacons();
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
@@ -1,0 +1,134 @@
+package com.gmail.goosius.siegewar.utils;
+
+import com.gmail.goosius.siegewar.SiegeController;
+import com.gmail.goosius.siegewar.enums.SiegeSide;
+import com.gmail.goosius.siegewar.objects.Siege;
+import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.FireworkEffect;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Firework;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.meta.FireworkMeta;
+
+/**
+ * Util class for everything fancy.
+ * 
+ * @author Warriorrrr
+ */
+public class CosmeticUtil {
+	public static void evaluateBeacons() {
+		for (Player player : Bukkit.getOnlinePlayers()) {
+            for (Siege siege : SiegeController.getSieges()) {
+                if (SiegeWarDistanceUtil.isInSiegeZone((Entity) player, siege))
+                    evaluateBeacon(player, siege);
+            }
+        }
+	}
+
+    public static void evaluateBeacon(Player player, Siege siege) {
+		if (SiegeWarSettings.getWarSiegeBeaconsEnabled())
+			createFakeBeacon(player, siege.getFlagLocation(), getGlassColor(player, siege));
+    }
+
+	/**
+	 * Creates a fake beacon at the specified location. Only the specified player will be able to see it.
+	 * @param loc The location to create the beacon at.
+	 * @param player The player to show the beacon for.
+     * @param glassColor The glass block that will be above the beacon, to change the color.
+	 */
+	public static void createFakeBeacon(Player player, Location loc, Material glassColor) {
+		player.sendBlockChange(loc.clone().subtract(0, 1, 0), Bukkit.createBlockData(glassColor));
+		player.sendBlockChange(loc.clone().subtract(0, 2, 0), Bukkit.createBlockData(Material.BEACON));
+
+		int[][] ironBlockLocations = {{1, 1}, {1, 0}, {1, -1}, {0, 1}, {0, 0}, {0, -1}, {-1, 1}, {-1, 0}, {-1, -1}};
+		for (int i = 0; i < 9; i++) {
+			player.sendBlockChange(loc.clone().add(ironBlockLocations[i][0], -3, ironBlockLocations[i][1]), Bukkit.createBlockData(Material.IRON_BLOCK));
+		}
+
+		//Set any non-transparent blocks above the banner to glass.
+		for (int i = (int) loc.getY(); i < 256; i++) {
+			Block block = loc.getWorld().getBlockAt((int) loc.getX(), i, (int) loc.getZ());
+			if (block.getType().isBlock() && block.getType().isOccluding())
+				player.sendBlockChange(block.getLocation(), Bukkit.createBlockData(Material.GLASS));
+		}
+	}
+
+	public static void removeFakeBeacon(Player player, Location loc) {
+		player.sendBlockChange(loc.clone().subtract(0, 1, 0), Bukkit.createBlockData(loc.clone().subtract(0, 1, 0).getBlock().getType()));
+		player.sendBlockChange(loc.clone().subtract(0, 2, 0), Bukkit.createBlockData(loc.clone().subtract(0, 2, 0).getBlock().getType()));
+
+		int[][] ironBlockLocations = {{1, 1}, {1, 0}, {1, -1}, {0, 1}, {0, 0}, {0, -1}, {-1, 1}, {-1, 0}, {-1, -1}};
+		for (int i = 0; i < 9; i++) {
+			player.sendBlockChange(loc.clone().add(ironBlockLocations[i][0], -3, ironBlockLocations[i][1]), Bukkit.createBlockData(loc.clone().add(ironBlockLocations[i][0], -3, ironBlockLocations[i][1]).getBlock().getType()));
+		}
+
+		for (int i = (int) loc.getY(); i < 256; i++) {
+			Block block = loc.getWorld().getBlockAt((int) loc.getX(), i, (int) loc.getZ());
+			if (block.getType().isBlock() && block.getType().isOccluding())
+				player.sendBlockChange(block.getLocation(), Bukkit.createBlockData(block.getType()));
+		}
+	}
+	
+	/**
+	 * @param player The player to get the glass color for.
+	 * @param siege The siege
+	 * @return The material for the colour of glass.
+	 */
+    public static Material getGlassColor(Player player, Siege siege) {
+		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
+		if (siege.getBannerControllingSide() != getSiegeSide(resident, siege) && siege.getBannerControllingSide() != SiegeSide.NOBODY)
+			return Material.RED_STAINED_GLASS;
+
+        if (siege.getBannerControlSessions().containsKey(player))
+			return Material.YELLOW_STAINED_GLASS;
+		
+		if (siege.getBannerControllingResidents().contains(resident) || siege.getBannerControllingSide() == getSiegeSide(resident, siege))
+			return Material.GREEN_STAINED_GLASS;
+
+        return Material.GLASS;
+    }
+    
+    /**
+     * Spawns a firework at the specified location.
+     * 
+     * @param location The location to spawn the firework at.
+     * @param primaryColor The primary color.
+     * @param fadeColor The fade color.
+     * @param instantDetonate Whether the firework should detonate instantly.
+     */
+    public static void spawnFirework(Location location, Color primaryColor, Color fadeColor, boolean instantDetonate) {
+        Firework firework = location.getWorld().spawn(location, Firework.class);
+		FireworkMeta fireworkMeta = (FireworkMeta) firework.getFireworkMeta();
+		fireworkMeta.addEffects(FireworkEffect.builder().withColor(primaryColor).withFade(fadeColor).build());
+		firework.setFireworkMeta(fireworkMeta);
+		firework.detonate();
+    }
+
+	public static SiegeSide getSiegeSide(Resident resident, Siege siege) {
+		if (!resident.hasTown())
+			return SiegeSide.NOBODY;
+		
+		Town town = null;
+		try {
+			town = resident.getTown();
+		} catch (NotRegisteredException ignored) {}
+		
+		if (town.isAlliedWith(siege.getDefendingTown()) && town.isAlliedWith(siege.getAttackingNation().getCapital()))
+			return SiegeSide.NOBODY;
+		
+		if (town.isAlliedWith(siege.getDefendingTown()))
+			return SiegeSide.DEFENDERS;
+		else
+			return SiegeSide.ATTACKERS;
+	}
+}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
@@ -29,10 +29,20 @@ public class CosmeticUtil {
 	public static void evaluateBeacons() {
 		for (Player player : Bukkit.getOnlinePlayers()) {
             for (Siege siege : SiegeController.getSieges()) {
+				if (!siege.getStatus().isActive())
+					continue;
+				
                 if (SiegeWarDistanceUtil.isInSiegeZone((Entity) player, siege))
                     evaluateBeacon(player, siege);
             }
         }
+	}
+
+	public static void removeFakeBeacons(Siege siege) {
+		for (Player player : Bukkit.getOnlinePlayers()) {
+			if (SiegeWarDistanceUtil.isInSiegeZone((Entity) player, siege))
+                removeFakeBeacon(player, siege.getFlagLocation());
+		}
 	}
 
     public static void evaluateBeacon(Player player, Siege siege) {
@@ -88,14 +98,14 @@ public class CosmeticUtil {
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
 		if (siege.getBannerControlSessions().containsKey(player))
 			return Material.YELLOW_STAINED_GLASS;
-		
-		if (siege.getBannerControllingSide() != getSiegeSide(resident, siege) && siege.getBannerControllingSide() != SiegeSide.NOBODY)
-			return Material.RED_STAINED_GLASS;
-		
-		if (siege.getBannerControllingResidents().contains(resident) || siege.getBannerControllingSide() == getSiegeSide(resident, siege))
-			return Material.GREEN_STAINED_GLASS;
 
-        return Material.GLASS;
+		if (getSiegeSide(resident, siege) == SiegeSide.NOBODY || siege.getBannerControllingSide() == SiegeSide.NOBODY)
+			return Material.GLASS;
+		
+		if (siege.getBannerControllingSide() != getSiegeSide(resident, siege))
+			return Material.RED_STAINED_GLASS;
+		else
+			return Material.GREEN_STAINED_GLASS;
     }
     
     /**
@@ -128,7 +138,9 @@ public class CosmeticUtil {
 		
 		if (town.isAlliedWith(siege.getDefendingTown()))
 			return SiegeSide.DEFENDERS;
-		else
+		else if (town.isAlliedWith(siege.getAttackingNation().getCapital()))
 			return SiegeSide.ATTACKERS;
+		else
+			return SiegeSide.NOBODY;
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
@@ -47,8 +47,16 @@ public class CosmeticUtil {
 		}
 	}
 
+	public static void removeFakeBeacons(Player player) {
+		for (Siege siege : SiegeController.getSieges()) {
+			if (SiegeWarDistanceUtil.isInSiegeZone((Entity) player, siege))
+				removeFakeBeacon(player, siege.getFlagLocation());
+		}
+	}
+
     public static void evaluateBeacon(Player player, Siege siege) {
-		if (SiegeWarSettings.getWarSiegeBeaconsEnabled())
+		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
+		if (SiegeWarSettings.getBeaconsEnabled() && !ResidentMetaDataController.getBeaconsDisabled(resident))
 			createFakeBeacon(player, siege.getFlagLocation(), getGlassColor(player, siege));
     }
 
@@ -99,15 +107,15 @@ public class CosmeticUtil {
     public static Material getGlassColor(Player player, Siege siege) {
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
 		if (siege.getBannerControlSessions().containsKey(player))
-			return getCaptureColorPreference(resident);
+			return getCaptureColor();
 
 		if (getSiegeSide(resident, siege) == SiegeSide.NOBODY || siege.getBannerControllingSide() == SiegeSide.NOBODY)
 			return Material.GLASS;
 		
 		if (siege.getBannerControllingSide() != getSiegeSide(resident, siege))
-			return getEnemyColorPreference(resident);
+			return getEnemyColor();
 		else
-			return getAllyColorPreference(resident);
+			return getCapturedColor();
     }
     
     /**
@@ -148,11 +156,8 @@ public class CosmeticUtil {
 			return SiegeSide.NOBODY;
 	}
 
-	public static Material getCaptureColorPreference(Resident resident) {
-		String materialName = ResidentMetaDataController.getCaptureColorPreference(resident);
-		if (materialName.equals(""))
-			return Material.YELLOW_STAINED_GLASS;
-		
+	public static Material getCaptureColor() {
+		String materialName = SiegeWarSettings.getBeaconCaptureColor();	
 		Material material;
 		try {
 			material = GlassColor.valueOf(materialName.toUpperCase()).getMaterial();
@@ -162,11 +167,8 @@ public class CosmeticUtil {
 		return material;
 	}
 
-	public static Material getAllyColorPreference(Resident resident) {
-		String materialName = ResidentMetaDataController.getAllyColorPreference(resident);
-		if (materialName.equals(""))
-			return Material.GREEN_STAINED_GLASS;
-		
+	public static Material getCapturedColor() {
+		String materialName = SiegeWarSettings.getBeaconCapturedColor();
 		Material material;
 		try {
 			material = GlassColor.valueOf(materialName.toUpperCase()).getMaterial();
@@ -176,11 +178,8 @@ public class CosmeticUtil {
 		return material;
 	}
 
-	public static Material getEnemyColorPreference(Resident resident) {
-		String materialName = ResidentMetaDataController.getEnemyColorPreference(resident);
-		if (materialName.equals(""))
-			return Material.RED_STAINED_GLASS;
-		
+	public static Material getEnemyColor() {
+		String materialName = SiegeWarSettings.getBeaconEnemyColor();
 		Material material;
 		try {
 			material = GlassColor.valueOf(materialName.toUpperCase()).getMaterial();

--- a/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
@@ -86,11 +86,11 @@ public class CosmeticUtil {
 	 */
     public static Material getGlassColor(Player player, Siege siege) {
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
+		if (siege.getBannerControlSessions().containsKey(player))
+			return Material.YELLOW_STAINED_GLASS;
+		
 		if (siege.getBannerControllingSide() != getSiegeSide(resident, siege) && siege.getBannerControllingSide() != SiegeSide.NOBODY)
 			return Material.RED_STAINED_GLASS;
-
-        if (siege.getBannerControlSessions().containsKey(player))
-			return Material.YELLOW_STAINED_GLASS;
 		
 		if (siege.getBannerControllingResidents().contains(resident) || siege.getBannerControllingSide() == getSiegeSide(resident, siege))
 			return Material.GREEN_STAINED_GLASS;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
@@ -1,7 +1,9 @@
 package com.gmail.goosius.siegewar.utils;
 
 import com.gmail.goosius.siegewar.SiegeController;
+import com.gmail.goosius.siegewar.enums.GlassColor;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
+import com.gmail.goosius.siegewar.metadata.ResidentMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
@@ -97,15 +99,15 @@ public class CosmeticUtil {
     public static Material getGlassColor(Player player, Siege siege) {
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
 		if (siege.getBannerControlSessions().containsKey(player))
-			return Material.YELLOW_STAINED_GLASS;
+			return getCaptureColorPreference(resident);
 
 		if (getSiegeSide(resident, siege) == SiegeSide.NOBODY || siege.getBannerControllingSide() == SiegeSide.NOBODY)
 			return Material.GLASS;
 		
 		if (siege.getBannerControllingSide() != getSiegeSide(resident, siege))
-			return Material.RED_STAINED_GLASS;
+			return getEnemyColorPreference(resident);
 		else
-			return Material.GREEN_STAINED_GLASS;
+			return getAllyColorPreference(resident);
     }
     
     /**
@@ -142,5 +144,47 @@ public class CosmeticUtil {
 			return SiegeSide.ATTACKERS;
 		else
 			return SiegeSide.NOBODY;
+	}
+
+	public static Material getCaptureColorPreference(Resident resident) {
+		String materialName = ResidentMetaDataController.getCaptureColorPreference(resident);
+		if (materialName.equals(""))
+			return Material.YELLOW_STAINED_GLASS;
+		
+		Material material;
+		try {
+			material = GlassColor.valueOf(materialName.toUpperCase()).getMaterial();
+		} catch (IllegalArgumentException e) {
+			material = Material.YELLOW_STAINED_GLASS;
+		}
+		return material;
+	}
+
+	public static Material getAllyColorPreference(Resident resident) {
+		String materialName = ResidentMetaDataController.getAllyColorPreference(resident);
+		if (materialName.equals(""))
+			return Material.GREEN_STAINED_GLASS;
+		
+		Material material;
+		try {
+			material = GlassColor.valueOf(materialName.toUpperCase()).getMaterial();
+		} catch (IllegalArgumentException e) {
+			material = Material.GREEN_STAINED_GLASS;
+		}
+		return material;
+	}
+
+	public static Material getEnemyColorPreference(Resident resident) {
+		String materialName = ResidentMetaDataController.getEnemyColorPreference(resident);
+		if (materialName.equals(""))
+			return Material.RED_STAINED_GLASS;
+		
+		Material material;
+		try {
+			material = GlassColor.valueOf(materialName.toUpperCase()).getMaterial();
+		} catch (IllegalArgumentException e) {
+			material = Material.RED_STAINED_GLASS;
+		}
+		return material;
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
@@ -119,11 +119,13 @@ public class CosmeticUtil {
      * @param instantDetonate Whether the firework should detonate instantly.
      */
     public static void spawnFirework(Location location, Color primaryColor, Color fadeColor, boolean instantDetonate) {
-        Firework firework = location.getWorld().spawn(location, Firework.class);
-		FireworkMeta fireworkMeta = (FireworkMeta) firework.getFireworkMeta();
-		fireworkMeta.addEffects(FireworkEffect.builder().withColor(primaryColor).withFade(fadeColor).build());
-		firework.setFireworkMeta(fireworkMeta);
-		firework.detonate();
+        location.getWorld().spawn(location, Firework.class, fw -> {
+			FireworkMeta fireworkMeta = (FireworkMeta) fw.getFireworkMeta();
+			fireworkMeta.addEffects(FireworkEffect.builder().withColor(primaryColor).withFade(fadeColor).build());
+			fw.setFireworkMeta(fireworkMeta);
+			if (instantDetonate)
+				fw.detonate();
+		});
     }
 
 	public static SiegeSide getSiegeSide(Resident resident, Siege siege) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -2,6 +2,7 @@ package com.gmail.goosius.siegewar.utils;
 
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
+import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
@@ -128,10 +129,12 @@ public class SiegeWarBannerControlUtil {
 			SiegeWarSettings.getBannerControlVerticalDistanceBlocks(),
 			TimeMgmt.getFormattedTimeValue(sessionDurationMillis)));
 
+		CosmeticUtil.evaluateBeacon(player, siege);
+
 		//Make player glow (which also shows them a timer)
 		int effectDurationSeconds = (SiegeWarSettings.getWarSiegeBannerControlSessionDurationMinutes() * 60) + (int)TownySettings.getShortInterval(); 
 		final int effectDurationTicks = (int)(TimeTools.convertToTicks(effectDurationSeconds));
-		Towny.getPlugin().getServer().getScheduler().scheduleSyncDelayedTask(Towny.getPlugin(), new Runnable() {
+		Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
 			public void run() {
 				List<PotionEffect> potionEffects = new ArrayList<>();
 				potionEffects.add(new PotionEffect(PotionEffectType.GLOWING, effectDurationTicks, 0));
@@ -196,6 +199,7 @@ public class SiegeWarBannerControlUtil {
 				if (!doesPlayerMeetBasicSessionRequirements(siege, bannerControlSession.getPlayer(), bannerControlSession.getResident())) {
 					siege.removeBannerControlSession(bannerControlSession);
 					Messaging.sendMsg(bannerControlSession.getPlayer(), Translation.of("msg_siege_war_banner_control_session_failure"));
+					CosmeticUtil.evaluateBeacon(bannerControlSession.getPlayer(), siege);
 
 					if (bannerControlSession.getPlayer().hasPotionEffect(PotionEffectType.GLOWING)) {
 						Towny.getPlugin().getServer().getScheduler().scheduleSyncDelayedTask(Towny.getPlugin(), new Runnable() {
@@ -230,6 +234,7 @@ public class SiegeWarBannerControlUtil {
 							message = Translation.of("msg_siege_war_banner_control_gained_by_defender", siege.getDefendingTown().getFormattedName());
 						}
 						SiegeWarNotificationUtil.informSiegeParticipants(siege, message);
+						CosmeticUtil.evaluateBeacon(bannerControlSession.getPlayer(), siege);
 					}
 				}
 			} catch (Exception e) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
@@ -27,6 +27,7 @@ public class SiegeWarSiegeCompletionUtil {
 			SiegeWarTimeUtil.activateRevoltImmunityTimer(siege.getDefendingTown()); //Prevent immediate revolt
 		}
 		SiegeWarTownUtil.setTownPvpFlags(siege.getDefendingTown(), false);
+		CosmeticUtil.removeFakeBeacons(siege);
 
 		//Save to db
 		SiegeController.saveSiege(siege);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -5,7 +5,6 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockType;
 import com.palmergames.bukkit.towny.object.TownyPermission;
-import com.palmergames.bukkit.towny.object.PlotGroup;
 import com.palmergames.bukkit.towny.object.TownyPermission.ActionType;
 import com.palmergames.bukkit.towny.object.TownyPermission.PermLevel;
 import com.palmergames.bukkit.towny.object.TownyPermissionChange.Action;

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -281,5 +281,5 @@ msg_err_cannon_in_two_towns: "&cYour cannon blocks are split between two towns. 
 msg_err_cannot_toggle_explosions_due_to_cannon_session: "&cYou cannot toggle explosions in the town until the current cannon session ends."
 
 #Added in 0.11
-msg_err_invalid_color: "&cInvalid color. Valid colors are: White, Orange, Magenta, Light Blue, Yellow, Lime, Pink, Gray, Light Gray, Cyan, Purple, Blue, Brown, Green, Red & Black."
-msg_color_preference_set: "&bColor preference set to %s."
+msg_err_invalid_bool: "&cInvalid option. Options: on/off"
+msg_beacon_preference_set: "&bBeacon preference set to %s."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.10
+version: 0.11
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -280,3 +280,6 @@ msg_err_cannot_fire_no_cannon_session: "You cannot fire any cannons in this town
 msg_err_cannon_in_two_towns: "&cYour cannon blocks are split between two towns. Please ensure your cannon is in just one town."
 msg_err_cannot_toggle_explosions_due_to_cannon_session: "&cYou cannot toggle explosions in the town until the current cannon session ends."
 
+#Added in 0.11
+msg_err_invalid_color: "&cInvalid color. Valid colors are: White, Orange, Magenta, Light Blue, Yellow, Lime, Pink, Gray, Light Gray, Cyan, Purple, Blue, Brown, Green, Red & Black."
+msg_color_preference_set: "&bColor preference set to %s."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -80,6 +80,10 @@ permissions:
         description: User is able to do the /siegewar collect command.
         default: true
 
+    siegewar.command.siegewar.preference:
+        description: User is able to do the /siegewar preference command.
+        default: true
+
     siegewar.immune.to.war.nausea:
         description: User is immune to war nausea.
         default: false


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds beacon markers for players while they are in a siege zone. A beacon can have 4 different colors:
* White: Neither side has banner control.
* Red: The side that isn't the player's has control.
* Green: The player or their side has control.
* Yellow: The player has an ongoing banner control session.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Adds `WAR_SIEGE_BEACONS_ENABLED`:
* war.siege.switches.beacons_enabled
* Default: true
* If enabled, client-side beacons will be shown for players while they are in a siege zone.

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
