### PR TITLE
Add feature to allow nations to choose which peaceful towns to occupy

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -325,6 +325,8 @@ public class TownPeacefulnessUtil {
 	}
 
 	public static Set<Town> getGuardianTowns(Town peacefulTown) {
+		Nation homeNationOfPeacefulTown;
+		Nation prevailingNationOfCandidateTown;
 		Set<Town> validGuardianTowns = new HashSet<>();
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 
@@ -340,7 +342,25 @@ public class TownPeacefulnessUtil {
 					&& !SiegeController.hasActiveSiege(candidateTown)
 					&& candidateTown.getTownBlocks().size() >= guardianTownPlotsRequirement
 					&& SiegeWarDistanceUtil.areTownsClose(peacefulTown, candidateTown, guardianTownMaxDistanceRequirementTownblocks)) {
-					validGuardianTowns.add(candidateTown);
+
+					/*
+					 * If the peaceful town has a nation,
+					 * then for the guardian town to qualify,
+					 * the prevailing nation of the guardian town must:
+					 * 1. Be the home nation of the peaceful town, or
+					 * 2. Consider the home nation of the peaceful town to be an enemy.
+					 */
+					if(peacefulTown.hasNation()) {
+						homeNationOfPeacefulTown = peacefulTown.getNation();
+						prevailingNationOfCandidateTown = candidateTown.hasNation() ? candidateTown.getNation() : TownOccupationController.getTownOccupier(candidateTown);
+
+						if (prevailingNationOfCandidateTown == homeNationOfPeacefulTown
+							|| prevailingNationOfCandidateTown.hasEnemy(homeNationOfPeacefulTown)) {
+							validGuardianTowns.add(candidateTown);
+						}
+					} else {
+						validGuardianTowns.add(candidateTown);
+					}
 				}
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
#### Description: 
- With current code, nations have poor control over which peaceful towns they "peacefully occupy"
- As of 0.3.1, this is no longer a problem of foreign towns entering the nation chat, but there is a problem, because "occupation", in both its effects and interpretation, can unnecessarily create tension between two otherwise friendly neighbouring nations, neither of which would generally like to occupy peaceful towns belonging to the other nation.
- In this PR, I fix the issue, by disqualifying guardian towns UNLESS the prevailing nation of the guardian town IS the home nation of the peaceful town OR its enemy.
- Thus, now nation's who are not enemies will not come to occupy each other's peaceful towns.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
