### PR TITLE
Add mitigation for annoyance sieges

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -478,7 +478,7 @@ public class SiegeController {
 
 		//Pay into warchest
 		if (useWarchest) {
-			siege.setWarChestAmount(SiegeWarMoneyUtil.getSiegeCost(targetTown));
+			siege.setWarChestAmount(SiegeWarMoneyUtil.calculateSiegeCost(targetTown));
 			if (TownyEconomyHandler.isActive()) {
 				//Pay upfront cost into warchest now
 				attacker.getAccount().withdraw(siege.getWarChestAmount(), "Cost of starting a siege.");

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -276,7 +276,7 @@ public class PlaceBlock {
 			if (System.currentTimeMillis() < TownMetaDataController.getSiegeImmunityEndTime(nearbyTown))
 				throw new TownyException(Translation.of("msg_err_cannot_start_siege_due_to_siege_immunity"));
 
-			if (TownyEconomyHandler.isActive() && !residentsNation.getAccount().canPayFromHoldings(SiegeWarMoneyUtil.getSiegeCost(nearbyTown)))
+			if (TownyEconomyHandler.isActive() && !residentsNation.getAccount().canPayFromHoldings(SiegeWarMoneyUtil.calculateSiegeCost(nearbyTown)))
 				throw new TownyException(Translation.of("msg_err_no_money"));
 
 			if(SiegeController.getActiveOffensiveSieges(residentsNation).size() >= SiegeWarSettings.getWarSiegeMaxActiveSiegeAttacksPerNation())

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -726,6 +726,8 @@ public enum ConfigNodes {
 			"# Benefits to Nations:",
 			"#   * The nation cannot be forced to fight more than one siege at a time",
 			"#		 (however it can choose to fight more, by attacking/occupying/revolting).",
+			"#   * The bigger a nation is, the riskier it is to attack one of its towns",
+			"#       (bigger warchest)",
 			"#   * After each home defence siege, the entire nation team gets a multi-day break from sieging",
 			"#		 (default 4.5 days for a full 3 day siege).",
 			"# ",
@@ -752,7 +754,18 @@ public enum ConfigNodes {
 			"# EXAMPLE:",
 			"# If the besieged town gets 9 days of siege immunity,",
 			"# and this value is 0.5",
-			"# then each non-besieged town will receive 4.5 days of siege immunity.");
+			"# then each non-besieged town will receive 4.5 days of siege immunity."),
+	ALL_NATION_SIEGES_HOME_TOWN_CONTRIBUTION_TO_ATTACK_COST(
+			"all_nation_sieges.home_town_contribution_to_attack_cost",
+			"0.1",
+			"",
+			"# If this setting is higher than 0,",
+			"# then the larger a nation is, the higher the cost to attack it.",
+			"# EXAMPLE:",
+			"# If this setting is 0.1,",
+			"# and a nation home town is attacked,",
+			"# then for every home town in that nation (including the attacked one),",
+			"# the attack-cost(a.k.a warchest) requirement is increased by 10% of the amount it would take to attack that town.");
 
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -405,5 +405,7 @@ public class SiegeWarSettings {
 		return Settings.getDouble(ConfigNodes.ALL_NATION_SIEGES_SIEGE_IMMUNITY_MODIFIER);
 	}
 
-
+	public static double getAllNationSiegesHomeTownContributionToAttackCost() {
+		return Settings.getDouble(ConfigNodes.ALL_NATION_SIEGES_HOME_TOWN_CONTRIBUTION_TO_ATTACK_COST);
+	}
 }


### PR DESCRIPTION
#### Description: 
Closes #231 , by increases the attack/warchest cost whenever a nation hometown is attacked, with the increase becoming larger as the nation increases in size.
 
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
