### PR TITLE
Remove BC Culling

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -272,7 +272,7 @@ public enum ConfigNodes {
 			"# If the value is too low, nations will find it difficult to hold territory due to constant revolts."),
 	WAR_SIEGE_BANNER_CONTROL_SESSION_DURATION_MINUTES (
 			"war.siege.times.banner_control_session_duration_minutes",
-			"10",
+			"5",
 			"",
 			"# This value determines the duration of each banner control session."),
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -270,23 +270,6 @@ public class SiegeWarBannerControlUtil {
 				siege.adjustDefenderBattleScore(battleScore);
 			break;
 			default:
-			return;
-		}
-
-		//Remove banner control if 
-		//1. All players on the list are logged out, or
-		//2. The list is now empty
-		boolean bannerControlLost = true;
-		for(Resident resident: siege.getBannerControllingResidents()) {
-			Player player = TownyAPI.getInstance().getPlayer(resident);
-			if(player != null) {
-				bannerControlLost = false;
-				break;
-			}
-		}
-		if(bannerControlLost) {
-			siege.setBannerControllingSide(SiegeSide.NOBODY);
-			siege.clearBannerControllingResidents();
 		}
 	}
 }


### PR DESCRIPTION
#### Description: 
- With current code, casual players are limited in involvement with quiet sieges, because if they gain banner control, the minute they log off, it is gone.
- For example, in a 15 minute play session, they would spend 10 mins getting banner control, then 5 minutes getting points (very little), then the control would be lost when they log out.
- Thus it is generally pointless for such players to get involved in quiet sieges
- This PR addresses the issue by removing BC culling (something made possible by the recent battle session refactor)
- Thus a casual player can make a decent contribution at a quiet siege ...  but not an overwhelming one because bc is wiped when the battle session ends.
- This will also have the knock-on effect of 'activating' otherwise quiet sieges more regularly, and drawing opposing soldiers together more regularly, i.e. those who want to fight but have trouble finding active sieges/battles.
- I also adjusted the bc_session requirement down from 10 mins to 5 mins, because with less timed-point reward from a bc_session (due to the hourly bc control wiping), we can now reduce the investment requirement also.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
