### PR TITLE
Fix bug with explosions bypassing trap mitigation

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
@@ -71,28 +71,7 @@ public class SiegeWarActionListener implements Listener {
 			event.setCancelled(true);
 		}
 	}
-	
-	/*
-	 * SW will prevent an explosion from altering an area around a banner.
-	 */
-	@EventHandler
-	public void onBlockExplode(TownyExplodingBlocksEvent event) {
-		if (SiegeWarSettings.getWarSiegeEnabled()) {
-			List<Block> blockList = event.getTownyFilteredBlockList();
-			List<Block> filteredList = new ArrayList<>();
-			for (Block block : blockList) {
-				if (
-					(!SiegeWarSettings.isTrapWarfareMitigationEnabled() || !SiegeWarDistanceUtil.isLocationInActiveTimedPointZoneAndBelowSiegeBannerAltitude(block.getLocation()))
-					&&
-					!SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(block)
-				) {
-					filteredList.add(block);
-				}
-			}
-			event.setBlockList(filteredList);
-		}
-	}
-	
+
 	/*
 	 * SW can affect the emptying of buckets, which could affect a banner.
 	 */

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -125,14 +125,14 @@ public class SiegeWarTownyEventListener implements Listener {
     }
 
     /**
-     * Do not explode the siege banner or or supporting block
+     * Do not explode the siege banner or its supporting block
      *
      * If trap mitigation is active,
-     *  do not explode blocks below the siege banner
+     *  do not explode blocks below the siege banner altitude
      *
      * If the cannons integration is active,
-     *  override Towny's explode protection,
-     *  for blocks within a town which has an active cannon session.
+     *  override any Towny protections of blocks which are within towns with active cannon sessions,
+     *  and allow their explosion.
      *
      * @param event the TownyExplodingBlocksEvent event
      */

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -6,6 +6,7 @@ import com.gmail.goosius.siegewar.hud.SiegeHUDManager;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.settings.Translation;
 import com.gmail.goosius.siegewar.tasks.SiegeWarTimerTaskController;
+import com.gmail.goosius.siegewar.utils.SiegeWarBlockUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
 import com.palmergames.bukkit.towny.TownyAPI;
@@ -124,28 +125,39 @@ public class SiegeWarTownyEventListener implements Listener {
     }
 
     /**
-     * If the cannons integration is active,
-     * SiegeWar will override Towny's explode protection,
-     *  for blocks within a town which has an active cannon session.
+     * Do not explode the siege banner or or supporting block
      *
-     * The method works as follows:
-     * 1. Create a final explode list, and add the blocks towny has already allowed.
-     * 2. Cycle through the original unfiltered list of blocks which were set to explode.
-     * 3. If any block is in a town with an active cannon session,
-     *    add it to the final explode-allowed list (if it is not already there).
+     * If trap mitigation is active,
+     *  do not explode blocks below the siege banner
+     *
+     * If the cannons integration is active,
+     *  override Towny's explode protection,
+     *  for blocks within a town which has an active cannon session.
      *
      * @param event the TownyExplodingBlocksEvent event
      */
     @EventHandler(priority = EventPriority.HIGH)
     public void onBlockExploding(TownyExplodingBlocksEvent event) {
+        List<Block> finalExplodeList = new ArrayList<>();
+
+        //Do not add to final explode list: Blocks near banner or protected by trap mitigation
+        List<Block> townyExplodeList = event.getTownyFilteredBlockList();
+        if(townyExplodeList != null) {
+            for(Block block: townyExplodeList) {
+                if ((SiegeWarSettings.isTrapWarfareMitigationEnabled() && SiegeWarDistanceUtil.isLocationInActiveTimedPointZoneAndBelowSiegeBannerAltitude(block.getLocation()))
+                    ||
+                    SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(block)) {
+                    //Do not add block to final explode list
+                } else {
+                    //Add to final explode list
+                    finalExplodeList.add(block);
+                }
+            }
+        }
+
+        //Add to final explode list: town blocks if there is a cannon session in progress
         if(SiegeWarSettings.isCannonsIntegrationEnabled() && SiegeWar.getCannonsPluginDetected()) {
             List<Block> vanillaExplodeList = event.getVanillaBlockList(); //original list of exploding blocks
-            List<Block> townyFilteredExplodeList = event.getTownyFilteredBlockList(); //the list of exploding blocks Towny has allowed
-            List<Block> finalExplodeList = new ArrayList<>();
-            if(townyFilteredExplodeList != null)
-                finalExplodeList.addAll(townyFilteredExplodeList);
-
-            //Override Towny's protections if there is a cannon session in progress
             Town town;
             for (Block block : vanillaExplodeList) {
                 if(!finalExplodeList.contains(block)) {


### PR DESCRIPTION
#### Description: 
- With current code, explosions sometimes seem to bypass trap mitigation.
- I had tested this before and it seemed ok, so its possible this is an intermittent issues caused by siegewar having 2 listener methods for the same event.
- In this PR I fix the issue by combining all the required checks into just 1 listener method.
- *Note*: This issue is probably not urgent to hotfix or anything, because there is an easy option to ban TNT in siegezones, which most servers are probably already doing anyway. The ones mainly affected will be those with the optional cannons integration, but this integration is likely not widespread yet seeing as it was only fully released today with 0.3.0.
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
