### PR TITLE
T277

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -76,8 +76,10 @@ public class SiegeController {
 		SiegeMetaDataController.setTownUUID(town, siege.getTown().getUUID().toString());
 		SiegeMetaDataController.setAttackerUUID(town, siege.getAttacker().getUUID().toString());
 		SiegeMetaDataController.setDefenderUUID(town, siege.getDefender().getUUID().toString());
-		SiegeMetaDataController.setAttackerName(town, siege.getAttacker().getName());
-		SiegeMetaDataController.setDefenderName(town, siege.getDefender().getName());
+		if(siege.getAttackerName() != null)
+			SiegeMetaDataController.setAttackerName(town, siege.getAttackerName());
+		if(siege.getDefenderName() != null)
+			SiegeMetaDataController.setDefenderName(town, siege.getDefenderName());
 		SiegeMetaDataController.setFlagLocation(town, siege.getFlagLocation().getWorld().getName()
 				+ "!" + siege.getFlagLocation().getX()
 				+ "!" + siege.getFlagLocation().getY()

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -313,18 +313,6 @@ public class SiegeController {
 		return null;
 	}
 
-	@Nullable
-	public static List<Siege> getSiegesByNationUUID(UUID uuid) {
-		List<Siege> siegeList = new ArrayList<>();
-		for (Siege siege : townSiegeMap.values()) {
-			if(siege.getAttacker().getUUID().equals(uuid)
-				|| siege.getDefender().getUUID().equals(uuid)) {
-				siegeList.add(siege);
-			}
-		}
-		return siegeList;
-	}
-
 	public static void setSiege(Town town, boolean bool) {
 		SiegeMetaDataController.setSiege(town, bool);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/hud/SiegeWarHud.java
+++ b/src/main/java/com/gmail/goosius/siegewar/hud/SiegeWarHud.java
@@ -21,8 +21,8 @@ public class SiegeWarHud {
         
         board.getObjective("WAR_HUD_OBJ").setDisplayName(SiegeHUDManager.checkLength(Colors.Gold + "§l" + siege.getTown().getName()) + " " + Translation.of("hud_title"));
         board.getTeam("siegeType").setSuffix(SiegeHUDManager.checkLength(siege.getSiegeType().getName()));
-        board.getTeam("attackers").setSuffix(SiegeHUDManager.checkLength(siege.getAttackingNationIfPossibleElseTown().getName()));
-        board.getTeam("defenders").setSuffix(SiegeHUDManager.checkLength(siege.getDefendingNationIfPossibleElseTown().getName()));
+        board.getTeam("attackers").setSuffix(SiegeHUDManager.checkLength(siege.getAttackerNameForDisplay()));
+        board.getTeam("defenders").setSuffix(SiegeHUDManager.checkLength(siege.getDefenderNameForDisplay()));
         board.getTeam("balance").setSuffix(siege.getSiegeBalance().toString());
         board.getTeam("timeRemaining").setSuffix(siege.getTimeRemaining());
         board.getTeam("warchest").setSuffix(TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount()));

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -138,10 +138,18 @@ public class SiegeWarNationEventListener implements Listener {
 		}
 		
 		/*
-		 * Remove any siege if the nation is deleted, regardless of whether SW is currently enabled.
+		 * Remove sieges in the following scenarios 
+		 * 1. Conquest/suppression/liberation  -> If the nation which started the attack is deleted
+         * 2. Revolt siege -> If the defending nation is deleted
 		 */
-		for (Siege siege : SiegeController.getSiegesByNationUUID(event.getNation().getUUID())) {
-			SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);
+		for (Siege siege : SiegeController.getSieges()) {
+			if(siege.getSiegeType() != SiegeType.REVOLT) {
+				if(siege.getAttacker() == event.getNation())
+					SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);									
+			} else {
+				if(siege.getDefender() == event.getNation())
+					SiegeController.removeSiege(siege, SiegeSide.ATTACKERS);					
+			}
 		}
 
 		/*

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -167,6 +167,7 @@ public class SiegeWarNationEventListener implements Listener {
 					} else if (event.getNation() == siege.getDefender()) { 
 						siege.setSiegeType(SiegeType.CONQUEST);
 						siege.setDefender(siege.getTown());
+						SiegeController.saveSiege(siege);
 						break;
 					}					
 					break;

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -146,7 +146,7 @@ public class SiegeWarNationEventListener implements Listener {
 				case SUPPRESSION:
 					/* 
 					 * Conquest or Suppression:
-					 * If attacker (which is a nation) disappears, we must delete
+					 * If attacker (which is a nation) disappears, we must delete the siege
 					 */
 					if(event.getNation() == siege.getAttacker()) { 
 						SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);
@@ -155,7 +155,7 @@ public class SiegeWarNationEventListener implements Listener {
 				case LIBERATION:									
 					/*
 					 * Liberation:
-					 * If attacker (which is a nation) disappears, we must delete
+					 * If attacker (which is a nation) disappears, we must delete the siege
 					 * If defender (which is a nation) disappears,
 					 *    we must ensure that the attacker does not lose any progress in the siege.
 					 *    We do this by transforming the siege into a conquest siege
@@ -173,7 +173,7 @@ public class SiegeWarNationEventListener implements Listener {
 				case REVOLT:
 					/*
 					 * Revolt
-					 * If defender (which is a nation) disappears, we must delete
+					 * If defender (which is a nation) disappears, we must delete the siege
 					 */
 					if (event.getNation() == siege.getDefender()) { 
 						SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -351,11 +351,11 @@ public class SiegeWarTownEventListener implements Listener {
 				// > Status: In Progress
 				out.add(Translation.of("status_town_siege_status", getStatusTownSiegeSummary(siege)));
 
-				// > Attacker: Land of Darkness (Nation)
-				out.add(Translation.of("status_town_siege_attacker", siege.getAttackingNationIfPossibleElseTown().getFormattedName()));
+				// > Attacker: Darkness
+				out.add(Translation.of("status_town_siege_attacker", siege.getAttackerNameForDisplay()));
 
-				// > Defender: Land of Light (Nation)
-				out.add(Translation.of("status_town_siege_defender", siege.getDefendingNationIfPossibleElseTown().getFormattedName()));
+				// > Defender: Light
+				out.add(Translation.of("status_town_siege_defender", siege.getDefenderNameForDisplay()));
 
 				switch (siegeStatus) {
 	                case IN_PROGRESS:

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -38,6 +38,9 @@ public class SiegeMetaDataController {
 	private static StringDataField siegeTownUUID = new StringDataField("siegewar_townUUID", "");
 	private static StringDataField siegeAttackerUUID = new StringDataField("siegewar_attackerUUID", "");
 	private static StringDataField siegeDefenderUUID = new StringDataField("siegewar_defenderUUID", "");
+	private static StringDataField siegeAttackerName = new StringDataField("siegewar_attackerName", "");
+	private static StringDataField siegeDefenderName = new StringDataField("siegewar_defenderName", "");
+	
 	private static StringDataField siegeFlagLocation = new StringDataField("siegewar_flagLocation", "");
 	private static StringDataField siegeStatus = new StringDataField("siegewar_status", "");
 	private static StringDataField siegeType = new StringDataField("siegewar_type", "");
@@ -97,6 +100,22 @@ public class SiegeMetaDataController {
 	}
 
 	@Nullable
+	public static String getAttackerName(Town town) {
+		StringDataField sdf = (StringDataField) siegeAttackerName.clone();
+		if (town.hasMeta(sdf.getKey()))
+			return MetaDataUtil.getString(town, sdf);
+		return null;
+	}
+
+	public static void setAttackerName(Town town, String name) {
+		StringDataField sdf = (StringDataField) siegeAttackerName.clone();
+		if (town.hasMeta(sdf.getKey()))
+			MetaDataUtil.setString(town, sdf, name);
+		else
+			town.addMetaData(new StringDataField("siegewar_attackerName", name));
+	}
+
+	@Nullable
 	public static String getDefenderUUID(Town town) {
 		StringDataField sdf = (StringDataField) siegeDefenderUUID.clone();
 		if (town.hasMeta(sdf.getKey()))
@@ -110,6 +129,22 @@ public class SiegeMetaDataController {
 			MetaDataUtil.setString(town, sdf, uuid);
 		else
 			town.addMetaData(new StringDataField("siegewar_defenderUUID", uuid));
+	}
+
+	@Nullable
+	public static String getDefenderName(Town town) {
+		StringDataField sdf = (StringDataField) siegeDefenderName.clone();
+		if (town.hasMeta(sdf.getKey()))
+			return MetaDataUtil.getString(town, sdf);
+		return null;
+	}
+
+	public static void setDefenderName(Town town, String name) {
+		StringDataField sdf = (StringDataField) siegeDefenderName.clone();
+		if (town.hasMeta(sdf.getKey()))
+			MetaDataUtil.setString(town, sdf, name);
+		else
+			town.addMetaData(new StringDataField("siegewar_defenderName", name));
 	}
 
 	@Nullable

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -330,6 +330,12 @@ public class SiegeMetaDataController {
 		sdf = (StringDataField) siegeDefenderUUID.clone();
 		if (town.hasMeta(sdf.getKey()))
 			town.removeMetaData(sdf);
+		sdf = (StringDataField) siegeAttackerName.clone();
+		if (town.hasMeta(sdf.getKey()))
+			town.removeMetaData(sdf);
+		sdf = (StringDataField) siegeDefenderName.clone();
+		if (town.hasMeta(sdf.getKey()))
+			town.removeMetaData(sdf);
 
 		sdf = (StringDataField) siegeNationUUID.clone();
 		if (town.hasMeta(sdf.getKey()))

--- a/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
@@ -43,8 +43,8 @@ public class Siege {
 	private Town town;
 	private Government attacker;
 	private Government defender;
-	private String attackerName; //used only in siege aftermath
-	private String defenderName; //used only in siege aftermath
+	private String attackerName; //Only used in non-active sieges
+	private String defenderName; //Only used in non-active sieges
     private SiegeStatus status;
     private boolean townPlundered;
     private boolean townInvaded;

--- a/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
@@ -43,6 +43,8 @@ public class Siege {
 	private Town town;
 	private Government attacker;
 	private Government defender;
+	private String attackerName; //used only in siege aftermath
+	private String defenderName; //used only in siege aftermath
     private SiegeStatus status;
     private boolean townPlundered;
     private boolean townInvaded;
@@ -70,6 +72,8 @@ public class Siege {
         siegeType = null;
         attacker = null;
         defender = null;
+        attackerName = "";
+        defenderName = "";
         status = null;
 		siegeBalance = 0;
 		siegeBannerLocation = null;
@@ -208,6 +212,23 @@ public class Siege {
 			return TownyAPI.getInstance().getTownNationOrNull((Town) attacker);
 		return attacker;
 	}
+
+	public String getAttackerNameForDisplay() {
+		if(status.isActive()) {
+			return getAttackingNationIfPossibleElseTown().getName();
+		} else {
+			return getAttackerName();
+		}
+	}
+	
+	public String getDefenderNameForDisplay() {
+		if(status.isActive()) {
+			return getDefendingNationIfPossibleElseTown().getName();
+		} else {
+			return getDefenderName();
+		}
+	}
+
 
 	public void setDefender(Government defender) {
 		this.defender = defender;
@@ -479,5 +500,21 @@ public class Siege {
 			result += homeNationContribution;
 		}
 		return result;
+	}
+
+	public String getAttackerName() {
+		return attackerName;
+	}
+
+	public void setAttackerName(String attackerName) {
+		this.attackerName = attackerName;
+	}
+
+	public String getDefenderName() {
+		return defenderName;
+	}
+
+	public void setDefenderName(String defenderName) {
+		this.defenderName = defenderName;
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
@@ -32,9 +32,9 @@ import static com.palmergames.util.TimeMgmt.ONE_HOUR_IN_MILLIS;
  * It typically lasts for a moderate duration (e.g. hours or days),
  * and can be ended n a number of ways, including when siege victory timer reaches 0, or abandon, or surrender.
  * 
- * After a siege ends, it enters an aftermath phase where the status is no longer "In Progress",
+ * After a siege ends, it enters an aftermath phase where it has an inactive type of siege status,
  * During this phase, the town cannot be attacked again,
- * and if an attacker has won, they have the options of "plunder" or "invade".
+ * and, depending on the siege type, the victor may have the options of "plunder" and/or "invade".
  *
  * @author Goosius
  */
@@ -43,8 +43,8 @@ public class Siege {
 	private Town town;
 	private Government attacker;
 	private Government defender;
-	private String attackerName; //Only used in non-active sieges
-	private String defenderName; //Only used in non-active sieges
+	private String attackerName; //Only used in the siege-aftermath
+	private String defenderName; //Only used in the siege-aftermath
     private SiegeStatus status;
     private boolean townPlundered;
     private boolean townInvaded;

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
@@ -140,7 +140,7 @@ public class DynmapTask {
             //Add siege marker if required
             for (Siege siege : SiegeController.getSieges()) {
 
-                String name = Translation.of("dynmap_siege_title", siege.getAttackingNationIfPossibleElseTown().getName(), siege.getDefendingNationIfPossibleElseTown().getName());
+                String name = Translation.of("dynmap_siege_title", siege.getAttackerNameForDisplay(), siege.getDefenderNameForDisplay());
                 try {
                     if (siege.getStatus().isActive()) {
                         //If anyone is in a BC session or on the BC list, it is a fire & swords icon

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
@@ -35,11 +35,12 @@ public class SiegeWarSiegeCompletionUtil {
 		CosmeticUtil.removeFakeBeacons(siege);
 		/*
 		 * The siege is now historical rather than active.
-		 * Set the attackerName, and defenderName strings
-		 * These will now be used to display the participant names
 		 * 
-		 * Thus, even if the town switches nation after the siege,
-		 *   the correct historical nation participants will still be shown.
+		 * To ensure that the correct historical participants are always displayed,
+		 * we now set the attackerName and defenderName String variables,
+		 * and use them to display the participants.
+		 *
+		 * These 2 variables will not change.
 		 */
 		siege.setAttackerName(siege.getAttackingNationIfPossibleElseTown().getName());
 		siege.setDefenderName(siege.getDefendingNationIfPossibleElseTown().getName());

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
@@ -35,14 +35,14 @@ public class SiegeWarSiegeCompletionUtil {
 		CosmeticUtil.removeFakeBeacons(siege);
 		/*
 		 * The siege is now historical rather than active.
-		 * Thus, fix the attacker and defender as nations where possible,
-		 * rather than towns.
-		 *
+		 * Set the attackerName, and defenderName strings
+		 * These will now be used to display the participant names
+		 * 
 		 * Thus, even if the town switches nation after the siege,
 		 *   the correct historical nation participants will still be shown.
 		 */
-		siege.setAttacker(siege.getAttackingNationIfPossibleElseTown());
-		siege.setDefender(siege.getDefendingNationIfPossibleElseTown());
+		siege.setAttackerName(siege.getAttackingNationIfPossibleElseTown().getName());
+		siege.setDefenderName(siege.getDefendingNationIfPossibleElseTown().getName());
 
 		//Save to db
 		SiegeController.saveSiege(siege);


### PR DESCRIPTION
#### Description: 
This PR fixes a bug: (#277)

**Bug Replication Steps:**
1. There is a nation n1
2. There is a nation n2
2. There is a town t1 within n1
3. The town t1 loses a siege
4. The nation n1 then merges into n2.
5. The siege on t1 then disappears

**Why does this happen?**
1. Take an example of a conquest siege
2. During the active stage of the siege, the defender variable references the besieged town
3. However, when a siege enters its aftermatch stage, the defender variable is automatically
   updated to be the nation of the defending town.
4. Then, if the defending nation is deleted (via normal delete or merge), 
   SW runs the "onDeleteNation" method.
   This method deletes all sieges which the defending nation was associated with,
   including the example one.

**Solution in this PR**
1. First, I simplify the logic by removing the (non-intuitive/hard-to-debug)
   automatic-aftermath-update of the attacker/defender
2. In place of this mechanic, I add 2 new fields to track the historical participants
   (attackerName, defenderName)
3. Then I change the logic in the "onDeleteNation" method, so that it only deletes the siege when appropriate,
   with care taken that a victor is never denied an invasion/plunder which they have earned
4. Also in a small unrelated change,
   I do a small cleanup in SiegeMetaDataController to remove some old migration code which caters for siege data from many versions back.
 
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
Fixes #277 

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
