### PR TITLE
Improve warchest distribution

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
@@ -24,8 +24,10 @@ public class DefenderWin
 		SiegeWarSiegeCompletionUtil.setCommonSiegeCompletionValues(siege, siegeStatus);
 		switch(siege.getSiegeType()) {
 			case CONQUEST:
-			case LIBERATION:
 				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefendingNationIfPossibleElseTown());
+				break;
+			case LIBERATION:
+				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefender());
 				break;
 			case SUPPRESSION:
 				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefendingNationIfPossibleElseTown());

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
@@ -24,9 +24,8 @@ public class DefenderWin
 		SiegeWarSiegeCompletionUtil.setCommonSiegeCompletionValues(siege, siegeStatus);
 		switch(siege.getSiegeType()) {
 			case CONQUEST:
-				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefendingNationIfPossibleElseTown());
 			case LIBERATION:
-				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefender());
+				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefendingNationIfPossibleElseTown());
 				break;
 			case SUPPRESSION:
 				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefendingNationIfPossibleElseTown());

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
@@ -24,11 +24,12 @@ public class DefenderWin
 		SiegeWarSiegeCompletionUtil.setCommonSiegeCompletionValues(siege, siegeStatus);
 		switch(siege.getSiegeType()) {
 			case CONQUEST:
+				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefendingNationIfPossibleElseTown());
 			case LIBERATION:
 				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefender());
 				break;
 			case SUPPRESSION:
-				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefender());
+				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefendingNationIfPossibleElseTown());
 				TownOccupationController.removeTownOccupation(siege.getTown());
 				break;
 			case REVOLT:


### PR DESCRIPTION
#### Description: 
- The following small issue has existing since the start of the system:
  - If a nation town successfully defends a siege, the town gets the warchest.
  - However this is not quite right, because statistically is very much the nation (& allies) who have done most of the fighting, not the town.
- This issue has become more exposed recently with the new text attributions of nation as defender, and the new emphasis on nation defences as a team effort.
- This very small PR resolves the issue by giving the warchest to the nation after a nation wins a siege defence.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
