### PR TITLE
Fixes to perms issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>0.3.3</version>
+  <version>0.3.4</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -100,12 +100,15 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 	}
 
 	private void parseSiegeWarCommand(Player player, String[] args) {
-		
-		if (!player.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_COMMAND_SIEGEWAR.getNode(args[0]))) {
-			Messaging.sendErrorMsg(player, Translation.of("msg_err_command_disable"));
-			return;
+
+		//This permission check handles all the perms checks except for nation
+		if(!args[0].equalsIgnoreCase("nation")) {
+			if (!player.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_COMMAND_SIEGEWAR.getNode(args[0]))) {
+				Messaging.sendErrorMsg(player, Translation.of("msg_err_command_disable"));
+				return;
+			}
 		}
-			
+
 		switch (args[0]) {
 		case "collect":
 			parseSiegeWarCollectCommand(player);

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -205,7 +205,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 			player.sendMessage(Translation.of("msg_err_command_disable"));
 			return;
 		}
-
+			
 		switch (args[0]) {
 			case "paysoldiers":
 				try {

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -108,7 +108,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 				return;
 			}
 		}
-
+			
 		switch (args[0]) {
 		case "collect":
 			parseSiegeWarCollectCommand(player);
@@ -205,7 +205,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 			player.sendMessage(Translation.of("msg_err_command_disable"));
 			return;
 		}
-			
+
 		switch (args[0]) {
 			case "paysoldiers":
 				try {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -52,6 +52,7 @@ permissions:
         default: false
         children:
             siegewar.command.siegewar.nation.paysoldiers: true
+            siegewar.command.siegewar.nation.release: true
 
     siegewar.nation.siege.*:
         description: User holds all of the siegewar nation nodes.


### PR DESCRIPTION
#### Description: 
- With current code, `/sw nation ... ` commands only work for admins (not kings)
- This PR fixes the issue:
   - In SiegeWarCommand class, I update the logic to allow nation commands to skip a  perms check which does not relate to them (and was causing the fail).
   - In plugin.yml, I added a node for the new `/sw nation release`  inside the generic nation command node

____
#### New Nodes/Commands/ConfigOptions: 
- Added a node for `sw release` to the plugin yml so that kings can run it

____
#### Relevant Issue ticket:
N/A


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
