### PR TITLE
Trap-Warfare Mitigation

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
@@ -71,7 +71,7 @@ public class SiegeWarActionListener implements Listener {
 			event.setCancelled(true);
 		}
 	}
-
+	
 	/*
 	 * SW will prevent an explosion from altering an area around a banner.
 	 */

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
@@ -68,10 +68,10 @@ public class SiegeWarActionListener implements Listener {
 	@EventHandler
 	public void onBurn(TownyBurnEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled() && SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())) {
-			event.setCancelled(true);	
+			event.setCancelled(true);
 		}
 	}
-
+	
 	/*
 	 * SW will prevent an explosion from altering an area around a banner.
 	 */

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
@@ -3,6 +3,9 @@ package com.gmail.goosius.siegewar.listeners;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -45,10 +48,17 @@ public class SiegeWarActionListener implements Listener {
 	 */
 	@EventHandler
 	public void onBlockBreak(TownyDestroyEvent event) {
-		if (SiegeWarSettings.getWarSiegeEnabled()) 
+		if (SiegeWarSettings.getWarSiegeEnabled())
+			if(SiegeWarSettings.isTrapWarfareMitigationEnabled()
+					&& SiegeWarDistanceUtil.isLocationInActiveTimedPointZoneAndBelowSiegeBannerAltitude(event.getBlock().getLocation())) {
+				event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.DARK_RED + Translation.of("msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone")));
+				event.setCancelled(true);
+				return;
+			}
 			if (SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())) {
 				event.setMessage(Translation.of("msg_err_siege_war_cannot_destroy_siege_banner"));
 				event.setCancelled(true);
+				return;
 			}
 	}
 	
@@ -57,11 +67,11 @@ public class SiegeWarActionListener implements Listener {
 	 */
 	@EventHandler
 	public void onBurn(TownyBurnEvent event) {
-		if (SiegeWarSettings.getWarSiegeEnabled() && SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())) {	
-			event.setCancelled(true);	
+		if (SiegeWarSettings.getWarSiegeEnabled() && SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())) {
+			event.setCancelled(true);
 		}
 	}
-	
+
 	/*
 	 * SW will prevent an explosion from altering an area around a banner.
 	 */
