### PR TITLE
Put banner xyz on a config

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -313,7 +313,7 @@ public class SiegeWarTownEventListener implements Listener {
 						// > Attacker: Land of Empire (Nation)
 						out.add(Translation.of("status_town_siege_status_besieger", siege.getAttackingNation().getFormattedName()));
 
-						// > Points: +530
+						// > Balance: +530
 						int pointsInt = siege.getSiegeBalance();
 						String pointsString = pointsInt > 0 ? "+" + pointsInt : "" + pointsInt;
 						out.add(Translation.of("status_town_siege_status_siege_balance", pointsString));

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -318,13 +318,15 @@ public class SiegeWarTownEventListener implements Listener {
 						String pointsString = pointsInt > 0 ? "+" + pointsInt : "" + pointsInt;
 						out.add(Translation.of("status_town_siege_status_siege_balance", pointsString));
 
-						// > Banner XYZ: {2223,82,9877}
-	                    out.add(
-	                            Translation.of("status_town_siege_status_banner_xyz",
-	                            siege.getFlagLocation().getBlockX(),
-	                            siege.getFlagLocation().getBlockY(),
-	                            siege.getFlagLocation().getBlockZ())
-	                    );
+						if(SiegeWarSettings.isBannerXYZTextEnabled()) {
+							// > Banner XYZ: {2223,82,9877}
+							out.add(
+									Translation.of("status_town_siege_status_banner_xyz",
+											siege.getFlagLocation().getBlockX(),
+											siege.getFlagLocation().getBlockY(),
+											siege.getFlagLocation().getBlockZ())
+							);
+						}
 
 						// >  Victory Timer: 5.3 hours
 						String victoryTimer = Translation.of("status_town_siege_victory_timer", siege.getFormattedHoursUntilScheduledCompletion());

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -701,7 +701,22 @@ public enum ConfigNodes {
 			"",
 			"# The color that the beacon will be for a player when the enemy side has control of the banner.",
 			"# See above for valid colors.",
-			"# Defaults to red if no valid color is entered.");
+			"# Defaults to red if no valid color is entered."),
+
+	BANNER_XYZ_TEXT(
+			"banner_xyz_text",
+			"",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |                   Banner XYZ Text                    | #",
+			"# +------------------------------------------------------+ #",
+			"############################################################",
+			""),
+	BANNER_XYZ_TEXT_ENABLED(
+			"banner_xyz_text.enabled",
+			"false",
+			"The banner xyz text is an alternative to beacon markers for siege banners (but they can also be used together).",
+			"# If enabled, besieged towns will show the XYZ of the siege banner on their town screens.");
 
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -392,4 +392,9 @@ public class SiegeWarSettings {
 	public static double getWarSiegeBannerControlReversalBonusFactor() {
 		return Settings.getDouble(ConfigNodes.WAR_SIEGE_BANNER_CONTROL_REVERSAL_BONUS_MULTIPLIER);
 	}
+
+	public static boolean isBannerXYZTextEnabled() {
+		return Settings.getBoolean(ConfigNodes.BANNER_XYZ_TEXT_ENABLED);
+	}
+
 }


### PR DESCRIPTION
#### Description: 
- With current code, the town screen xyz banner location text is almost redundant .......... because you can usually use the dynmap to get the approximate position of the banner, and then when you get close, you see the nice new beacon.
- In this PR I put the town screen xyz banner location text on a config (default disabled)

#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
