### PR TITLE
Misc small fixes and improvements

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
@@ -22,6 +22,8 @@ public class TownMetaDataController {
 	private static LongDataField revoltImmunityEndTime = new LongDataField("siegewar_revoltImmunityEndTime", 0l);
 	private static LongDataField siegeImmunityEndTime = new LongDataField("siegewar_siegeImmunityEndTime", 0l);
 	private static StringDataField occupyingNationUUID = new StringDataField("siegewar_occupyingNationUUID", "");
+	//The nation who was the occupier prior to peacefulness confirmation
+	private static StringDataField prePeacefulOccupierUUID = new StringDataField("siegewar_prePeacefulOccupierUUID", "");
 
 	public TownMetaDataController(SiegeWar plugin) {
 		this.plugin = plugin;
@@ -129,4 +131,25 @@ public class TownMetaDataController {
 			town.removeMetaData(sdf);
 	}
 
+	@Nullable
+	public static String getPrePeacefulOccupierUUID(Town town) {
+		StringDataField sdf = (StringDataField) prePeacefulOccupierUUID.clone();
+		if (town.hasMeta(sdf.getKey()))
+			return MetaDataUtil.getString(town, sdf);
+		return null;
+	}
+
+	public static void setPrePeacefulOccupierUUID(Town town, String uuid) {
+		StringDataField sdf = (StringDataField) prePeacefulOccupierUUID.clone();
+		if (town.hasMeta(sdf.getKey()))
+			MetaDataUtil.setString(town, sdf, uuid);
+		else
+			town.addMetaData(new StringDataField("siegewar_prePeacefulOccupierUUID", uuid));
+	}
+
+	public static void removePrePeacefulOccupierUUID(Town town) {
+		StringDataField sdf = (StringDataField) prePeacefulOccupierUUID.clone();
+		if (town.hasMeta(sdf.getKey()))
+			town.removeMetaData(sdf);
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
@@ -81,10 +81,8 @@ public class SiegeWarTimerTaskController {
 	 * Evaluate banner control for all sieges
 	 */
 	public static void evaluateBannerControl() {
-		if(BattleSession.getBattleSession().isActive()) {
-			for (Siege siege : SiegeController.getSieges()) {
-				SiegeWarBannerControlUtil.evaluateBannerControl(siege);
-			}
+		for (Siege siege : SiegeController.getSieges()) {
+			SiegeWarBannerControlUtil.evaluateBannerControl(siege);
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerTimedWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerTimedWin.java
@@ -23,6 +23,11 @@ public class AttackerTimedWin {
         String message = "";
         switch (siege.getSiegeType()) {
             case CONQUEST:
+                message = Translation.of(key,
+                        siege.getTown().getName(),
+                        siege.getAttacker().getName(),
+                        siege.getDefendingNationIfPossibleElseTown().getName());
+                break;
             case LIBERATION:
                 message = Translation.of(key,
                         siege.getTown().getName(),

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -62,16 +62,16 @@ public class SiegeWarBannerControlUtil {
 				resident = universe.getResident(player.getUniqueId());
 	            if (resident == null)
 	            	throw new TownyException(Translation.of("msg_err_not_registered_1", player.getName()));
-	            
-				if(!doesPlayerMeetBasicSessionRequirements(siege, player, resident))
-					continue;
 
 				if(!BattleSession.getBattleSession().isActive()) {
 					String message = Translation.of("msg_war_siege_battle_session_break_cannot_get_banner_control",
-													SiegeWarBattleSessionUtil.getFormattedTimeUntilNextBattleSessionStarts());
+							SiegeWarBattleSessionUtil.getFormattedTimeUntilNextBattleSessionStarts());
 					Messaging.sendErrorMsg(player, message);
 					continue;
 				}
+
+				if(!doesPlayerMeetBasicSessionRequirements(siege, player, resident))
+					continue;
 
 				if(siege.getBannerControlSessions().containsKey(player))
 					continue; // Player already has a control session
@@ -182,6 +182,9 @@ public class SiegeWarBannerControlUtil {
 	}
 
 	private static void evaluateExistingBannerControlSessions(Siege siege) {
+		if(!BattleSession.getBattleSession().isActive())
+			return;
+
 		BANNER_CONTROL_SESSIONS_LOOP:
 		for(BannerControlSession bannerControlSession: siege.getBannerControlSessions().values()) {
 			try {
@@ -291,6 +294,9 @@ public class SiegeWarBannerControlUtil {
 	}
 
 	private static void evaluateBannerControlEffects(Siege siege) {
+		if(!BattleSession.getBattleSession().isActive())
+			return;
+
 		//Evaluate the siege zone only if the siege is 'in progress'.
 		if(siege.getStatus() != SiegeStatus.IN_PROGRESS)
 			return;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -65,7 +65,7 @@ public class SiegeWarBannerControlUtil {
 
 				if(!BattleSession.getBattleSession().isActive()) {
 					String message = Translation.of("msg_war_siege_battle_session_break_cannot_get_banner_control",
-							SiegeWarBattleSessionUtil.getFormattedTimeUntilNextBattleSessionStarts());
+													SiegeWarBattleSessionUtil.getFormattedTimeUntilNextBattleSessionStarts());
 					Messaging.sendErrorMsg(player, message);
 					continue;
 				}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -90,9 +90,9 @@ public class SiegeWarBattleSessionUtil {
 						}
 					} catch (Throwable t) {
 						try {
-							System.err.println("Problem ending battle for siege: " + siege.getName());
+							System.err.println("Problem ending battle for siege: " + siege.getTown().getName());
 						} catch (Throwable t2) {
-							System.err.println("Problem ending battle for siege: (could not read siege name)");
+							System.err.println("Problem ending battle for siege: (could not read town name)");
 						}
 						t.printStackTrace();
 					}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -23,7 +23,6 @@ import com.palmergames.util.TimeTools;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -23,11 +23,13 @@ import com.palmergames.util.TimeTools;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.UUID;
 
 public class TownPeacefulnessUtil {
 
@@ -71,8 +73,33 @@ public class TownPeacefulnessUtil {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			if (town.isNeutral()) {
 				message = Translation.of("msg_town_became_peaceful", town.getFormattedName());
+
+				//If town is occupied, record the occupier
+				if(TownOccupationController.isTownOccupied(town)) {
+					TownMetaDataController.setPrePeacefulOccupierUUID(town, TownOccupationController.getTownOccupier(town).getUUID().toString());
+				}
 			} else {
 				message = Translation.of("msg_town_became_non_peaceful", town.getFormattedName());
+
+				/*
+				 * If the town was occupied before turning peaceful,
+				 * return it to the previous occupier.
+				 * If the previous occupier is now the town's home nation, do not re-occupy.
+				 */
+				try {
+					String prePeacefulOccupierUUID = TownMetaDataController.getPrePeacefulOccupierUUID(town);
+					if(prePeacefulOccupierUUID != null) {
+						Nation prePeacefulOccupierNation = TownyUniverse.getInstance().getNation(UUID.fromString(prePeacefulOccupierUUID));
+							if (!(town.hasNation() && town.getNation() == prePeacefulOccupierNation)) {
+								TownOccupationController.setTownOccupation(town, prePeacefulOccupierNation);
+								TownMetaDataController.removePrePeacefulOccupierUUID(town);
+								message += Translation.of("msg_town_returned_to_pre_peaceful_occupier",prePeacefulOccupierNation.getName());
+						}
+					}
+				} catch (Throwable t) {
+					System.out.println("Issue with re-assigning pre-peaceful occupier for town " + town.getName());
+					t.printStackTrace();
+				}
 			}
 		} else {
 			if (town.isNeutral()) {

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -388,6 +388,8 @@ nation_help_14 : 'Release the given town from occupation.'
 # Peaceful towns
 msg_town_became_peaceful: '&b%s has been confirmed as Peaceful. The town is now immune to siege attacks. The town may get automatically occupied by a nation with a strong presence in the local area. (see user-guide for more details). Residents cannot enter siege-zones or gain nation-military ranks.'
 msg_town_became_non_peaceful: '&b%s has been confirmed as Not-Peaceful. The town is no longer immune to siege attacks. The town can no longer get automatically occupied. Residents can enter siege-zones and gain nation-military ranks.'
+msg_town_returned_to_pre_peaceful_occupier: " The town has been returned to the occupier it had before turning peaceful - %s."
+
 msg_peaceful_town_total_switches: '&b%d peaceful town%s %s been peacefully occupied, or released from occupation.'
 
 msg_your_town_peacefully_occupied: "&bYour town has been peacefully occupied by %s."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -335,9 +335,9 @@ status_town_siege_status_invaded: '   &2Town Invaded: %s'
 
 # Siege statuses
 siege_status_attacker_abandon: "Abandon de l'attaquant"
-siege_status_defender_surrender: "Capitulation du d<C3><A9>fenseur"
+siege_status_defender_surrender: "Capitulation du défenseur"
 siege_status_pending_attacker_abandon: "En attente de l'abandon de l'attaquant"
-siege_status_pending_defender_surrender: "En attente de la capitulation du d<C3><A9>fenseur"
+siege_status_pending_defender_surrender: "En attente de la capitulation du défenseur"
 
 # Nation screen
 status_nation_occupied_home_towns: '&2Occupied Home Towns &a[%s]&2: &f'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -421,3 +421,6 @@ msg_swa_town_occupation_change_success: '&bTown occupier changed to %s for %s.'
 
 
 
+
+
+

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -285,6 +285,7 @@ siege_type_revolt: 'Revolt'
 siege_type_suppression: 'Suppression'
 
 # Dynmap
+
 dynmap_siege_title: 'Siege: %s vs %s'
 dynmap_siege_type: 'Type: %s'
 dynmap_siege_town: 'Town: %s'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -285,7 +285,6 @@ siege_type_revolt: 'Revolt'
 siege_type_suppression: 'Suppression'
 
 # Dynmap
-
 dynmap_siege_title: 'Siege: %s vs %s'
 dynmap_siege_type: 'Type: %s'
 dynmap_siege_town: 'Town: %s'
@@ -335,9 +334,9 @@ status_town_siege_status_invaded: '   &2Town Invaded: %s'
 
 # Siege statuses
 siege_status_attacker_abandon: "Abandon de l'attaquant"
-siege_status_defender_surrender: "Capitulation du défenseur"
+siege_status_defender_surrender: "Capitulation du d<C3><A9>fenseur"
 siege_status_pending_attacker_abandon: "En attente de l'abandon de l'attaquant"
-siege_status_pending_defender_surrender: "En attente de la capitulation du défenseur"
+siege_status_pending_defender_surrender: "En attente de la capitulation du d<C3><A9>fenseur"
 
 # Nation screen
 status_nation_occupied_home_towns: '&2Occupied Home Towns &a[%s]&2: &f'
@@ -399,6 +398,8 @@ nation_help_14 : 'Release the given town from occupation.'
 # Peaceful towns
 msg_town_became_peaceful: '&b%s has been confirmed as Peaceful. The town is now immune to siege attacks. The town may get automatically occupied by a nation with a strong presence in the local area. (see user-guide for more details). Residents cannot enter siege-zones or gain nation-military ranks.'
 msg_town_became_non_peaceful: '&b%s has been confirmed as Not-Peaceful. The town is no longer immune to siege attacks. The town can no longer get automatically occupied. Residents can enter siege-zones and gain nation-military ranks.'
+msg_town_returned_to_pre_peaceful_occupier: " The town has been returned to the occupier it had before turning peaceful - %s."
+
 msg_peaceful_town_total_switches: '&b%d peaceful town%s %s been peacefully occupied, or released from occupation.'
 
 msg_your_town_peacefully_occupied: "&bYour town has been peacefully occupied by %s."
@@ -416,9 +417,6 @@ msg_err_swa_home_nation_cannot_be_occupier: '&cYou cannot set the towns home nat
 msg_swa_set_invade_success: '&bSet invaded to %s for %s.'
 msg_swa_town_occupation_removal_success: '&bTown occupier removed for %s.'
 msg_swa_town_occupation_change_success: '&bTown occupier changed to %s for %s.'
-
-
-
 
 
 


### PR DESCRIPTION
#### Description: 
- Fixed issue where towns might use peacefulness switching to escape occupation - fixed by recording the pre-peaceful occupier and returning them to it if they switch back to non-peaceful.
- Fix for battle session not started yet error message not showing (previous pr prevented this)
- Improved timed attacker win message
- Bug fix for merge issue (siege.getName() compilation problem)

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
