### PR TITLE
Remove redundant warning from config

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -644,11 +644,7 @@ public enum ConfigNodes {
 			"#    - While a cannon session is in effect, town cannons can be fired, and town explosion perm protections are forced off.",
 			"#    - The cannon session usually lasts just a few minutes (don't make it too long or the defender will often be too scared to fire).",
 			"#    - The max duration is configured below.",
-			"# ",
-			"# WARNING: ",
-			"# Do not enable this feature unless the following issue is resolved",
-			"# (Either in the Cannons plugin, Towny plugin, or your own custom branch of either) - ",
-			"# https://github.com/DerPavlov/Cannons/pull/37."),
+			"# "),
 	CANNONS_INTEGRATION_MAX_CANNON_SESSION_DURATION(
 			"cannons_integration.max_cannon_session_duration",
 			"9",


### PR DESCRIPTION
#### Description: 
- With current code there is a warning in the siegewar config relating to the Cannons plugin
- This warning is now redundant, as the Cannons team have fixed the problem
- In this PR, I remove the warning.
 
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
