### PR TITLE
Fix nation towns not getting pvp off when besieged town leaves

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -13,6 +13,7 @@ import com.gmail.goosius.siegewar.settings.Translation;
 import com.gmail.goosius.siegewar.utils.PermissionUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarNationUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarTownUtil;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyFormatter;
@@ -24,6 +25,7 @@ import com.palmergames.bukkit.towny.event.PreDeleteNationEvent;
 import com.palmergames.bukkit.towny.event.NationPreAddTownEvent;
 import com.palmergames.bukkit.towny.event.nation.NationRankAddEvent;
 import com.palmergames.bukkit.towny.event.nation.NationPreTownLeaveEvent;
+import com.palmergames.bukkit.towny.event.nation.NationTownLeaveEvent;
 import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumOnlinePlayersCalculationEvent;
 import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumTownsCalculationEvent;
 import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumResidentsCalculationEvent;
@@ -284,6 +286,23 @@ public class SiegeWarNationEventListener implements Listener {
 		// We want to un-cancel it.
 		if (event.isCancelled())
 			event.setCancelled(false);
+	}
+
+	/**
+	 * When a besieged town leaves a nation,
+	 * pvp in the remaining towns is returned to the off state.
+	 */
+	@EventHandler
+	public void on(NationTownLeaveEvent event) {
+		if (SiegeWarSettings.getWarSiegeEnabled()
+			&& SiegeWarSettings.isAllNationSiegesEnabled()
+			&& SiegeController.hasActiveSiege(event.getTown())) {
+
+			for(Town nationTown: event.getNation().getTowns()) {
+				if(nationTown != event.getTown() && !nationTown.isNeutral())
+					SiegeWarTownUtil.setPvpFlag(nationTown, false);
+			}
+		}
 	}
 
 	/*

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownUtil.java
@@ -53,7 +53,7 @@ public class SiegeWarTownUtil {
 	 * @param town The town to set the flags for.
 	 * @param desiredSetting The value to set pvp and explosions to.
 	 */
-	private static void setPvpFlag(Town town, boolean desiredSetting) {
+	public static void setPvpFlag(Town town, boolean desiredSetting) {
 		
 		if (town.getPermissions().pvp != desiredSetting && SiegeWarSettings.getWarSiegePvpAlwaysOnInBesiegedTowns()) {
 			town.getPermissions().pvp = desiredSetting;


### PR DESCRIPTION
#### Description: 
Closes #242 , by ensure PVP goes off in the remaining towns when a besieged town leaves a nation.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
