### PR TITLE
Remove glow when battle session ends

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -2,6 +2,7 @@ package com.gmail.goosius.siegewar.utils;
 
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
+import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.objects.BattleSession;
@@ -9,6 +10,9 @@ import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.settings.Translation;
 import com.palmergames.util.TimeMgmt;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffectType;
 
 import java.time.*;
 import java.util.ArrayList;
@@ -57,6 +61,18 @@ public class SiegeWarBattleSessionUtil {
 
 						//Prepare result for messaging
 						battleResults.put(siege, battlePointsOfWinner);
+
+						//Remove glowing effects from players in bc sessions
+						for(Player player: siege.getBannerControlSessions().keySet()) {
+							if(player.isOnline() && player.hasPotionEffect(PotionEffectType.GLOWING)) {
+								Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
+									@Override
+									public void run() {
+										player.removePotionEffect(PotionEffectType.GLOWING);
+									}
+								});
+							}
+						}
 
 						//Clear battle related stats from the siege
 						siege.setBannerControllingSide(SiegeSide.NOBODY);


### PR DESCRIPTION
#### Description: 
- With current code, when a battle session ends, players who were in bc sessions continue to glow.
- In this PR I fix the bug, and remove the glow.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
