### PR TITLE
Banner Control Session Pausing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>0.2.2</version>
+  <version>0.2.3</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/objects/BannerControlSession.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/BannerControlSession.java
@@ -10,12 +10,14 @@ public class BannerControlSession {
 	private Resident resident;
 	private SiegeSide siegeSide;
 	private long sessionEndTime;
+	int shortTicksUntilNextPauseWarning;
 
 	public BannerControlSession(Resident resident, Player player, SiegeSide siegeSide, long sessionEndTime) {
 		this.resident = resident;
 		this.player = player;
 		this.siegeSide = siegeSide;
 		this.sessionEndTime = sessionEndTime;
+		this.shortTicksUntilNextPauseWarning = 0;
 	}
 
 	public Player getPlayer() {
@@ -32,5 +34,17 @@ public class BannerControlSession {
 
 	public Resident getResident() {
 		return resident;
+	}
+
+	public int getShortTicksUntilNextPauseWarning() {
+		return shortTicksUntilNextPauseWarning;
+	}
+
+	public void setShortTicksUntilNextPauseWarning(int i) {
+		shortTicksUntilNextPauseWarning = i;
+	}
+
+	public void decrementShortTicksUntilNextPauseWarning() {
+		shortTicksUntilNextPauseWarning--;
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -715,7 +715,7 @@ public enum ConfigNodes {
 	BANNER_XYZ_TEXT_ENABLED(
 			"banner_xyz_text.enabled",
 			"false",
-			"The banner xyz text is an alternative to beacon markers for siege banners (but they can also be used together).",
+			"# The banner xyz text is an alternative to beacon markers for siege banners (but they can also be used together).",
 			"# If enabled, besieged towns will show the XYZ of the siege banner on their town screens.");
 
 	private final String Root;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -234,6 +234,13 @@ public class SiegeWarBannerControlUtil {
 									bannerControlSession.getPlayer().addPotionEffects(potionEffects);
 								}
 							});
+							//Send message to player every 9 ticks (ie 3 minutes)
+							if(bannerControlSession.getShortTicksUntilNextPauseWarning() < 1) {
+								Messaging.sendMsg(bannerControlSession.getPlayer(), Translation.of("msg_siege_war_banner_control_session_paused"));
+								bannerControlSession.setShortTicksUntilNextPauseWarning(9);
+							}
+							bannerControlSession.decrementShortTicksUntilNextPauseWarning();
+
 							continue BANNER_CONTROL_SESSIONS_LOOP;
 						}
 					}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -223,8 +223,7 @@ public class SiegeWarBannerControlUtil {
 
 					//Pause success if there are enemy soldiers nearby.
 					for(BannerControlSession bcSession: siege.getBannerControlSessions().values()) {
-						if(bcSession != bannerControlSession
-							&& bcSession.getSiegeSide() != bannerControlSession.getSiegeSide()) {
+						if(bcSession.getSiegeSide() != bannerControlSession.getSiegeSide()) {
 							//Reapply glow for 1 short tick
 							long effectDurationSeconds = TownySettings.getShortInterval();
 							final int effectDurationTicks = (int)(TimeTools.convertToTicks(effectDurationSeconds));

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.12
+version: 0.13
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -313,3 +313,6 @@ msg_siege_war_banner_control_reversal_bonus: ' Reversal Bonus: %s%d'
 
 #Admin
 msg_swa_set_siege_balance_success: '&bSuccessfully set siege balance to %d for %s.'
+
+#Added in 0.13
+msg_siege_war_banner_control_session_paused: '&cYour banner control session is paused because there are enemy soldiers near the banner. To complete your session, remove the enemy soldiers.'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.12
+version: 0.13
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -313,3 +313,6 @@ msg_siege_war_banner_control_reversal_bonus: ' Reversal Bonus: %s%d'
 
 #Admin
 msg_swa_set_siege_balance_success: '&bSuccessfully set siege balance to %d for %s.'
+
+#Added in 0.13:
+msg_siege_war_banner_control_session_paused: '&cYour banner control session is paused because there are enemy soldiers near the banner. To complete your session, remove the enemy soldiers.'


### PR DESCRIPTION
#### Description: 
- Today on EarthPol, players are very tough to kill
- This is allowing players to steal banner control by essentially running around the timed point zone for 15 minutes, sometimes giving them significant points when they steal control (due to the Reversal Bonus).
- Although other servers might not make players quite so tough, this issue may come up elsewhere too, possibly because reversals are more common than expected anyway, and possibly because the default session duration has been reduced from 10 mins to 7 mins. 
- In the PR I fix the issue by pausing the success of BC sessions if there are any enemy soldiers in the timed point zone.
- Thus a team which wants to gain or steal banner control no longer has an option of simply walking, dancing, or indeed, flying (and we heard a report about that once too) around the BC zone.
- Instead, they must first achieve the quite natural requirement of clearing the area of the enemy soldiers.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
