### PR TITLE
message spam fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>0.3.2</version>
+  <version>0.3.3</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -63,15 +63,15 @@ public class SiegeWarBannerControlUtil {
 	            if (resident == null)
 	            	throw new TownyException(Translation.of("msg_err_not_registered_1", player.getName()));
 
+				if(!doesPlayerMeetBasicSessionRequirements(siege, player, resident))
+					continue;
+
 				if(!BattleSession.getBattleSession().isActive()) {
 					String message = Translation.of("msg_war_siege_battle_session_break_cannot_get_banner_control",
-													SiegeWarBattleSessionUtil.getFormattedTimeUntilNextBattleSessionStarts());
+							SiegeWarBattleSessionUtil.getFormattedTimeUntilNextBattleSessionStarts());
 					Messaging.sendErrorMsg(player, message);
 					continue;
 				}
-
-				if(!doesPlayerMeetBasicSessionRequirements(siege, player, resident))
-					continue;
 
 				if(siege.getBannerControlSessions().containsKey(player))
 					continue; // Player already has a control session

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -68,7 +68,7 @@ public class SiegeWarBannerControlUtil {
 
 				if(!BattleSession.getBattleSession().isActive()) {
 					String message = Translation.of("msg_war_siege_battle_session_break_cannot_get_banner_control",
-							SiegeWarBattleSessionUtil.getFormattedTimeUntilNextBattleSessionStarts());
+													SiegeWarBattleSessionUtil.getFormattedTimeUntilNextBattleSessionStarts());
 					Messaging.sendErrorMsg(player, message);
 					continue;
 				}


### PR DESCRIPTION
#### Description: 
- With current code, during the 10 minute battle session break, all players gets spammed with a warning every 20 seconds.
- This PR fixes the issue

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
