### PR TITLE
Fixed bug where peaceful towns could not be plundered

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
@@ -45,9 +45,6 @@ public class PlunderTown {
     public static void processPlunderTownRequest(Player player,
 												 Town townToBePlundered) throws TownyException {
 
-		if(SiegeWarSettings.getWarCommonPeacefulTownsEnabled() && townToBePlundered.isNeutral())
-			throw new TownyException(Translation.of("msg_war_siege_err_cannot_plunder_peaceful_town"));
-		
 		TownyUniverse universe = TownyUniverse.getInstance();
 		Resident resident = universe.getResident(player.getUniqueId());
         if (resident == null)


### PR DESCRIPTION
#### Description: 
- With current code, peaceful towns cannot be plundered
- This is not meant to be the case (and indeed the required error msg lang strings are missing)
- Peaceful towns are supposed to be immune to attack,  but if they get attacked before their go peaceful, and then go peaceful during the siege, then this should be "too late" to get protection from plunder.
- In this PR I fix the bug

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
