### PR TITLE
Fix Peaceful Ruins Transferring

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -182,6 +182,10 @@ public class TownPeacefulnessUtil {
 				if (!peacefulTown.isNeutral())
 					continue;
 
+				//Skip if town is ruined
+				if(peacefulTown.isRuined())
+					continue;
+
 				//Find guardian towns
 				Set<Town> guardianTowns = getValidGuardianTowns(peacefulTown);
 


### PR DESCRIPTION
#### Description: 
- With current code, peaceful ruins can transfer between nations.
- This is not expected, and can also lead to problematic gameplay issues if such a ruin becomes the capital of a nation.
- In this PR I fix the issue by ensuring that peaceful ruins do not move (they will now stay nationless unless reclaimed)

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
