### PR TITLE
Updated perms terminology to match ingame texts & user guide

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
@@ -8,14 +8,14 @@ package com.gmail.goosius.siegewar.enums;
 public enum SiegeWarPermissionNodes {
 
 	//This permission affects battle points, but the perm currently has the older name of siege points
-	SIEGEWAR_NATION_BATTLE_POINTS("siegewar.nation.siege.points"),
+	SIEGEWAR_NATION_BATTLE_POINTS("siegewar.nation.battle.points"),
 	SIEGEWAR_NATION_SIEGE_LEADERSHIP("siegewar.nation.siege.leadership"),
 	SIEGEWAR_NATION_SIEGE_ATTACK("siegewar.nation.siege.attack"),
 	SIEGEWAR_NATION_SIEGE_ABANDON("siegewar.nation.siege.abandon"),
 	SIEGEWAR_NATION_SIEGE_INVADE("siegewar.nation.siege.invade"),
 	SIEGEWAR_NATION_SIEGE_PLUNDER("siegewar.nation.siege.plunder"),
 	//This permission affects battle points, but the perm currently has the older name of siege points
-	SIEGEWAR_TOWN_BATTLE_POINTS("siegewar.town.siege.points"),
+	SIEGEWAR_TOWN_BATTLE_POINTS("siegewar.town.battle.points"),
 	SIEGEWAR_TOWN_SIEGE_SURRENDER("siegewar.town.siege.surrender"),
 	SIEGEWAR_TOWN_SIEGE_START_CANNON_SESSION("siegewar.town.siege.startcannonsession"),
 	// Siegewar related war sickness immunities

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -57,8 +57,7 @@ permissions:
         description: User holds all of the siegewar nation nodes.
         default: false
         children:
-            siegewar.nation.siege.points: true
-            siegewar.nation.siege.leadership: true
+            siegewar.nation.battle.points: true
             siegewar.nation.siege.attack: true
             siegewar.nation.siege.abandon: true
             siegewar.nation.siege.invade: true
@@ -68,7 +67,7 @@ permissions:
         description: User holds all of the siegewar town nodes.
         default: false
         children:
-            siegewar.town.siege.points: true
+            siegewar.town.battle.points: true
             siegewar.town.siege.surrender: true
             siegewar.town.siege.startcannonsession: true
 


### PR DESCRIPTION
#### Description: 
- With current code, the terminology of some townyperms does not match the ingame texts and the user guide.
- Specifically, admins are asked to add  `*.siege.points` perms,  which are no longer appropriate, because as of the 0.2.2 scoring rework, those perms provide "battle points", which are later applied by battle winner into the single value of "siege balance".
- With 0.3.0 upcoming where people will be paying particular attention to the update guide, its likely best to do this now to save ourselves from unnecessary support work in the long term due to confusion arising etc.
- In this PR I fix the townyperms terminology to be accurate to the ingame texts & user guide.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
