### PR TITLE
Guardian Town Fixes

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -267,7 +267,11 @@ public class TownPeacefulnessUtil {
 				topGuardianTown = guardianTown;
 			}
 		}
-		return topGuardianTown.getNation();
+		if(TownOccupationController.isTownOccupied(topGuardianTown)) {
+			return TownOccupationController.getTownOccupier(topGuardianTown);
+		} else {
+			return topGuardianTown.getNation();
+		}
 	}
 
 	private static boolean ensureTownIsPeacefullyUnoccupied(Town peacefulTown) throws NotRegisteredException {
@@ -334,7 +338,6 @@ public class TownPeacefulnessUtil {
 				if(!candidateTown.isNeutral()
 					&& candidateTown.hasNation()
 					&& candidateTown.isOpen()
-					&& !TownOccupationController.isTownOccupied(candidateTown)
 					&& !SiegeController.hasActiveSiege(candidateTown)
 					&& candidateTown.getTownBlocks().size() >= guardianTownPlotsRequirement
 					&& SiegeWarDistanceUtil.areTownsClose(peacefulTown, candidateTown, guardianTownMaxDistanceRequirementTownblocks)) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -336,8 +336,7 @@ public class TownPeacefulnessUtil {
 			List<Town> candidateTowns = new ArrayList<>(townyUniverse.getDataSource().getTowns());
 			for(Town candidateTown: candidateTowns) {
 				if(!candidateTown.isNeutral()
-					&& candidateTown.hasNation()
-					&& candidateTown.isOpen()
+					&& (candidateTown.hasNation() || TownOccupationController.isTownOccupied(candidateTown))
 					&& !SiegeController.hasActiveSiege(candidateTown)
 					&& candidateTown.getTownBlocks().size() >= guardianTownPlotsRequirement
 					&& SiegeWarDistanceUtil.areTownsClose(peacefulTown, candidateTown, guardianTownMaxDistanceRequirementTownblocks)) {


### PR DESCRIPTION
#### Description: 
2 Fixes:
- 1.
   - In the move to 0.3.1, it looks like guardian towns accidentally lost the ability to operate if they are occupied.
   - The ability is important, because it allows a conquering nation to, naturally, pull in peaceful towns if it captures their guardian town.
   - This PR fixes the issue.
- 2.
   - An issue existed even back in 0.3.0 where a guardian town, once captured, could toggle off its "open" status, which would deny its guarded peaceful towns to the occupying nation
   - The open requirement is no longer needed, as there is now no downside which needs optional avoidance by the occupier, in terms of occupied towns getting into its nation chat.
   - This PR fixes the issues by removing the 'open town' requirement
  
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
