### PR TITLE
Remove occupation when town goes to ruin

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -62,8 +62,12 @@ public class SiegeWarTownEventListener implements Listener {
 
 	@EventHandler
 	public void onTownGoesToRuin(TownRuinedEvent event) {
+		//Remove siege if town has one
 		if (SiegeController.hasSiege(event.getTown()))
 			SiegeController.removeSiege(SiegeController.getSiege(event.getTown()), SiegeSide.ATTACKERS);
+		//Remove occupier if town has one
+		if (TownOccupationController.isTownOccupied(event.getTown()))
+			TownOccupationController.removeTownOccupation(event.getTown());
 	}
 	
 	/*


### PR DESCRIPTION
#### Description: 
- When town goes to ruin, just like its home nation is removed, the occupier nation should also be removed.

 ____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
