### PR TITLE
Fix to perm nodes scheme

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
@@ -8,14 +8,14 @@ package com.gmail.goosius.siegewar.enums;
 public enum SiegeWarPermissionNodes {
 
 	//This permission affects battle points, but the perm currently has the older name of siege points
-	SIEGEWAR_NATION_BATTLE_POINTS("siegewar.nation.battle.points"),
+	SIEGEWAR_NATION_SIEGE_BATTLE_POINTS("siegewar.nation.siege.battle.points"),
 	SIEGEWAR_NATION_SIEGE_LEADERSHIP("siegewar.nation.siege.leadership"),
 	SIEGEWAR_NATION_SIEGE_ATTACK("siegewar.nation.siege.attack"),
 	SIEGEWAR_NATION_SIEGE_ABANDON("siegewar.nation.siege.abandon"),
 	SIEGEWAR_NATION_SIEGE_INVADE("siegewar.nation.siege.invade"),
 	SIEGEWAR_NATION_SIEGE_PLUNDER("siegewar.nation.siege.plunder"),
 	//This permission affects battle points, but the perm currently has the older name of siege points
-	SIEGEWAR_TOWN_BATTLE_POINTS("siegewar.town.battle.points"),
+	SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS("siegewar.town.siege.battle.points"),
 	SIEGEWAR_TOWN_SIEGE_SURRENDER("siegewar.town.siege.surrender"),
 	SIEGEWAR_TOWN_SIEGE_START_CANNON_SESSION("siegewar.town.siege.startcannonsession"),
 	// Siegewar related war sickness immunities

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -146,7 +146,7 @@ public class SiegeWarNationEventListener implements Listener {
 		//In Siegewar, if target town is peaceful, can't add military rank
 		if(SiegeWarSettings.getWarSiegeEnabled()
 			&& SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
-			&& PermissionUtil.doesNationRankAllowPermissionNode(event.getRank(), SiegeWarPermissionNodes.SIEGEWAR_NATION_BATTLE_POINTS)
+			&& PermissionUtil.doesNationRankAllowPermissionNode(event.getRank(), SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS)
 			&& TownyAPI.getInstance().getResidentTownOrNull(event.getResident()).isNeutral()) { // We know that the resident's town will not be null based on the tests already done.
 			event.setCancelled(true);
 			event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident"));

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -170,7 +170,7 @@ public class SiegeWarTownEventListener implements Listener {
 				//Remove any military nation ranks of residents
 				for(Resident peacefulTownResident: town.getResidents()) {
 					for (String nationRank : new ArrayList<>(peacefulTownResident.getNationRanks())) {
-						if (PermissionUtil.doesNationRankAllowPermissionNode(nationRank, SiegeWarPermissionNodes.SIEGEWAR_NATION_BATTLE_POINTS)) {
+						if (PermissionUtil.doesNationRankAllowPermissionNode(nationRank, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS)) {
 							try {
 								peacefulTownResident.removeNationRank(nationRank);
 							} catch (NotRegisteredException ignored) {}

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -69,9 +69,9 @@ public class PlayerDeath {
 			 * Do an early permission test to avoid hitting the sieges list if
 			 * it could never return a proper SiegeSide.
 			 */			
-			if (!tps.testPermission(deadPlayer, SiegeWarPermissionNodes.SIEGEWAR_TOWN_BATTLE_POINTS.getNode())
+			if (!tps.testPermission(deadPlayer, SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS.getNode())
 				&& !PermissionUtil.hasTownMilitaryRank(deadResident)
-				&& !tps.testPermission(deadPlayer, SiegeWarPermissionNodes.SIEGEWAR_NATION_BATTLE_POINTS.getNode())
+				&& !tps.testPermission(deadPlayer, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS.getNode())
 				&& !PermissionUtil.hasNationMilitaryRank(deadResident))
 				return;
 
@@ -98,7 +98,7 @@ public class PlayerDeath {
 				//Is player eligible ?
 				if (SiegeController.hasActiveSiege(deadResidentTown)
 					&& SiegeController.getSiege(deadResidentTown) == candidateSiege
-					&& (tps.testPermission(deadPlayer, SiegeWarPermissionNodes.SIEGEWAR_TOWN_BATTLE_POINTS.getNode())
+					&& (tps.testPermission(deadPlayer, SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS.getNode())
 						|| PermissionUtil.hasTownMilitaryRank(deadResident))
 				) {
 					candidateSiegePlayerSide = SiegeSide.DEFENDERS; //Candidate siege has player defending own-town
@@ -106,7 +106,7 @@ public class PlayerDeath {
 				} else if (deadResidentTown.hasNation()
 					&& candidateSiege.getDefendingTown().hasNation()
 					&& candidateSiege.getStatus().isActive()
-					&& (tps.testPermission(deadPlayer, SiegeWarPermissionNodes.SIEGEWAR_NATION_BATTLE_POINTS.getNode())
+					&& (tps.testPermission(deadPlayer, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS.getNode())
 						|| PermissionUtil.hasNationMilitaryRank(deadResident))
 					&& (deadResidentTown.getNation() == candidateSiege.getDefendingTown().getNation()
 						|| deadResidentTown.getNation().hasMutualAlly(candidateSiege.getDefendingTown().getNation()))) {
@@ -115,7 +115,7 @@ public class PlayerDeath {
 
 				} else if (deadResidentTown.hasNation()
 					&& candidateSiege.getStatus().isActive()
-					&& (tps.testPermission(deadPlayer, SiegeWarPermissionNodes.SIEGEWAR_NATION_BATTLE_POINTS.getNode())
+					&& (tps.testPermission(deadPlayer, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS.getNode())
 						|| PermissionUtil.hasNationMilitaryRank(deadResident))
 					&& (deadResidentTown.getNation() == candidateSiege.getAttackingNation()
 						|| deadResidentTown.getNation().hasMutualAlly(candidateSiege.getAttackingNation()))) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -78,7 +78,7 @@ public class SiegeWarBannerControlUtil {
 
 				residentTown = resident.getTown();
 				if(residentTown == siege.getDefendingTown()
-					&& universe.getPermissionSource().testPermission(resident.getPlayer(), SiegeWarPermissionNodes.SIEGEWAR_TOWN_BATTLE_POINTS.getNode())) {
+					&& universe.getPermissionSource().testPermission(resident.getPlayer(), SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS.getNode())) {
 					//Player is defending their own town
 
 					if(siege.getBannerControllingSide() == SiegeSide.DEFENDERS && siege.getBannerControllingResidents().contains(resident))
@@ -88,7 +88,7 @@ public class SiegeWarBannerControlUtil {
 					continue;
 
 				} else if (residentTown.hasNation()
-					&& universe.getPermissionSource().testPermission(resident.getPlayer(), SiegeWarPermissionNodes.SIEGEWAR_NATION_BATTLE_POINTS.getNode())) {
+					&& universe.getPermissionSource().testPermission(resident.getPlayer(), SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS.getNode())) {
 
 					if (defendingTown.hasNation()
 						&& (defendingTown.getNation() == residentTown.getNation()

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
@@ -124,21 +124,21 @@ public class SiegeWarSicknessUtil {
         	
 
         if (residentTown.equals(defendingTown) && resident.getPlayer()
-                .hasPermission(SiegeWarPermissionNodes.SIEGEWAR_TOWN_BATTLE_POINTS.getNode())) {
+                .hasPermission(SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS.getNode())) {
             // Player is defending their own town
             return true;
         }
 
         if (residentNation != null
         		&& (attackingNation.equals(TownyAPI.getInstance().getTownNationOrNull(residentTown)) || attackingNation.hasMutualAlly(TownyAPI.getInstance().getTownNationOrNull(residentTown)))
-                && resident.getPlayer().hasPermission(SiegeWarPermissionNodes.SIEGEWAR_NATION_BATTLE_POINTS.getNode())) {
+                && resident.getPlayer().hasPermission(SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS.getNode())) {
             // Player is attacking
             return true;
         }
 
         if (defendingNation != null && residentNation != null 
                 && (defendingNation.equals(residentNation) || defendingNation.hasMutualAlly(residentNation))
-                && resident.getPlayer().hasPermission(SiegeWarPermissionNodes.SIEGEWAR_NATION_BATTLE_POINTS.getNode())) {
+                && resident.getPlayer().hasPermission(SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS.getNode())) {
             // Player is defending another town in the nation
             return true;
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -57,7 +57,7 @@ permissions:
         description: User holds all of the siegewar nation nodes.
         default: false
         children:
-            siegewar.nation.battle.points: true
+            siegewar.nation.siege.battle.points: true
             siegewar.nation.siege.attack: true
             siegewar.nation.siege.abandon: true
             siegewar.nation.siege.invade: true
@@ -67,7 +67,7 @@ permissions:
         description: User holds all of the siegewar town nodes.
         default: false
         children:
-            siegewar.town.battle.points: true
+            siegewar.town.siege.battle.points: true
             siegewar.town.siege.surrender: true
             siegewar.town.siege.startcannonsession: true
 


### PR DESCRIPTION
#### Description: 
- With last PR, although functionally there were no issues, I inadvertently messed up the perm nodes scheme.
- For example, kings with `towny.nation.siege.*`  would only expect to get nodes starting with `towny.nation.siege` i.e.
> towny.nation.siege.A
> towny.nation.siege.B
> towny.nation.siege.C
- They would not expect to get
> towny.nation.battle.X
- In this PR I fix the issue by the putting battle points into the correct node structure i.e.
> towny.nation.siege.battle.points

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
