### PR TITLE
Allegiance logic fix

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
@@ -52,16 +52,23 @@ public class SiegeWarAllegianceUtil {
     }
 
     private static boolean isNationSoldierOrAlliedSoldier(Player player, Town residentTown, Government governmentToCheck) throws NotRegisteredException {
-        if (residentTown.hasNation() && governmentToCheck instanceof Nation) {
+        if(!residentTown.hasNation())
+            return false;
 
-            if(!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS.getNode()))
-                return false;
+        if(!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS.getNode()))
+            return false;
 
+        if(governmentToCheck instanceof Nation) {
+            //The government-to-check is a nation
             return residentTown.getNation() == governmentToCheck
                     || residentTown.getNation().hasMutualAlly((Nation) governmentToCheck);
+        } else if (((Town)governmentToCheck).hasNation()) {
+            //The government-to-check is a nation town
+            return residentTown.getNation() == ((Town)governmentToCheck).getNation()
+                    || residentTown.getNation().hasMutualAlly(((Town)governmentToCheck).getNation());
         } else {
+            //The government-to-check is a non-nation town. Nation soldiers cannot contribute
             return false;
         }
     }
-
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
@@ -71,4 +71,5 @@ public class SiegeWarAllegianceUtil {
             return false;
         }
     }
+
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
@@ -13,31 +13,48 @@ public class SiegeWarNotificationUtil {
 
 		try {
 			//Build list of who to inform
+			Nation nation;
 			Set<Nation> nationsToInform = new HashSet<>();
 			Set<Town> townsToInform= new HashSet<>();
 
-			//attackers
+			//Attackers
 			if(siege.getAttacker() instanceof Nation) {
-				nationsToInform.add((Nation)siege.getAttacker());
-				nationsToInform.addAll(((Nation)siege.getAttacker()).getMutualAllies());
+				//Attacker is a nation
+				nation = (Nation)siege.getAttacker();
+				nationsToInform.add(nation);
+				nationsToInform.addAll(nation.getMutualAllies());
+			} else if (((Town)siege.getAttacker()).hasNation()) {
+				//Attacker is a nation town
+				nation = ((Town)siege.getAttacker()).getNation();
+				nationsToInform.add(nation);
+				nationsToInform.addAll(nation.getMutualAllies());
 			} else {
+				//Attacker is a non-nation town
 				townsToInform.add((Town)siege.getAttacker());
 			}
 
-			//defender
+			//Defenders
 			if(siege.getDefender() instanceof Nation) {
-				nationsToInform.add((Nation)siege.getDefender());
-				nationsToInform.addAll(((Nation)siege.getDefender()).getMutualAllies());
+				//Defender is a nation
+				nation = (Nation)siege.getDefender();
+				nationsToInform.add(nation);
+				nationsToInform.addAll(nation.getMutualAllies());
+			} else if (((Town)siege.getDefender()).hasNation()) {
+				//Defender is a nation town
+				nation = ((Town)siege.getDefender()).getNation();
+				nationsToInform.add(nation);
+				nationsToInform.addAll(nation.getMutualAllies());
 			} else {
+				//Defender is a non-nation town
 				townsToInform.add((Town)siege.getDefender());
 			}
 
 			//Inform required towns and nations
-			for(Nation nation: nationsToInform) {
-				TownyMessaging.sendPrefixedNationMessage(nation, message);
+			for(Nation nationToInform: nationsToInform) {
+				TownyMessaging.sendPrefixedNationMessage(nationToInform, message);
 			}
-			for(Town town: townsToInform) {
-				TownyMessaging.sendPrefixedTownMessage(town, message);
+			for(Town townToInform: townsToInform) {
+				TownyMessaging.sendPrefixedTownMessage(townToInform, message);
 			}
 
 		} catch (Exception e) {


### PR DESCRIPTION
#### Description: 
- With current code, soldiers who are not in the defending town are not counted as the defender.
- This PR fixes the bug, along with a less serious messaging bug

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
