### PR TITLE
Revolt Siege Attacker Name Fix

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/hud/SiegeWarHud.java
+++ b/src/main/java/com/gmail/goosius/siegewar/hud/SiegeWarHud.java
@@ -21,7 +21,7 @@ public class SiegeWarHud {
         
         board.getObjective("WAR_HUD_OBJ").setDisplayName(SiegeHUDManager.checkLength(Colors.Gold + "§l" + siege.getTown().getName()) + " " + Translation.of("hud_title"));
         board.getTeam("siegeType").setSuffix(SiegeHUDManager.checkLength(siege.getSiegeType().getName()));
-        board.getTeam("attackers").setSuffix(SiegeHUDManager.checkLength(siege.getAttacker().getName()));
+        board.getTeam("attackers").setSuffix(SiegeHUDManager.checkLength(siege.getAttackingNationIfPossibleElseTown().getName()));
         board.getTeam("defenders").setSuffix(SiegeHUDManager.checkLength(siege.getDefendingNationIfPossibleElseTown().getName()));
         board.getTeam("balance").setSuffix(siege.getSiegeBalance().toString());
         board.getTeam("timeRemaining").setSuffix(siege.getTimeRemaining());

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -359,7 +359,7 @@ public class SiegeWarTownEventListener implements Listener {
 				out.add(Translation.of("status_town_siege_status", getStatusTownSiegeSummary(siege)));
 
 				// > Attacker: Land of Darkness (Nation)
-				out.add(Translation.of("status_town_siege_attacker", siege.getAttacker().getFormattedName()));
+				out.add(Translation.of("status_town_siege_attacker", siege.getAttackingNationIfPossibleElseTown().getFormattedName()));
 
 				// > Defender: Land of Light (Nation)
 				out.add(Translation.of("status_town_siege_defender", siege.getDefendingNationIfPossibleElseTown().getFormattedName()));

--- a/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
@@ -196,6 +196,21 @@ public class Siege {
 		return defender;
 	}
 
+	/**
+	 * Get the attacking nation if there is one,
+	 * else get attacking town
+	 *
+	 * @return the attacker,
+	 */
+	public Government getAttackingNationIfPossibleElseTown() {
+		if(attacker instanceof Town && ((Town)attacker).hasNation()) {
+			try {
+				return ((Town)attacker).getNation();
+			} catch (NotRegisteredException ignored) {}
+		}
+		return defender;
+	}
+
 	public void setDefender(Government defender) {
 		this.defender = defender;
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
@@ -140,7 +140,7 @@ public class DynmapTask {
             //Add siege marker if required
             for (Siege siege : SiegeController.getSieges()) {
 
-                String name = Translation.of("dynmap_siege_title", siege.getAttacker().getName(), siege.getDefendingNationIfPossibleElseTown().getName());
+                String name = Translation.of("dynmap_siege_title", siege.getAttackingNationIfPossibleElseTown().getName(), siege.getDefendingNationIfPossibleElseTown().getName());
                 try {
                     if (siege.getStatus().isActive()) {
                         //If anyone is in a BC session or on the BC list, it is a fire & swords icon


### PR DESCRIPTION
#### Description: 
- With current code, the appearance of revolt sieges by nation towns doesn't look right
- Specifically, the attacker is shown as the town e.g.     "Nice v.s. France"
- But this presentation is not in synch with the other siege types, and is less helpful
- What we really want to see is the name of the attacking nation e.g.  "Ostrogoths v.s. France"
- This PR resolves the issue by ensuring that for revolting nation towns, the nation is presented as the attacker.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