@@ -71,7 +81,11 @@ public class SiegeWarActionListener implements Listener {
 			List<Block> blockList = event.getTownyFilteredBlockList();
 			List<Block> filteredList = new ArrayList<>();
 			for (Block block : blockList) {
-				if (!SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(block)) {
+				if (
+					(!SiegeWarSettings.isTrapWarfareMitigationEnabled() || !SiegeWarDistanceUtil.isLocationInActiveTimedPointZoneAndBelowSiegeBannerAltitude(block.getLocation()))
+					&&
+					!SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(block)
+				) {
 					filteredList.add(block);
 				}
 			}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
@@ -68,10 +68,10 @@ public class SiegeWarActionListener implements Listener {
 	@EventHandler
 	public void onBurn(TownyBurnEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled() && SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())) {
-			event.setCancelled(true);
+			event.setCancelled(true);	
 		}
 	}
-	
+
 	/*
 	 * SW will prevent an explosion from altering an area around a banner.
 	 */

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -22,6 +22,9 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Nation;
 
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.Banner;
@@ -60,6 +63,14 @@ public class PlaceBlock {
 	public static void evaluateSiegeWarPlaceBlockRequest(Player player, Block block, TownyBuildEvent event) {
 		
 		try {
+			//Enforce Anti-Trap warfare build block if below siege banner altitude.
+			if(SiegeWarSettings.isTrapWarfareMitigationEnabled()
+					&& SiegeWarDistanceUtil.isLocationInActiveTimedPointZoneAndBelowSiegeBannerAltitude(event.getBlock().getLocation())) {
+				event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.DARK_RED + Translation.of("msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone")));
+				event.setCancelled(true);
+				return;
+			}
+
 			Material mat = block.getType();
 
 			//Standing Banner placement
@@ -82,7 +93,7 @@ public class PlaceBlock {
 					return;
 				}
 	
-			//Check for forbidden block placement
+			//Check for forbidden siegezone block placement
 			if(SiegeWarSettings.isWarSiegeZoneBlockPlacementRestrictionsEnabled() 
 					&& TownyAPI.getInstance().isWilderness(block) 
 					&& SiegeWarDistanceUtil.isLocationInActiveSiegeZone(block.getLocation())

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -164,7 +164,8 @@ public class PlayerDeath {
 
 				if (confirmedCandidateSiege.getBannerControlSessions().containsKey(deadPlayer)) { //If the player that died had an ongoing session, remove it.
 					confirmedCandidateSiege.removeBannerControlSession(confirmedCandidateSiege.getBannerControlSessions().get(deadPlayer));
-					Messaging.sendMsg(deadPlayer, Translation.of("msg_siege_war_banner_control_session_failure"));
+					String errorMessage = SiegeWarSettings.isTrapWarfareMitigationEnabled() ? Translation.of("msg_siege_war_banner_control_session_failure_with_altitude") : Translation.of("msg_siege_war_banner_control_session_failure");
+					Messaging.sendMsg(deadPlayer, errorMessage);
 				}
 			}
 		} catch (Exception e) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -156,10 +156,13 @@ public enum ConfigNodes {
 			"# If this setting is true, then Siegewar statistics will be shown on nation status screens."),
 	WAR_SIEGE_SWITCHES_TRAP_WARFARE_MITIGATION_ENABLED(
 			"war.siege.switches.trap_warfare_mitigation_enabled",
-			"true",
+			"false",
 			"# If this setting is true, then ",
 			"# 1. Players cannot build/destroy blocks in the timed point zone below the siege banner altitude, and",
-			"# 2. Banner control cannot be gained if the player is below the siege banner altitude"),
+			"# 2. Banner control cannot be gained if the player is below the siege banner altitude",
+			"# NOTE: ",
+			"# If you enable this feature, ",
+			"# make sure to also have a server rule preventing traps being created in the timed-point-zone BEFORE the banner is placed"),
 
 	//Monetary Values
 

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -157,9 +157,9 @@ public enum ConfigNodes {
 	WAR_SIEGE_SWITCHES_TRAP_WARFARE_MITIGATION_ENABLED(
 			"war.siege.switches.trap_warfare_mitigation_enabled",
 			"true",
-			"# If this setting is true, ",
-			"# then within the timed point zones of active sieges,",
-			"# players cannot build/destroy blocks below the siege banner altitude."),
+			"# If this setting is true, then ",
+			"# 1. Players cannot build/destroy blocks in the timed point zone below the siege banner altitude, and",
+			"# 2. Banner control cannot be gained if the player is below the siege banner altitude"),
 
 	//Monetary Values
 

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -154,6 +154,12 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# If this setting is true, then Siegewar statistics will be shown on nation status screens."),
+	WAR_SIEGE_SWITCHES_TRAP_WARFARE_MITIGATION_ENABLED(
+			"war.siege.switches.trap_warfare_mitigation_enabled",
+			"true",
+			"# If this setting is true, ",
+			"# then within the timed point zones of active sieges,",
+			"# players cannot build/destroy blocks below the siege banner altitude."),
 
 	//Monetary Values
 

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -157,6 +157,7 @@ public enum ConfigNodes {
 	WAR_SIEGE_SWITCHES_TRAP_WARFARE_MITIGATION_ENABLED(
 			"war.siege.switches.trap_warfare_mitigation_enabled",
 			"false",
+			"",
 			"# If this setting is true, then ",
 			"# 1. Players cannot build/destroy blocks in the timed point zone below the siege banner altitude, and",
 			"# 2. Banner control cannot be gained if the player is below the siege banner altitude",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -397,4 +397,7 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.BANNER_XYZ_TEXT_ENABLED);
 	}
 
+	public static boolean isTrapWarfareMitigationEnabled() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_SWITCHES_TRAP_WARFARE_MITIGATION_ENABLED);
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -199,6 +199,10 @@ public class SiegeWarBannerControlUtil {
 		if(!SiegeWarScoringUtil.isPlayerInTimedPointZone(player, siege))
 			return false; //player is not in the timed point zone
 
+		if(SiegeWarSettings.isTrapWarfareMitigationEnabled()
+			&& SiegeWarDistanceUtil.isBelowSiegeBannerAltitude(player.getLocation(), siege))
+			return false; //Player is below the siege banner
+
 		return true;
 	}
 
