### PR TITLE
Add SiegeWar safe mode

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -96,12 +96,15 @@ public class SiegeController {
 	}
 
 	public static void loadAll() {
-	    System.out.println(SiegeWar.prefix + "Loading SiegeList...");
-		clearSieges();
-		loadSiegeList();
-		loadSieges();
-		System.out.println(SiegeWar.prefix + SiegeController.getSieges().size() + " siege(s) loaded.");
-
+		try {
+			System.out.println(SiegeWar.prefix + "Loading SiegeList...");
+			clearSieges();
+			loadSiegeList();
+			loadSieges();
+			System.out.println(SiegeWar.prefix + SiegeController.getSieges().size() + " siege(s) loaded.");
+		} catch (Exception e){
+			e.printStackTrace();
+		}
 	}
 	
 	public static void loadSiegeList() {

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -140,7 +140,7 @@ public class SiegeWar extends JavaPlugin {
 
 	private void registerCommands() {
 		if(isInSafeMode) {
-			System.out.println("SiegeWar is in safe mode. SiegeWar commands not registered");
+			System.out.println(prefix + "SiegeWar is in safe mode. SiegeWar commands not registered");
 		} else {
 			getCommand("siegewar").setExecutor(new SiegeWarCommand());
 			getCommand("siegewaradmin").setExecutor(new SiegeWarAdminCommand());

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -61,7 +61,7 @@ public class SiegeWar extends JavaPlugin {
         if (!Settings.loadSettingsAndLang())
         	isError = true;
 
-		registerCommands();
+        registerCommands();
 
         if (Bukkit.getPluginManager().getPlugin("Towny").isEnabled())
         	SiegeController.loadAll();

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -30,7 +30,7 @@ public class SiegeWar extends JavaPlugin {
 	private static Version requiredTownyVersion = Version.fromString("0.96.7.4");
 	private final static SiegeHUDManager SiegeHudManager = new SiegeHUDManager(plugin);
 	private static boolean cannonsPluginDetected;
-	private static boolean isInSafeMode;  //Indicates if plugin got an error on startup and is in safe mode
+	private static boolean isError;  //Indicates if plugin got an error on startup and is in safe mode
 
 	public static SiegeWar getSiegeWar() {
 		return plugin;
@@ -53,20 +53,20 @@ public class SiegeWar extends JavaPlugin {
     	
         if (!townyVersionCheck(getTownyVersion())) {
             System.err.println(prefix + "Towny version does not meet required minimum version: " + requiredTownyVersion.toString());
-            isInSafeMode = true;
+            isError = true;
         } else {
             System.out.println(prefix + "Towny version " + getTownyVersion() + " found.");
         }
         
         if (!Settings.loadSettingsAndLang())
-        	isInSafeMode = true;
+        	isError = true;
 
 		registerCommands();
 
         if (Bukkit.getPluginManager().getPlugin("Towny").isEnabled())
         	SiegeController.loadAll();
 
-		if(isInSafeMode) {
+		if(isError) {
 			System.err.println(prefix + "SiegeWar is in safe mode. Dynmap integration disabled.");
 		} else {
 			Plugin dynmap = Bukkit.getPluginManager().getPlugin("dynmap");
@@ -78,7 +78,7 @@ public class SiegeWar extends JavaPlugin {
 			}
 		}
 
-		if(isInSafeMode) {
+		if(isError) {
 			System.err.println(prefix + "SiegeWar is in safe mode. Cannons integration disabled.");
 		} else {
 			Plugin cannons = Bukkit.getPluginManager().getPlugin("Cannons");
@@ -96,7 +96,7 @@ public class SiegeWar extends JavaPlugin {
 
 		registerListeners();
 
-		if(isInSafeMode) {
+		if(isError) {
 			System.err.println(prefix + "SiegeWar did not load successfully, and is now in safe mode.");
 		} else {
 			System.out.println(prefix + "SiegeWar loaded successfully.");
@@ -124,7 +124,7 @@ public class SiegeWar extends JavaPlugin {
 	private void registerListeners() {
 		PluginManager pm = Bukkit.getServer().getPluginManager();
 		
-		if (isInSafeMode)
+		if (isError)
 			pm.registerEvents(new SiegeWarSafeModeListener(), this);
 		else {
 			pm.registerEvents(new SiegeWarActionListener(this), this);
@@ -139,7 +139,7 @@ public class SiegeWar extends JavaPlugin {
 	}
 
 	private void registerCommands() {
-		if(isInSafeMode) {
+		if(isError) {
 			System.err.println(prefix + "SiegeWar is in safe mode. SiegeWar commands not registered");
 		} else {
 			getCommand("siegewar").setExecutor(new SiegeWarCommand());
@@ -169,6 +169,6 @@ public class SiegeWar extends JavaPlugin {
 	}
 	
 	public static boolean isError() {
-		return isInSafeMode;
+		return isError;
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -62,7 +62,7 @@ public class SiegeWar extends JavaPlugin {
         	isError = true;
 
         registerCommands();
-
+        
         if (Bukkit.getPluginManager().getPlugin("Towny").isEnabled())
         	SiegeController.loadAll();
 

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -17,6 +17,7 @@ import com.gmail.goosius.siegewar.listeners.SiegeWarActionListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarBukkitEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarNationEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarPlotEventListener;
+import com.gmail.goosius.siegewar.listeners.SiegeWarSafeModeListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarTownEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarTownyEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarCannonsListener;
@@ -29,6 +30,7 @@ public class SiegeWar extends JavaPlugin {
 	private static Version requiredTownyVersion = Version.fromString("0.96.7.4");
 	private final static SiegeHUDManager SiegeHudManager = new SiegeHUDManager(plugin);
 	private static boolean cannonsPluginDetected;
+	private static boolean isError;
 
 	public static SiegeWar getSiegeWar() {
 		return plugin;
@@ -51,13 +53,13 @@ public class SiegeWar extends JavaPlugin {
     	
         if (!townyVersionCheck(getTownyVersion())) {
             System.err.println(prefix + "Towny version does not meet required minimum version: " + requiredTownyVersion.toString());
-            onDisable();
+            isError = true;
         } else {
             System.out.println(prefix + "Towny version " + getTownyVersion() + " found.");
         }
         
         if (!Settings.loadSettingsAndLang())
-        	onDisable();
+        	isError = true;
 
         registerCommands();
         
@@ -109,14 +111,18 @@ public class SiegeWar extends JavaPlugin {
 	
 	private void registerListeners() {
 		PluginManager pm = Bukkit.getServer().getPluginManager();
-		pm.registerEvents(new SiegeWarActionListener(this), this);
-		pm.registerEvents(new SiegeWarBukkitEventListener(this), this);		
-		pm.registerEvents(new SiegeWarTownyEventListener(this), this);
-		pm.registerEvents(new SiegeWarNationEventListener(this), this);
-		pm.registerEvents(new SiegeWarTownEventListener(this), this);
-		pm.registerEvents(new SiegeWarPlotEventListener(this), this);
-		if(cannonsPluginDetected) {
-			pm.registerEvents(new SiegeWarCannonsListener(this), this);
+		
+		if (isError)
+			pm.registerEvents(new SiegeWarSafeModeListener(), this);
+		else {
+			pm.registerEvents(new SiegeWarActionListener(this), this);
+			pm.registerEvents(new SiegeWarBukkitEventListener(this), this);		
+			pm.registerEvents(new SiegeWarTownyEventListener(this), this);
+			pm.registerEvents(new SiegeWarNationEventListener(this), this);
+			pm.registerEvents(new SiegeWarTownEventListener(this), this);
+			pm.registerEvents(new SiegeWarPlotEventListener(this), this);
+			if(cannonsPluginDetected)
+				pm.registerEvents(new SiegeWarCannonsListener(this), this);
 		}
 	}
 	
@@ -144,5 +150,9 @@ public class SiegeWar extends JavaPlugin {
 
 	public static boolean getCannonsPluginDetected() {
 		return cannonsPluginDetected;
+	}
+	
+	public static boolean isError() {
+		return isError;
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -140,7 +140,7 @@ public class SiegeWar extends JavaPlugin {
 
 	private void registerCommands() {
 		if(isInSafeMode) {
-			System.out.println(prefix + "SiegeWar is in safe mode. SiegeWar commands not registered");
+			System.err.println(prefix + "SiegeWar is in safe mode. SiegeWar commands not registered");
 		} else {
 			getCommand("siegewar").setExecutor(new SiegeWarCommand());
 			getCommand("siegewaradmin").setExecutor(new SiegeWarAdminCommand());

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -67,7 +67,7 @@ public class SiegeWar extends JavaPlugin {
         	SiegeController.loadAll();
 
 		if(isInSafeMode) {
-			System.err.println("SiegeWar is in safe mode. Dynmap integration disabled.");
+			System.err.println(prefix + "SiegeWar is in safe mode. Dynmap integration disabled.");
 		} else {
 			Plugin dynmap = Bukkit.getPluginManager().getPlugin("dynmap");
 			if (dynmap != null) {
@@ -79,7 +79,7 @@ public class SiegeWar extends JavaPlugin {
 		}
 
 		if(isInSafeMode) {
-			System.err.println("SiegeWar is in safe mode. Cannons integration disabled.");
+			System.err.println(prefix + "SiegeWar is in safe mode. Cannons integration disabled.");
 		} else {
 			Plugin cannons = Bukkit.getPluginManager().getPlugin("Cannons");
 			if (cannons != null) {

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -67,7 +67,7 @@ public class SiegeWar extends JavaPlugin {
         	SiegeController.loadAll();
 
 		if(isInSafeMode) {
-			System.out.println("SiegeWar is in safe mode. Dynmap integration disabled.");
+			System.err.println("SiegeWar is in safe mode. Dynmap integration disabled.");
 		} else {
 			Plugin dynmap = Bukkit.getPluginManager().getPlugin("dynmap");
 			if (dynmap != null) {
@@ -79,7 +79,7 @@ public class SiegeWar extends JavaPlugin {
 		}
 
 		if(isInSafeMode) {
-			System.out.println("SiegeWar is in safe mode. Cannons integration disabled.");
+			System.err.println("SiegeWar is in safe mode. Cannons integration disabled.");
 		} else {
 			Plugin cannons = Bukkit.getPluginManager().getPlugin("Cannons");
 			if (cannons != null) {
@@ -97,7 +97,7 @@ public class SiegeWar extends JavaPlugin {
 		registerListeners();
 
 		if(isInSafeMode) {
-			System.out.println(prefix + "SiegeWar did not load successfully, and is now in safe mode.");
+			System.err.println(prefix + "SiegeWar did not load successfully, and is now in safe mode.");
 		} else {
 			System.out.println(prefix + "SiegeWar loaded successfully.");
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
@@ -1,5 +1,6 @@
 package com.gmail.goosius.siegewar.listeners;
 
+import com.palmergames.bukkit.towny.event.time.NewShortTimeEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -15,13 +16,17 @@ import com.palmergames.bukkit.towny.event.nation.NationPreTownLeaveEvent;
 public class SiegeWarSafeModeListener implements Listener {
 
 	private void sendErrorMessage(Player player) {
-		Messaging.sendErrorMsg(player, getErrMsg());
+		Messaging.sendErrorMsg(player, getActionErrMsg());
 	}
 	
-	private String getErrMsg() {
+	private String getActionErrMsg() {
 		return "SiegeWar could not load and is in safe mode, action declined.";
 	}
-	
+
+	private String getShortTickErrMsg() {
+		return "SiegeWar could not load and is in safe mode.";
+	}
+
 	@EventHandler (priority=EventPriority.HIGHEST, ignoreCancelled=true)
 	public void onPlayerBreakDuringSafemode (BlockBreakEvent event) {
 		if (!SiegeWar.isError())
@@ -42,8 +47,7 @@ public class SiegeWarSafeModeListener implements Listener {
 	public void onTownClaimDuringSafemode (TownPreClaimEvent event) {
 		if (!SiegeWar.isError())
 			return;
-		
-		event.setCancelMessage(getErrMsg());
+		event.setCancelMessage(getActionErrMsg());
 		event.setCancelled(true);
 	}
 
@@ -51,9 +55,16 @@ public class SiegeWarSafeModeListener implements Listener {
 	public void onTownLeaveNationDuringSafemode (NationPreTownLeaveEvent event) {
 		if (!SiegeWar.isError())
 			return;
-		
-		event.setCancelMessage(getErrMsg());
+		event.setCancelMessage(getActionErrMsg());
 		event.setCancelled(true);
-	}	
-	
+	}
+
+	@EventHandler
+	public void onShortTime(NewShortTimeEvent event) {
+		if (!SiegeWar.isError())
+			return;
+		System.out.println(getShortTickErrMsg());
+		Messaging.sendGlobalMessage("&c" + getShortTickErrMsg());
+	}
+
 }

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
@@ -63,7 +63,6 @@ public class SiegeWarSafeModeListener implements Listener {
 	public void onShortTime(NewShortTimeEvent event) {
 		if (!SiegeWar.isError())
 			return;
-		System.err.println(getShortTickErrMsg());
 		Messaging.sendGlobalMessage("&c" + getShortTickErrMsg());
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
@@ -63,7 +63,7 @@ public class SiegeWarSafeModeListener implements Listener {
 	public void onShortTime(NewShortTimeEvent event) {
 		if (!SiegeWar.isError())
 			return;
-		System.out.println(getShortTickErrMsg());
+		System.err.println(getShortTickErrMsg());
 		Messaging.sendGlobalMessage("&c" + getShortTickErrMsg());
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
@@ -1,0 +1,59 @@
+package com.gmail.goosius.siegewar.listeners;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+import com.gmail.goosius.siegewar.Messaging;
+import com.gmail.goosius.siegewar.SiegeWar;
+import com.palmergames.bukkit.towny.event.TownPreClaimEvent;
+import com.palmergames.bukkit.towny.event.nation.NationPreTownLeaveEvent;
+
+public class SiegeWarSafeModeListener implements Listener {
+
+	private void sendErrorMessage(Player player) {
+		Messaging.sendErrorMsg(player, getErrMsg());
+	}
+	
+	private String getErrMsg() {
+		return "SiegeWar could not load and is in safe mode, action declined.";
+	}
+	
+	@EventHandler (priority=EventPriority.HIGHEST, ignoreCancelled=true)
+	public void onPlayerBreakDuringSafemode (BlockBreakEvent event) {
+		if (!SiegeWar.isError())
+			return;
+		sendErrorMessage(event.getPlayer());
+		event.setCancelled(true);
+	}
+	
+	@EventHandler (priority=EventPriority.HIGHEST, ignoreCancelled=true)
+	public void onPlayerBuildDuringSafemode (BlockPlaceEvent event) {
+		if (!SiegeWar.isError())
+			return;
+		sendErrorMessage(event.getPlayer());
+		event.setCancelled(true);
+	}
+	
+	@EventHandler (priority=EventPriority.HIGHEST, ignoreCancelled=true)
+	public void onTownClaimDuringSafemode (TownPreClaimEvent event) {
+		if (!SiegeWar.isError())
+			return;
+		
+		event.setCancelMessage(getErrMsg());
+		event.setCancelled(true);
+	}
+
+	@EventHandler (priority=EventPriority.HIGHEST, ignoreCancelled=true)
+	public void onTownLeaveNationDuringSafemode (NationPreTownLeaveEvent event) {
+		if (!SiegeWar.isError())
+			return;
+		
+		event.setCancelMessage(getErrMsg());
+		event.setCancelled(true);
+	}	
+	
+}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
@@ -2,7 +2,6 @@ package com.gmail.goosius.siegewar.listeners;
 
 import com.palmergames.bukkit.towny.event.time.NewShortTimeEvent;
 import org.bukkit.ChatColor;
-import org.bukkit.Color;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
@@ -1,6 +1,8 @@
 package com.gmail.goosius.siegewar.listeners;
 
 import com.palmergames.bukkit.towny.event.time.NewShortTimeEvent;
+import org.bukkit.ChatColor;
+import org.bukkit.Color;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -63,7 +65,7 @@ public class SiegeWarSafeModeListener implements Listener {
 	public void onShortTime(NewShortTimeEvent event) {
 		if (!SiegeWar.isError())
 			return;
-		Messaging.sendGlobalMessage("&c" + getShortTickErrMsg());
+		Messaging.sendGlobalMessage(ChatColor.DARK_RED + getShortTickErrMsg());
 	}
 
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
@@ -15,13 +15,13 @@ public class Settings {
 
 	public static boolean loadSettingsAndLang() {
 		SiegeWar sw = SiegeWar.getSiegeWar();
+		boolean loadSuccessFlag = true;
 
 		try {
 			Settings.loadConfig(sw.getDataFolder().getPath() + File.separator + "config.yml", sw.getVersion());
 		} catch (Exception e) {
-            e.printStackTrace();
             System.err.println(SiegeWar.prefix + "Config.yml failed to load! Disabling!");
-            return false;
+			loadSuccessFlag = false;
         }
 
 		// Some list variables do not reload upon loadConfig.
@@ -30,9 +30,8 @@ public class Settings {
 		try {
 			Translation.loadLanguage(sw.getDataFolder().getPath() + File.separator, "english.yml");
 		} catch (Exception e) {
-	        e.printStackTrace();
 	        System.err.println(SiegeWar.prefix + "Language file failed to load! Disabling!");
-	        return false;
+			loadSuccessFlag = false;
 	    }
 
 		//Extract images
@@ -41,7 +40,7 @@ public class Settings {
 		} catch (Exception e) {
 			e.printStackTrace();
 			System.err.println(SiegeWar.prefix + "Could not load images! Disabling!");
-			return false;
+			loadSuccessFlag = false;
 		}
 
 		//Schedule next battle session
@@ -50,26 +49,27 @@ public class Settings {
 		} catch (Exception e) {
 			e.printStackTrace();
 			System.err.println(SiegeWar.prefix + "Problem Scheduling Battle Session! Disabling!");
-			return false;
+			loadSuccessFlag = false;
 		}
 
-		return true;
+		return loadSuccessFlag;
 	}
 	
 	public static void loadConfig(String filepath, String version) throws Exception {
+		boolean loadSuccessFlag = true;
 		if (FileMgmt.checkOrCreateFile(filepath)) {
 			File file = new File(filepath);
 
 			// read the config.yml into memory
 			config = new CommentedConfiguration(file);
 			if (!config.load()) {
-				System.out.print("Failed to load Config!");
-				throw new IOException("Failed to load Config!");
+				loadSuccessFlag = false;
 			}
-
 			setDefaults(version, file);
 			config.save();
 		}
+		if(!loadSuccessFlag)
+			throw new IOException("Failed to load Config!");
 	}
 
 	public static void addComment(String root, String... comments) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
@@ -56,20 +56,17 @@ public class Settings {
 	}
 	
 	public static void loadConfig(String filepath, String version) throws Exception {
-		boolean loadSuccessFlag = true;
 		if (FileMgmt.checkOrCreateFile(filepath)) {
 			File file = new File(filepath);
 
 			// read the config.yml into memory
 			config = new CommentedConfiguration(file);
 			if (!config.load()) {
-				loadSuccessFlag = false;
+				throw new IOException("Failed to load Config!");
 			}
 			setDefaults(version, file);
 			config.save();
 		}
-		if(!loadSuccessFlag)
-			throw new IOException("Failed to load Config!");
 	}
 
 	public static void addComment(String root, String... comments) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
@@ -18,7 +18,7 @@ public class Settings {
 
 		try {
 			Settings.loadConfig(sw.getDataFolder().getPath() + File.separator + "config.yml", sw.getVersion());
-		} catch (IOException e) {
+		} catch (Exception e) {
             e.printStackTrace();
             System.err.println(SiegeWar.prefix + "Config.yml failed to load! Disabling!");
             return false;
@@ -29,7 +29,7 @@ public class Settings {
 		
 		try {
 			Translation.loadLanguage(sw.getDataFolder().getPath() + File.separator, "english.yml");
-		} catch (IOException e) {
+		} catch (Exception e) {
 	        e.printStackTrace();
 	        System.err.println(SiegeWar.prefix + "Language file failed to load! Disabling!");
 	        return false;
@@ -45,19 +45,27 @@ public class Settings {
 		}
 
 		//Schedule next battle session
-		SiegeWarBattleSessionUtil.scheduleNextBattleSession();
+		try {
+			SiegeWarBattleSessionUtil.scheduleNextBattleSession();
+		} catch (Exception e) {
+			e.printStackTrace();
+			System.err.println(SiegeWar.prefix + "Problem Scheduling Battle Session! Disabling!");
+			return false;
+		}
 
 		return true;
 	}
 	
-	public static void loadConfig(String filepath, String version) throws IOException {
+	public static void loadConfig(String filepath, String version) throws Exception {
 		if (FileMgmt.checkOrCreateFile(filepath)) {
 			File file = new File(filepath);
 
 			// read the config.yml into memory
 			config = new CommentedConfiguration(file);
-			if (!config.load())
+			if (!config.load()) {
 				System.out.print("Failed to load Config!");
+				throw new IOException("Failed to load Config!");
+			}
 
 			setDefaults(version, file);
 			config.save();

--- a/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
@@ -61,9 +61,9 @@ public class Settings {
 
 			// read the config.yml into memory
 			config = new CommentedConfiguration(file);
-			if (!config.load()) {
+			if (!config.load())
 				throw new IOException("Failed to load Config!");
-			}
+
 			setDefaults(version, file);
 			config.save();
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/settings/Translation.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/Translation.java
@@ -22,7 +22,7 @@ public final class Translation {
 	// This will read the language entry in the config.yml to attempt to load
 	// custom languages
 	// if the file is not found it will load the default from resource
-	public static void loadLanguage(String filepath, String defaultRes) throws IOException {
+	public static void loadLanguage(String filepath, String defaultRes) throws Exception {
 
 		String res = Settings.getString(ConfigNodes.LANGUAGE.getRoot(), defaultRes);
 		String fullPath = filepath + File.separator + res;
@@ -42,6 +42,7 @@ public final class Translation {
 			return;
 		} catch (InvalidConfigurationException e) {
 			System.err.println(SiegeWar.prefix + "Invalid Configuration in language file detected.");
+			throw e;
 		}
 		
 		String resVersion = newLanguage.getString("version");


### PR DESCRIPTION
#### Description: 
- This code was mostly by Llama.
- I just added the short tick message, blocked commands, and increased robustness.
- This PR adds a safe mode for SiegeWar, in which the following are blocked:
  - claiming
  - block placing
  - block destroying
  - towns leaving nation
  - sw commands
  - swa commands
- Also there is a message on each short tick (e.g. to reach people who are just standing waiting for a BC session to start or siege to end etc.). 

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
