### PR TITLE
Fixed bug with display of historical nation participants

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
@@ -208,7 +208,7 @@ public class Siege {
 				return ((Town)attacker).getNation();
 			} catch (NotRegisteredException ignored) {}
 		}
-		return defender;
+		return attacker;
 	}
 
 	public void setDefender(Government defender) {

--- a/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
@@ -196,6 +196,21 @@ public class Siege {
 		return defender;
 	}
 
+	/**
+	 * Get the attacking nation if there is one,
+	 * else get attacking town
+	 *
+	 * @return the attacker,
+	 */
+	public Government getAttackingNationIfPossibleElseTown() {
+		if(attacker instanceof Town && ((Town)attacker).hasNation()) {
+			try {
+				return ((Town)attacker).getNation();
+			} catch (NotRegisteredException ignored) {}
+		}
+		return defender;
+	}
+
 	public void setDefender(Government defender) {
 		this.defender = defender;
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
@@ -34,12 +34,14 @@ public class SiegeWarSiegeCompletionUtil {
 		CosmeticUtil.removeFakeBeacons(siege);
 		/*
 		 * The siege is now historical rather than active.
-		 * Thus, fix the attacker and defender as nations rather than towns.
-		 * Thus, even if the town switches nation,
-		 *       the correct historical nation participants will still be shown.
+		 * Thus, fix the attacker and defender as nations where possible,
+		 * rather than towns.
+		 *
+		 * Thus, even if the town switches nation after the siege,
+		 *   the correct historical nation participants will still be shown.
 		 */
-		siege.setAttacker(siege.getAtta);
-
+		siege.setAttacker(siege.getAttackingNationIfPossibleElseTown());
+		siege.setDefender(siege.getDefendingNationIfPossibleElseTown());
 		//Save to db
 		SiegeController.saveSiege(siege);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
@@ -32,6 +32,13 @@ public class SiegeWarSiegeCompletionUtil {
 		SiegeWarTimeUtil.activateSiegeImmunityTimers(siege.getTown(), siege);
 		SiegeWarTownUtil.setTownPvpFlags(siege.getTown(), false);
 		CosmeticUtil.removeFakeBeacons(siege);
+		/*
+		 * The siege is now historical rather than active.
+		 * Thus, fix the attacker and defender as nations rather than towns.
+		 * Thus, even if the town switches nation,
+		 *       the correct historical nation participants will still be shown.
+		 */
+		siege.setAttacker(siege.getAtta);
 
 		//Save to db
 		SiegeController.saveSiege(siege);


### PR DESCRIPTION
#### Description: 
- Closes #237 , by ensuring that for historical sieges, the displayed nations do not change, even if the sieged town changes nation.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
