### PR TITLE
Disable PVP-forcing for peaceful towns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>0.3.5</version>
+  <version>0.4.0</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -107,6 +107,16 @@ public class SiegeWarTownEventListener implements Listener {
 	@EventHandler
 	public void onTownTogglePVP(TownTogglePVPEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
+			//If the town is peaceful, it cannot toggle pvp
+			if (SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
+					&& !SiegeWarSettings.getWarCommonPeacefulTownsAllowedToTogglePVP()
+					&& event.getTown().isNeutral()
+					&& !event.getTown().isPVP()) {
+				event.setCancellationMsg(Translation.of("plugin_prefix") + Translation.of("msg_err_peaceful_town_pvp_forced_off"));
+				event.setCancelled(true);
+				return;
+			}
+
 			if (SiegeWarSettings.getWarSiegePvpAlwaysOnInBesiegedTowns()) {
 
 				//Is the town under siege
@@ -123,15 +133,6 @@ public class SiegeWarTownEventListener implements Listener {
 					event.setCancelled(true);
 					return;
 				}
-			}
-
-			if (SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
-					&& !SiegeWarSettings.getWarCommonPeacefulTownsAllowedToTogglePVP()
-					&& event.getTown().isNeutral()
-					&& !event.getTown().isPVP()) {
-				event.setCancellationMsg(Translation.of("plugin_prefix") + Translation.of("msg_err_peaceful_town_pvp_forced_off"));
-				event.setCancelled(true);
-				return;
 			}
 		}
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -106,17 +106,17 @@ public class SiegeWarTownEventListener implements Listener {
 	 */
 	@EventHandler
 	public void onTownTogglePVP(TownTogglePVPEvent event) {
-		if (SiegeWarSettings.getWarSiegeEnabled()) {
-			//If the town is peaceful, it cannot toggle pvp
-			if (SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
-					&& !SiegeWarSettings.getWarCommonPeacefulTownsAllowedToTogglePVP()
-					&& event.getTown().isNeutral()
-					&& !event.getTown().isPVP()) {
-				event.setCancellationMsg(Translation.of("plugin_prefix") + Translation.of("msg_err_peaceful_town_pvp_forced_off"));
-				event.setCancelled(true);
-				return;
-			}
+		//If the town is peaceful, it cannot toggle pvp
+		if (SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
+				&& !SiegeWarSettings.getWarCommonPeacefulTownsAllowedToTogglePVP()
+				&& event.getTown().isNeutral()
+				&& !event.getTown().isPVP()) {
+			event.setCancellationMsg(Translation.of("plugin_prefix") + Translation.of("msg_err_peaceful_town_pvp_forced_off"));
+			event.setCancelled(true);
+			return;
+		}
 
+		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			if (SiegeWarSettings.getWarSiegePvpAlwaysOnInBesiegedTowns()) {
 
 				//Is the town under siege

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -106,17 +106,17 @@ public class SiegeWarTownEventListener implements Listener {
 	 */
 	@EventHandler
 	public void onTownTogglePVP(TownTogglePVPEvent event) {
-		//If the town is peaceful, it cannot toggle pvp
-		if (SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
-				&& !SiegeWarSettings.getWarCommonPeacefulTownsAllowedToTogglePVP()
-				&& event.getTown().isNeutral()
-				&& !event.getTown().isPVP()) {
-			event.setCancellationMsg(Translation.of("plugin_prefix") + Translation.of("msg_err_peaceful_town_pvp_forced_off"));
-			event.setCancelled(true);
-			return;
-		}
-
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
+			//If the town is peaceful, it cannot toggle pvp
+			if (SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
+					&& !SiegeWarSettings.getWarCommonPeacefulTownsAllowedToTogglePVP()
+					&& event.getTown().isNeutral()
+					&& !event.getTown().isPVP()) {
+				event.setCancellationMsg(Translation.of("plugin_prefix") + Translation.of("msg_err_peaceful_town_pvp_forced_off"));
+				event.setCancelled(true);
+				return;
+			}
+
 			if (SiegeWarSettings.getWarSiegePvpAlwaysOnInBesiegedTowns()) {
 
 				//Is the town under siege

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -30,7 +30,7 @@ public class SiegeWarTownUtil {
 	 * Wrapper method to set pvp flags in a town to the desired 
 	 * setting, as well as the nation if HomeDefence is enabled
 	 * and the town has a nation.
-	 *
+	 * 
 	 * @param town The town to set the flags for.
 	 * @param desiredSetting The value to set pvp and explosions to.
 	 */

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -30,7 +30,7 @@ public class SiegeWarTownUtil {
 	 * Wrapper method to set pvp flags in a town to the desired 
 	 * setting, as well as the nation if HomeDefence is enabled
 	 * and the town has a nation.
-	 * 
+	 *
 	 * @param town The town to set the flags for.
 	 * @param desiredSetting The value to set pvp and explosions to.
 	 */
@@ -38,7 +38,9 @@ public class SiegeWarTownUtil {
 		
 		if(SiegeWarSettings.isHomeDefenceSiegeEffectsEnabled() && town.hasNation()) {
 			for(Town nationTown: TownyAPI.getInstance().getTownNationOrNull(town).getTowns()) {
-				setPvpFlag(nationTown, desiredSetting);
+				//Only non-peaceful towns are affected by the PVP change
+				if(!nationTown.isNeutral())
+					setPvpFlag(nationTown, desiredSetting);
 			}
 		} else {
 			setPvpFlag(town, false);


### PR DESCRIPTION
#### Description: 
- In the home defence feature, there was a small oversight, in that the home defence effects cause PVP to be forced ON in peaceful towns. 
- This is not a bug as such (after all, these towns are still immune to attack), however it is not in keeping with the general vibe of the peaceful towns feature.
- This PR resolves the issue by disabling home-defence-PVP-forcing for peaceful towns

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A


____
- [N/A I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
