### PR TITLE
Add Battle Sessions defensive code

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
@@ -5,6 +5,7 @@ import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
+import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.timeractions.AttackerWin;
@@ -92,8 +93,10 @@ public class SiegeWarTimerTaskController {
 	 * Evaluate banner control for all sieges
 	 */
 	public static void evaluateBannerControl() {
-		for (Siege siege : SiegeController.getSieges()) {
-			SiegeWarBannerControlUtil.evaluateBannerControl(siege);
+		if(BattleSession.getBattleSession().isActive()) {
+			for (Siege siege : SiegeController.getSieges()) {
+				SiegeWarBannerControlUtil.evaluateBannerControl(siege);
+			}
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -92,7 +92,7 @@ public class SiegeWarBattleSessionUtil {
 						try {
 							System.err.println("Problem ending battle for siege: " + siege.getName());
 						} catch (Throwable t2) {
-							System.err.println("Problem ending battle session for siege: (could not read siege name)");
+							System.err.println("Problem ending battle for siege: (could not read siege name)");
 						}
 						t.printStackTrace();
 					}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -37,61 +37,69 @@ public class SiegeWarBattleSessionUtil {
 				//Finish battle session
 				battleSession.setActive(false);
 
+				//Schedule next session
+				scheduleNextBattleSession();
+
 				//Gather the results of all active battles, then end them
 				Map<Siege, Integer> battleResults = new HashMap<>();
-				for(Siege siege: SiegeController.getSieges()) {
-
-					if (siege.getStatus() == SiegeStatus.IN_PROGRESS
-						&& (siege.getAttackerBattlePoints() > 0 || siege.getDefenderBattlePoints() > 0)) {
-						//Calculate result
-						int battlePointsOfWinner;
-						if (siege.getAttackerBattlePoints() > siege.getDefenderBattlePoints()) {
-							battlePointsOfWinner = siege.getAttackerBattlePoints();
-						} else if (siege.getAttackerBattlePoints() < siege.getDefenderBattlePoints()) {
-							battlePointsOfWinner = -siege.getDefenderBattlePoints();
-						} else {
-							battlePointsOfWinner = 0;
-						}
-
-						//Apply the battle points of the winner to the siege balance
-						siege.adjustSiegeBalance(battlePointsOfWinner);
-
-						//Propagate attacker battle contributions to siege history
-						siege.propagateAttackerBattleContributorsToAttackerSiegeContributors();
-
-						//Prepare result for messaging
-						battleResults.put(siege, battlePointsOfWinner);
-
-						//Remove glowing effects from players in bc sessions
-						for(Player player: siege.getBannerControlSessions().keySet()) {
-							if(player.isOnline() && player.hasPotionEffect(PotionEffectType.GLOWING)) {
-								Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
-									@Override
-									public void run() {
-										player.removePotionEffect(PotionEffectType.GLOWING);
-									}
-								});
+				for (Siege siege : SiegeController.getSieges()) {
+					try {
+						if (siege.getStatus() == SiegeStatus.IN_PROGRESS
+								&& (siege.getAttackerBattlePoints() > 0 || siege.getDefenderBattlePoints() > 0)) {
+							//Calculate result
+							int battlePointsOfWinner;
+							if (siege.getAttackerBattlePoints() > siege.getDefenderBattlePoints()) {
+								battlePointsOfWinner = siege.getAttackerBattlePoints();
+							} else if (siege.getAttackerBattlePoints() < siege.getDefenderBattlePoints()) {
+								battlePointsOfWinner = -siege.getDefenderBattlePoints();
+							} else {
+								battlePointsOfWinner = 0;
 							}
+
+							//Apply the battle points of the winner to the siege balance
+							siege.adjustSiegeBalance(battlePointsOfWinner);
+
+							//Propagate attacker battle contributions to siege history
+							siege.propagateAttackerBattleContributorsToAttackerSiegeContributors();
+
+							//Prepare result for messaging
+							battleResults.put(siege, battlePointsOfWinner);
+
+							//Remove glowing effects from players in bc sessions
+							for (Player player : siege.getBannerControlSessions().keySet()) {
+								if (player.isOnline() && player.hasPotionEffect(PotionEffectType.GLOWING)) {
+									Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
+										@Override
+										public void run() {
+											player.removePotionEffect(PotionEffectType.GLOWING);
+										}
+									});
+								}
+							}
+
+							//Clear battle related stats from the siege
+							siege.setBannerControllingSide(SiegeSide.NOBODY);
+							siege.clearBannerControllingResidents();
+							siege.clearBannerControlSessions();
+							siege.setAttackerBattlePoints(0);
+							siege.setDefenderBattlePoints(0);
+							siege.clearAttackerBattleContributors();
+
+							//Save siege
+							SiegeController.saveSiege(siege);
 						}
-
-						//Clear battle related stats from the siege
-						siege.setBannerControllingSide(SiegeSide.NOBODY);
-						siege.clearBannerControllingResidents();
-						siege.clearBannerControlSessions();
-						siege.setAttackerBattlePoints(0);
-						siege.setDefenderBattlePoints(0);
-						siege.clearAttackerBattleContributors();
-
-						//Save siege
-						SiegeController.saveSiege(siege);
+					} catch (Throwable t) {
+						try {
+							System.err.println("Problem ending battle for siege: " + siege.getName());
+						} catch (Throwable t2) {
+							System.err.println("Problem ending battle session for siege: (could not read siege name)");
+						}
+						t.printStackTrace();
 					}
 				}
 
 				//Send message
 				sendBattleSessionEndedMessage(battleResults);
-
-				//Schedule next session
-				scheduleNextBattleSession();
 			}
 
 		} else {


### PR DESCRIPTION
#### Description: 
- Today on a public server (not mine) I noticed that a battle session seemed to end in a messy way
  - After the session should have ended, the siege side was listed as defender, and points kept being gained.
  - But the next session was scheduled
- I investigated and am not sure precisely what happened
- However I did notice a general lack of defensive code around ending battles
- For example, the banner control code has much better defensive code
- In this PR I add more defensive control about battle sessions:
  - Now it is impossible to get points in the session has ended
  - Now there is a a try-catch around the complex part of the end-battles code

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 
  -  The changes are more trivial than what git shows. In SiegeWarBattleSessionUtil, the only two changes were 1. moving the scheduling line up and 2. wrapping an operation in a try catch.
 
By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
