### PR TITLE
Update peacefulness switch value

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -543,7 +543,7 @@ public enum ConfigNodes {
 			"#"),
 	PEACEFUL_TOWNS_CONFIRMATION_REQUIREMENT_DAYS(
 			"peaceful_towns.confirmation_requirement_days",
-			"5",
+			"10",
 			"",
 			"# This value determines how long it takes to confirm a town peacefulness status change.",
 			"# It is recommended to be high, for use by genuinely peaceful towns, not just for war cost avoidance."),


### PR DESCRIPTION
#### Description: 
- Now that occupation is much harder to get out of (requires a revolt siege instead of an immediate leave command), this opens the possibility that switching to peaceful and back could be used as a way to escape occupation.
- In this PR I resolve the issue by increasing the default peaceful switch time from 5 days to 10.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
