### PR TITLE
Pacify Inactive Sieges on Dynmap

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
@@ -92,7 +92,10 @@ public class DynmapTask {
                     markerMap.remove(marker.getMarkerID());
 
                 } else if (marker.getMarkerIcon().getMarkerIconID().equals(PEACEFUL_BANNER_ICON_ID)) {
-                    //Change to battle icon if a battle is in progress
+                    /*
+                     * Change to battle icon if siege is in progress,
+                     * and battle is active.
+                     */
                     if (siege.getStatus() == SiegeStatus.IN_PROGRESS
                         && BattleSession.getBattleSession().isActive()
                         && (siege.getAttackerBattleScore() > 0
@@ -103,9 +106,16 @@ public class DynmapTask {
                     }
 
                 } else if (marker.getMarkerIcon().getMarkerIconID().equals(BATTLE_BANNER_ICON_ID)) {
-                    //Change to peaceful icon if siege is no longer in progress or battle is over
+                    /*
+                     * Change to peaceful icon if siege is no longer in progress,
+                     * or battle is no longer active.
+                     */
                     if (siege.getStatus() != SiegeStatus.IN_PROGRESS
-                        || !BattleSession.getBattleSession().isActive()) {
+                        || !BattleSession.getBattleSession().isActive()
+                        || (siege.getAttackerBattleScore() == 0
+                            && siege.getDefenderBattleScore() == 0
+                            && siege.getBannerControllingSide() == SiegeSide.NOBODY
+                            && siege.getBannerControlSessions().size() == 0)) {
                         marker.setMarkerIcon(markerapi.getMarkerIcon(PEACEFUL_BANNER_ICON_ID));
                     }
                 }


### PR DESCRIPTION
#### Description: 
- With current code, sieges on the dynmap, once activated by a banner control session, keep the active icon even if the session fails (in the context that there is no other activity at the siege such as battle points or banner control).
- This gives the misleading impression to dynmap users that there is activity at the siege.
- In this PR I fix the issue by restoring the peaceful icon if banner control has failed.   

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
