### PR TITLE
Patch remaining methods to break siege banners

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
@@ -1,12 +1,8 @@
 package com.gmail.goosius.siegewar.listeners;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.ChatColor;
-import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -18,7 +14,6 @@ import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.palmergames.bukkit.towny.event.actions.TownyBuildEvent;
 import com.palmergames.bukkit.towny.event.actions.TownyBurnEvent;
 import com.palmergames.bukkit.towny.event.actions.TownyDestroyEvent;
-import com.palmergames.bukkit.towny.event.actions.TownyExplodingBlocksEvent;
 import com.gmail.goosius.siegewar.settings.Translation;
 
 /**

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -9,6 +9,7 @@ import com.gmail.goosius.siegewar.hud.SiegeHUDManager;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.CosmeticUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarBlockUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarScoringUtil;
 import com.palmergames.bukkit.towny.TownyUniverse;
@@ -18,7 +19,11 @@ import com.palmergames.bukkit.towny.permissions.TownyPermissionSource;
 import com.gmail.goosius.siegewar.settings.Translation;
 
 import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Banner;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
@@ -136,6 +141,8 @@ public class PlayerDeath {
 				//Award penalty points w/ notification if siege is in progress
 				if(confirmedCandidateSiege.getStatus() == SiegeStatus.IN_PROGRESS) {
 					if (SiegeWarSettings.getWarSiegeDeathSpawnFireworkEnabled()) {
+						if (isBannerMissing(confirmedCandidateSiege.getFlagLocation()))
+							replaceMissingBanner(confirmedCandidateSiege.getFlagLocation());
 						Color bannerColor = ((Banner) confirmedCandidateSiege.getFlagLocation().getBlock().getState()).getBaseColor().getColor();
 						CosmeticUtil.spawnFirework(deadPlayer.getLocation().add(0, 2, 0), Color.RED, bannerColor, true);
 					}
@@ -214,5 +221,16 @@ public class PlayerDeath {
 			playerDeathEvent.setKeepInventory(true);
 			playerDeathEvent.getDrops().clear();
 		}
+	}
+
+	private static boolean isBannerMissing(Location location) {
+		return !Tag.BANNERS.isTagged(location.getBlock().getType());
+	}
+
+	private static void replaceMissingBanner(Location location) {
+		if (SiegeWarBlockUtil.isSupportBlockUnstable(location.getBlock()))
+			location.getBlock().getRelative(BlockFace.DOWN).setType(Material.STONE);
+		
+		location.getBlock().setType(Material.BLACK_BANNER);
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBlockUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBlockUtil.java
@@ -9,6 +9,8 @@ import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Banner;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -145,44 +147,28 @@ public class SiegeWarBlockUtil {
 	 * @return true if support block is unstable
 	 */
 	public static boolean isSupportBlockUnstable(Block block) {
-		Block blockBelowBanner = block.getRelative(BlockFace.DOWN);
-		switch(blockBelowBanner.getType()){
+		Material blockBelowBanner = block.getRelative(BlockFace.DOWN).getType();
+		if (Tag.BANNERS.isTagged(blockBelowBanner) || Tag.SIGNS.isTagged(blockBelowBanner) || Tag.WALL_SIGNS.isTagged(blockBelowBanner)
+			|| Tag.LOGS.isTagged(blockBelowBanner) || Tag.LEAVES.isTagged(blockBelowBanner) || Tag.ANVIL.isTagged(blockBelowBanner)
+			|| Tag.DOORS.isTagged(blockBelowBanner))
+			return true;
+		switch(blockBelowBanner) {
 			case AIR:
 			case CAVE_AIR:
 			case VOID_AIR:
 			case GRAVEL:
 			case SAND:
-			case SOUL_SAND:
 			case RED_SAND:
-			case ACACIA_LOG:
-			case BIRCH_LOG:
-			case DARK_OAK_LOG:
-			case JUNGLE_LOG:
-			case OAK_LOG:
-			case SPRUCE_LOG:
-			case CRIMSON_STEM:
-			case WARPED_STEM:
-			case CRIMSON_HYPHAE:
-			case WARPED_HYPHAE:
-			case STRIPPED_ACACIA_LOG:
-			case STRIPPED_BIRCH_LOG:
-			case STRIPPED_DARK_OAK_LOG:
-			case STRIPPED_JUNGLE_LOG:
-			case STRIPPED_OAK_LOG:
-			case STRIPPED_SPRUCE_LOG:
-			case STRIPPED_CRIMSON_STEM:
-			case STRIPPED_WARPED_STEM:
-			case STRIPPED_CRIMSON_HYPHAE:
-			case STRIPPED_WARPED_HYPHAE:
 			case CACTUS:
-			case OAK_LEAVES:
-			case SPRUCE_LEAVES:
-			case BIRCH_LEAVES:
-			case ACACIA_LEAVES:
-			case DARK_OAK_LEAVES:
-			case JUNGLE_LEAVES:
 			case NETHER_WART_BLOCK:
 			case WARPED_WART_BLOCK:
+			case LANTERN:
+			case SOUL_LANTERN:
+			case MUSHROOM_STEM:
+			case RED_MUSHROOM_BLOCK:
+			case BROWN_MUSHROOM_BLOCK:
+			case BAMBOO:
+			case TURTLE_EGG:
 				return true;
 			default:
 				return false;


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR fixes a few of the remaining ways there were to break siege banners, and if a banner is broken, it will get replaced by a new one if the death firework effect is enabled (to prevent error spam in console when a player dies).
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
