### PR TITLE
Stop peaceful towns using homeblock-move exploit

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -39,6 +39,7 @@ import com.palmergames.bukkit.towny.event.town.TownUnconquerEvent;
 import com.palmergames.bukkit.towny.event.town.TownMapColourCalculationEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownToggleNeutralEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownTogglePVPEvent;
+import com.palmergames.bukkit.towny.event.town.TownPreSetHomeBlockEvent;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
@@ -284,6 +285,25 @@ public class SiegeWarTownEventListener implements Listener {
 				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_err_siege_affected_home_nation_town_cannot_unclaim"));
 				return;
 			}
+		}
+	}
+
+	/*
+	 * If town is peaceful, it can't move homeblock.
+	 * otherwise it could be / definitely would be
+	 * used by players an an easy and hard-to-moderate exploit to escape occupation.
+	 *
+	 * If a town wants to move its homeblock,
+	 * it can toggle peaceful off, switch homeblock to new location,
+	 * then toggle peaceful on again.
+	 */
+	@EventHandler
+	public void on(TownPreSetHomeBlockEvent event) {
+		if (SiegeWarSettings.getWarSiegeEnabled()
+				&& SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
+				&& event.getTown().isNeutral()) {
+			event.setCancelled(true);
+			event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_err_peaceful_town_cannot_move_homeblock"));
 		}
 	}
 

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -418,3 +418,6 @@ msg_err_siege_affected_home_nation_town_cannot_recruit: "&cThe town cannot add n
 msg_err_siege_affected_home_nation_town_cannot_claim: "&cCannot claim land, because one of your nation's home towns is under siege attack."
 msg_err_siege_affected_home_nation_town_cannot_unclaim: "&cCannot unclaim land, because one of your nation's home towns is under siege attack."
 msg_err_cannot_start_siege_because_towns_home_nation_has_besieged_town: "&cCannot start siege on this nation town, because one of its nation's home towns is already under siege attack."
+
+#Peaceful towns
+msg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -429,3 +429,6 @@ msg_err_siege_affected_home_nation_town_cannot_recruit: "&cThe town cannot add n
 msg_err_siege_affected_home_nation_town_cannot_claim: "&cCannot claim land, because one of your nation's home towns is under siege attack."
 msg_err_siege_affected_home_nation_town_cannot_unclaim: "&cCannot unclaim land, because one of your nation's home towns is under siege attack."
 msg_err_cannot_start_siege_because_towns_home_nation_has_besieged_town: "&cCannot start siege on this nation town, because one of its nation's home towns is already under siege attack."
+
+#Peaceful towns
+msg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."


### PR DESCRIPTION
#### Description: 
- For some time peaceful towns have been using the exploit of moving their homeblock to control their nation choice by placing the homeblock far away from an enemy guardian town, or near to a friendly one.
- Due to the long range of guardian town influence, it tends to be used more by towns towards the edge of a guardian's town's influence rage, still it is an unsavoury trick and exploit.
- This PR fixes the issue by preventing homeblock move for peaceful towns
- Peaceful towns can still do it if they wish, just have to toggle off peaceful, move the homeblock, then toggle peaceful back on again.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
