### PR TITLE
Added metadata teardown for primarytowngovernments

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -311,6 +311,9 @@ public class SiegeMetaDataController {
 		sdf = (StringDataField) attackerSiegeContributors.clone();
 		if (town.hasMeta(sdf.getKey()))
 			town.removeMetaData(sdf);
+		sdf = (StringDataField) primaryTownGovernments.clone();
+		if (town.hasMeta(sdf.getKey()))
+			town.removeMetaData(sdf);
 
 		IntegerDataField idf = (IntegerDataField) siegeBalance.clone();
 		if (town.hasMeta(idf.getKey()))


### PR DESCRIPTION
#### Description: 
- Small update to ensure the new metadata is torn down when siege ends

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