@@ -209,7 +213,9 @@ public class SiegeWarBannerControlUtil {
 				//Check if session failed
 				if (!doesPlayerMeetBasicSessionRequirements(siege, bannerControlSession.getPlayer(), bannerControlSession.getResident())) {
 					siege.removeBannerControlSession(bannerControlSession);
-					Messaging.sendMsg(bannerControlSession.getPlayer(), Translation.of("msg_siege_war_banner_control_session_failure"));
+
+					String errorMessage = SiegeWarSettings.isTrapWarfareMitigationEnabled() ? Translation.of("msg_siege_war_banner_control_session_failure_with_altitude") : Translation.of("msg_siege_war_banner_control_session_failure");
+					Messaging.sendMsg(bannerControlSession.getPlayer(), errorMessage);
 					CosmeticUtil.evaluateBeacon(bannerControlSession.getPlayer(), siege);
 
 					if (bannerControlSession.getPlayer().hasPotionEffect(PotionEffectType.GLOWING)) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -206,7 +206,7 @@ public class SiegeWarDistanceUtil {
 		return false;
 	}
 
-	private static boolean isBelowSiegeBannerAltitude(Location location, Siege siege) {
+	public static boolean isBelowSiegeBannerAltitude(Location location, Siege siege) {
 		return location.getY() < siege.getFlagLocation().getY();
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -14,6 +14,7 @@ import com.palmergames.bukkit.towny.object.WorldCoord;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Nullable;
 
@@ -123,8 +124,8 @@ public class SiegeWarDistanceUtil {
 		return areLocationsCloseHorizontally(entity.getLocation(), siege.getFlagLocation(), SiegeWarSettings.getWarSiegeZoneRadiusBlocks());
 	}
 
-	public static boolean isInTimedPointZone(Entity entity, Siege siege) {
-		return areLocationsClose(entity.getLocation(), siege.getFlagLocation(), TownySettings.getTownBlockSize(), SiegeWarSettings.getBannerControlVerticalDistanceBlocks());
+	public static boolean isInTimedPointZone(Location location, Siege siege) {
+		return areLocationsClose(location, siege.getFlagLocation(), TownySettings.getTownBlockSize(), SiegeWarSettings.getBannerControlVerticalDistanceBlocks());
 	}
 
 	public static boolean areTownsClose(Town town1, Town town2, int radiusTownblocks) {
@@ -186,4 +187,29 @@ public class SiegeWarDistanceUtil {
 		int locZ = worldCoord.getZ() * TOWNBLOCKSIZE;
 		return new Location(worldCoord.getBukkitWorld(), locX, 255, locZ);
 	}
+
+	/**
+	 * This method is used in Anti-trap warfare mitigation
+	 *
+	 * @param location
+	 * @return true of the location is in an active timed point zone AND below siege banner altitude
+	 */
+	public static boolean isLocationInActiveTimedPointZoneAndBelowSiegeBannerAltitude(Location location) {
+		//Look through all sieges
+		for (Siege siege : SiegeController.getSieges()) {
+			if (siege.getStatus().isActive()
+				&& isInTimedPointZone(location, siege)
+				&& isBelowSiegeBannerAltitude(location, siege))
+				return true;
+		}
+		//Location does not meet the criteria
+		return false;
+	}
+
+	private static boolean isBelowSiegeBannerAltitude(Location location, Siege siege) {
+		return location.getY() < siege.getFlagLocation().getY();
+	}
 }
+
+
+

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -14,7 +14,6 @@ import com.palmergames.bukkit.towny.object.WorldCoord;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Nullable;
 
@@ -210,6 +209,3 @@ public class SiegeWarDistanceUtil {
 		return location.getY() < siege.getFlagLocation().getY();
 	}
 }
-
-
-

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
@@ -53,7 +53,7 @@ public class SiegeWarScoringUtil {
 	 */
 	public static boolean isPlayerInTimedPointZone(Player player, Siege siege) {
 		return TownyAPI.getInstance().isWilderness(player.getLocation())
-				&& SiegeWarDistanceUtil.isInTimedPointZone(player, siege);
+				&& SiegeWarDistanceUtil.isInTimedPointZone(player.getLocation(), siege);
 	}
 
 	/**

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -320,4 +320,4 @@ msg_siege_war_version: '&bThe current SiegeWar version is: %s.'
 #Added in 0.14
 msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below banner altitude in the timed point zone.'
 msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going into the town, or flying.'
-msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going above the altitude of the banner, going into the town, or flying.'
+msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going below the altitude of the banner, going into the town, or flying.'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -319,4 +319,4 @@ msg_siege_war_banner_control_session_paused: '&cYour banner control session is p
 msg_siege_war_version: '&bThe current SiegeWar version is: %s.'
 
 #Added in 0.14
-msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below the banner altitude in the timed point zone.'
+msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below banner altitude in the timed point zone.'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -317,3 +317,6 @@ msg_swa_set_siege_balance_success: '&bSuccessfully set siege balance to %d for %
 #Added in 0.13
 msg_siege_war_banner_control_session_paused: '&cYour banner control session is paused because there are enemy soldiers near the banner. To complete your session, remove the enemy soldiers.'
 msg_siege_war_version: '&bThe current SiegeWar version is: %s.'
+
+#Added in 0.14
+msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below the banner altitude in the timed point zone.'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -109,7 +109,6 @@ msg_err_siege_war_banner_support_block_not_stable: "&cYou cannot place the banne
 # Spawn
 msg_err_siege_war_cannot_spawn_into_siegezone_or_besieged_town: '&cOnly town residents can spawn into a besieged town or siege zone (unless the target town is peaceful).'
 #Banner control
-msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: Going into the town, too far from the banner, or flying.'
 msg_war_siege_zone_milk_bucket_forbidden_while_attempting_banner_control: 'You cannot use this item while in a banner control session.'
 
 #Town Info Siege Section
@@ -320,3 +319,5 @@ msg_siege_war_version: '&bThe current SiegeWar version is: %s.'
 
 #Added in 0.14
 msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below banner altitude in the timed point zone.'
+msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, entering the town, going too far from the banner, or flying.'
+msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, entering the town, going too far from the banner, going above the altitude of the banner, or flying.'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -319,5 +319,5 @@ msg_siege_war_version: '&bThe current SiegeWar version is: %s.'
 
 #Added in 0.14
 msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below banner altitude in the timed point zone.'
-msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, entering the town, going too far from the banner, or flying.'
-msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, entering the town, going too far from the banner, going above the altitude of the banner, or flying.'
+msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going into the town, or flying.'
+msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going above the altitude of the banner, going into the town, or flying.'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -109,7 +109,6 @@ msg_err_siege_war_banner_support_block_not_stable: "&cVous ne pouvez pas placer 
 # Spawn
 msg_err_siege_war_cannot_spawn_into_siegezone_or_besieged_town: "&cSeuls les habitants de la ville peuvent spawn dans une ville assiégée ou une zone de siège (sauf si la ville cible est paisible)."
 #Banner control
-msg_siege_war_banner_control_session_failure: "&cLa session de contrôle de bannière a échoué ! Les causes courantes de ceci incluent: Entrer dans la ville, trop loin de la bannière, ou voler."
 msg_war_siege_zone_milk_bucket_forbidden_while_attempting_banner_control: "Vous ne pouvez pas utiliser cet item pendant une session de contrôle de bannière."
 
 #Town Info Siege Section
@@ -319,3 +318,5 @@ msg_siege_war_banner_control_session_paused: '&cYour banner control session is p
 
 #Added in 0.14
 msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below banner altitude in the timed point zone.'
+msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, entering the town, going too far from the banner, or flying.'
+msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, entering the town, going too far from the banner, going above the altitude of the banner, or flying.'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -316,3 +316,6 @@ msg_swa_set_siege_balance_success: '&bSuccessfully set siege balance to %d for %
 
 #Added in 0.13:
 msg_siege_war_banner_control_session_paused: '&cYour banner control session is paused because there are enemy soldiers near the banner. To complete your session, remove the enemy soldiers.'
+
+#Added in 0.14
+msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below the banner altitude in the timed point zone.'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -318,4 +318,4 @@ msg_swa_set_siege_balance_success: '&bSuccessfully set siege balance to %d for %
 msg_siege_war_banner_control_session_paused: '&cYour banner control session is paused because there are enemy soldiers near the banner. To complete your session, remove the enemy soldiers.'
 
 #Added in 0.14
-msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below the banner altitude in the timed point zone.'
+msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below banner altitude in the timed point zone.'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -318,5 +318,5 @@ msg_siege_war_banner_control_session_paused: '&cYour banner control session is p
 
 #Added in 0.14
 msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below banner altitude in the timed point zone.'
-msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, entering the town, going too far from the banner, or flying.'
-msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, entering the town, going too far from the banner, going above the altitude of the banner, or flying.'
+msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going into the town, or flying.'
+msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going above the altitude of the banner, going into the town, or flying.'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -319,4 +319,4 @@ msg_siege_war_banner_control_session_paused: '&cYour banner control session is p
 #Added in 0.14
 msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below banner altitude in the timed point zone.'
 msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going into the town, or flying.'
-msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going above the altitude of the banner, going into the town, or flying.'
+msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going below the altitude of the banner, going into the town, or flying.'


### PR DESCRIPTION
#### Description: 
- "Trap-Warfare" is the tactic of fighting battles by digging huge pits/traps (sometimes right under the siege banner), and trying to get enemy soldiers to fall into them to immediately kill or injure them.
- The tactic is generally hated by most players, who would prefer more face to face (or even arrow to face) combat when the action starts.
- This PR resolves the issue by blocking siege participants from altering any terrain in the timed-point-zone which is below the altitude of the siege-banner.
- Thus occasional fun trapping can be done in the wider siegezone area, but this mitigation should greatly reduce the tactic as an influence in in battles.
- Note: This mitigation feature, when enabled, also includes the requirement that players cannot get BC if below the banner altitude (otherwise attackers could do an exploit by making a walled off cave, having some soldiers go into it, then then planting the banner over the cave, thus making those attackers invulnerable).

____
#### New Nodes/Commands/ConfigOptions: 
- war.siege.switches.trap_warfare_mitigation_enabled  (enabled by default)

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
