### PR TITLE
Fix town screen presentation of siege balance

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -313,10 +313,8 @@ public class SiegeWarTownEventListener implements Listener {
 						// > Attacker: Land of Empire (Nation)
 						out.add(Translation.of("status_town_siege_status_besieger", siege.getAttackingNation().getFormattedName()));
 
-						// > Balance: +530
-						int pointsInt = siege.getSiegeBalance();
-						String pointsString = pointsInt > 0 ? "+" + pointsInt : "" + pointsInt;
-						out.add(Translation.of("status_town_siege_status_siege_balance", pointsString));
+						// > Balance: 530
+						out.add(Translation.of("status_town_siege_status_siege_balance", siege.getSiegeBalance()));
 
 						if(SiegeWarSettings.isBannerXYZTextEnabled()) {
 							// > Banner XYZ: {2223,82,9877}

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.12
+version: 0.13
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -276,7 +276,7 @@ msg_beacon_preference_set: "&bBeacon preference set to %s."
 msg_na: 'N/A'
 
 #Town screen
-status_town_siege_status_siege_balance: '&2 > Balance: &a%s'
+status_town_siege_status_siege_balance: '&2 > Balance: &a%d'
 status_town_siege_status_warchest: '&2 > War Chest: &a%s'
 
 #Death points

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -276,7 +276,7 @@ msg_beacon_preference_set: "&bBeacon preference set to %s."
 msg_na: 'N/A'
 
 #Town screen
-status_town_siege_status_siege_balance: '&2 > Balance: &a%s'
+status_town_siege_status_siege_balance: '&2 > Balance: &a%d'
 status_town_siege_status_warchest: '&2 > War Chest: &a%s'
 
 #Death points

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.12
+version: 0.13
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"


### PR DESCRIPTION
#### Description: 
- With current code the presentation of the siege balance looks different from different sources, when the value is positive e.g.
  - dynmap:     520
  - hud:            520
  - town screen: +520
- These presentation should all look the same.
- I prefer the dynmap and hud version, because: 
  - The siege balance, being most important, should look most like a normal integer (i.e. no plus if positive).
  - Also the lack of positive sign helps distinguish it from the battle points  presentations (which all have the plus sign)
- In this PR I fix the the issue by setting the siege balance to present like a normal integer, and like the dynmap and hud.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
