### PR TITLE
Restrict homeblock move for sieged & occupied towns

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -289,21 +289,30 @@ public class SiegeWarTownEventListener implements Listener {
 	}
 
 	/*
-	 * If town is peaceful, it can't move homeblock.
-	 * otherwise it could be / definitely would be
+	 * If town is peaceful, sieged, or occupied, it can't move homeblock.
+	 * otherwise the move homeblock command could be / definitely would be
 	 * used by players an an easy and hard-to-moderate exploit to escape occupation.
-	 *
-	 * If a town wants to move its homeblock,
-	 * it can toggle peaceful off, switch homeblock to new location,
-	 * then toggle peaceful on again.
 	 */
 	@EventHandler
 	public void on(TownPreSetHomeBlockEvent event) {
-		if (SiegeWarSettings.getWarSiegeEnabled()
-				&& SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
+		if (SiegeWarSettings.getWarSiegeEnabled()) {
+			if(SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
 				&& event.getTown().isNeutral()) {
-			event.setCancelled(true);
-			event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_err_peaceful_town_cannot_move_homeblock"));
+				event.setCancelled(true);
+				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_err_peaceful_town_cannot_move_homeblock"));
+			}
+
+			if(SiegeController.hasActiveSiege(event.getTown())) {
+				event.setCancelled(true);
+				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_err_besieged_town_cannot_move_homeblock"));
+			}
+
+			if(TownOccupationController.isTownOccupied(event.getTown())) {
+				event.setCancelled(true);
+				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_err_occupied_town_cannot_move_homeblock"));
+			}
+
+
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -311,8 +311,6 @@ public class SiegeWarTownEventListener implements Listener {
 				event.setCancelled(true);
 				event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_err_occupied_town_cannot_move_homeblock"));
 			}
-
-
 		}
 	}
 

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -423,3 +423,6 @@ msg_err_cannot_start_siege_because_towns_home_nation_has_besieged_town: "&cCanno
 
 #Peaceful towns
 msg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."
+
+msg_err_besieged_town_cannot_move_homeblock: "&cBesieged towns cannot move their homeblocks."
+msg_err_occupied_town_cannot_move_homeblock: "&cOccupied towns cannot move their homeblocks."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -421,8 +421,11 @@ msg_err_cannot_start_siege_because_towns_home_nation_has_besieged_town: "&cCanno
 
 # Added in 0.17
 
-#Peaceful towns
+# Homeblock move restrictions
 msg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."
 
+# Added in 0.18
+
+# Homeblock move restrictions
 msg_err_besieged_town_cannot_move_homeblock: "&cBesieged towns cannot move their homeblocks."
 msg_err_occupied_town_cannot_move_homeblock: "&cOccupied towns cannot move their homeblocks."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -421,7 +421,7 @@ msg_err_cannot_start_siege_because_towns_home_nation_has_besieged_town: "&cCanno
 
 # Added in 0.17
 
-# Homeblock move restrictions
+# Peaceful towns homeblock move restrictions
 msg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."
 
 # Added in 0.18

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.17
+version: 0.18
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -432,7 +432,7 @@ msg_err_cannot_start_siege_because_towns_home_nation_has_besieged_town: "&cCanno
 
 # Added in 0.17
 
-# Homeblock move restrictions
+# Peaceful towns homeblock move restrictions
 msg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."
 
 # Added in 0.18

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.17
+version: 0.18
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -428,7 +428,7 @@ msg_err_siege_affected_home_nation_town_cannot_toggle_pvp: "&cCannot toggle PVP,
 msg_err_siege_affected_home_nation_town_cannot_recruit: "&cThe town cannot add new residents, because one of its nation's home towns is under siege attack."
 msg_err_siege_affected_home_nation_town_cannot_claim: "&cCannot claim land, because one of your nation's home towns is under siege attack."
 msg_err_siege_affected_home_nation_town_cannot_unclaim: "&cCannot unclaim land, because one of your nation's home towns is under siege attack."
-msg_err_cannot_start_siege_because_towns_home_namsg_err_besieged_town_cannot_move_homeblocktion_has_besieged_town: "&cCannot start siege on this nation town, because one of its nation's home towns is already under siege attack."
+msg_err_cannot_start_siege_because_towns_home_nation_has_besieged_town: "&cCannot start siege on this nation town, because one of its nation's home towns is already under siege attack."
 
 # Added in 0.17
 

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -434,3 +434,6 @@ msg_err_cannot_start_siege_because_towns_home_nation_has_besieged_town: "&cCanno
 
 #Peaceful towns
 msg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."
+
+msg_err_besieged_town_cannot_move_homeblock: "&cBesieged towns cannot move their homeblocks."
+msg_err_occupied_town_cannot_move_homeblock: "&cOccupied towns cannot move their homeblocks."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -428,12 +428,15 @@ msg_err_siege_affected_home_nation_town_cannot_toggle_pvp: "&cCannot toggle PVP,
 msg_err_siege_affected_home_nation_town_cannot_recruit: "&cThe town cannot add new residents, because one of its nation's home towns is under siege attack."
 msg_err_siege_affected_home_nation_town_cannot_claim: "&cCannot claim land, because one of your nation's home towns is under siege attack."
 msg_err_siege_affected_home_nation_town_cannot_unclaim: "&cCannot unclaim land, because one of your nation's home towns is under siege attack."
-msg_err_cannot_start_siege_because_towns_home_nation_has_besieged_town: "&cCannot start siege on this nation town, because one of its nation's home towns is already under siege attack."
+msg_err_cannot_start_siege_because_towns_home_namsg_err_besieged_town_cannot_move_homeblocktion_has_besieged_town: "&cCannot start siege on this nation town, because one of its nation's home towns is already under siege attack."
 
 # Added in 0.17
 
-#Peaceful towns
+# Homeblock move restrictions
 msg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."
 
+# Added in 0.18
+
+# Homeblock move restrictions
 msg_err_besieged_town_cannot_move_homeblock: "&cBesieged towns cannot move their homeblocks."
 msg_err_occupied_town_cannot_move_homeblock: "&cOccupied towns cannot move their homeblocks."


### PR DESCRIPTION
#### Description: 
Closes #232 , by restricting homeblock move for sieged & occupied towns.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
