### PR TITLE
Remove "Battle Score" terminology

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -358,7 +358,7 @@ public class SiegeWarTownEventListener implements Listener {
 								out.addAll(ChatTools.listArr(bannerControllingResidents, Translation.of("status_town_banner_control", siege.getBannerControllingSide().getFormattedName(), siege.getBannerControllingResidents().size())));
 							}
 
-							// > Score: +90 / -220
+							// > Points: +90 / -220
 							out.add(Translation.of("status_town_siege_battle_score", siege.getFormattedAttackerBattlePoints(), siege.getFormattedDefenderBattlePoints()));
 
 							// > Time Remaining: 22 minutes

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -407,9 +407,9 @@ public enum ConfigNodes {
 			"2",
 			"# This setting determines the strength of the bonus multiplier.",
 			"# Example: Assuming this value is 2,",
-			"# then if team A has gained a battle score of 420 from banner control,",
+			"# then if team A has gained 420 battle points from banner control,",
 			"# and banner control is then reversed by Team B,",
-			"# then Team B will get a reversal bonus to their battle score, of 840."),
+			"# then Team B will get an instant bonus of 840 battle points."),
 
 	//Siege zone block/use restrictions
 	WAR_SIEGE_ZONE_BLOCK_PLACEMENT_RESTRICTIONS_ENABLED(

--- a/src/main/java/com/gmail/goosius/siegewar/utils/BookUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/BookUtil.java
@@ -206,7 +206,7 @@ public class BookUtil {
 
 		//Battle sessions
 		text += "\nBATTLE SESSIONS\n\n";
-		text += "Fighting is organised into " + activeSession + " 'battle sessions'. During a battle session, each team (attackers/defenders) competes in 'battles' at each siege. Killing or banner control will give them a 'battle score'. When the battle session ends, at each battle, the team with the highest battle score wins the battle, and their battle score is applied to the siege balance. After a battle session ends, there is typically a break until the next battle session. In this break, nobody can gain battle points.\n\n";
+		text += "Fighting is organised into " + activeSession + " 'battle sessions'. During a battle session, each team (attackers/defenders) competes in 'battles' at each siege. Killing or banner control will give them a 'Battle Points'. When the battle session ends, at each battle, the team with the highest battle points wins the battle, and their battle points are applied to the siege balance. After a battle session ends, there is typically a break until the next battle session. In this break, nobody can gain battle points.\n\n";
 
 		return text;
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -331,7 +331,7 @@ public class SiegeWarBannerControlUtil {
 			default:
 		}
 
-		//Record score for use by the 'Banner Control Reversal Bonus' feature
+		//Record gained battle points for use by the 'Banner Control Reversal Bonus' feature
 		siege.adjustBattlePointsEarnedFromCurrentBannerControl(battlePoints);
 	}
 

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.13
+version: 0.14
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -286,7 +286,7 @@ msg_siege_war_defender_death: '&bSiege of %s > Defender died > %s > Battle Point
 #Battle sessions
 status_town_siege_battle: '&2Battle'
 status_town_siege_battle_time_remaining: '&2 > Time Remaining: &a%s'
-status_town_siege_battle_score: '&2 > Score: &a%s &2/ &a%s'
+status_town_siege_battle_score: '&2 > Points: &a%s &2/ &a%s'
 msg_war_siege_battle_session_started: "&bA new battle session has started."
 msg_war_siege_battle_session_ended_with_battles: "&bThe current battle session has ended. The following teams won their battles:"
 msg_war_siege_battle_session_ended_without_battles: "&bThe current battle session has ended. There were no battles."
@@ -303,7 +303,7 @@ hud_battle_time_remaining: 'BAT Time Left: '
 
 #Dynmap
 dynmap_battle_points: 'Siege Balance: %d'
-dynmap_siege_battle_score: 'Battle Score: %s / %s'
+dynmap_siege_battle_score: 'Battle Points: %s / %s'
 dynmap_siege_battle_time_left: 'Battle Time Left: %s'
 
 #Banner control

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.13
+version: 0.14
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -286,7 +286,7 @@ msg_siege_war_defender_death: '&bSiege of %s > Defender died > %s > Battle Point
 #Battle sessions
 status_town_siege_battle: '&2Battle'
 status_town_siege_battle_time_remaining: '&2 > Time Remaining: &a%s'
-status_town_siege_battle_score: '&2 > Score: &a%s &2/ &a%s'
+status_town_siege_battle_score: '&2 > Points: &a%s &2/ &a%s'
 msg_war_siege_battle_session_started: "&bA new battle session has started."
 msg_war_siege_battle_session_ended_with_battles: "&bThe current battle session has ended. The following teams won their battles:"
 msg_war_siege_battle_session_ended_without_battles: "&bThe current battle session has ended. There were no battles."
@@ -303,7 +303,7 @@ hud_battle_time_remaining: 'BAT Time Left: '
 
 #Dynmap
 dynmap_battle_points: 'Siege Balance: %d'
-dynmap_siege_battle_score: 'Battle Score: %s / %s'
+dynmap_siege_battle_score: 'Battle Points: %s / %s'
 dynmap_siege_battle_time_left: 'Battle Time Left: %s'
 
 #Banner control


### PR DESCRIPTION
#### Description: 
- With current code, battle points are sometimes referred to as "Battle Points" and sometimes as "Battle Score".
- "Battle Score" is essentially a dev artefact, does not appear in any documentation, and makes the display needlessly complicated, as "battle points" serve adequately in all cases to show the relevant points.
- In this PR I fix the issue - replacing all instances of "battle score" with "battle points". 

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
