### PR TITLE
T278

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -53,7 +53,7 @@ public class SiegeWarBattleSessionUtil {
 								siege.recordPrimaryTownGovernment();
 
 							//If any battle points were gained, calculate a result
-							if(siege.getAttackerBattlePoints() > 0 && siege.getDefenderBattlePoints() > 0) {
+							if(siege.getAttackerBattlePoints() > 0 || siege.getDefenderBattlePoints() > 0) {
 								//Calculate result
 								int battlePointsOfWinner;
 								if (siege.getAttackerBattlePoints() > siege.getDefenderBattlePoints()) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -52,32 +52,28 @@ public class SiegeWarBattleSessionUtil {
 							if(SiegeWarSettings.isNationSiegeImmunityEnabled())
 								siege.recordPrimaryTownGovernment();
 
-							//Continue to next siege if there were no battle points
-							if(siege.getAttackerBattlePoints() == 0 && siege.getDefenderBattlePoints() == 0) {
-								if(SiegeWarSettings.isNationSiegeImmunityEnabled())
-									SiegeController.saveSiege(siege);
-								continue;
+							//If any battle points were gained, calculate a battle result
+							if(siege.getAttackerBattlePoints() > 0 && siege.getDefenderBattlePoints() > 0) {
+								//Calculate result
+								int battlePointsOfWinner;
+								if (siege.getAttackerBattlePoints() > siege.getDefenderBattlePoints()) {
+									battlePointsOfWinner = siege.getAttackerBattlePoints();
+								} else if (siege.getAttackerBattlePoints() < siege.getDefenderBattlePoints()) {
+									battlePointsOfWinner = -siege.getDefenderBattlePoints();
+								} else {
+									battlePointsOfWinner = 0;
+								}
+	
+								//Apply the battle points of the winner to the siege balance
+								siege.adjustSiegeBalance(battlePointsOfWinner);
+	
+								//Propagate attacker battle contributions to siege history
+								siege.propagateSuccessfulBattleContributorsToResidentTimedPointContributors();
+	
+								//Prepare result for messaging
+								battleResults.put(siege, battlePointsOfWinner);							
 							}
-
-							//Calculate result
-							int battlePointsOfWinner;
-							if (siege.getAttackerBattlePoints() > siege.getDefenderBattlePoints()) {
-								battlePointsOfWinner = siege.getAttackerBattlePoints();
-							} else if (siege.getAttackerBattlePoints() < siege.getDefenderBattlePoints()) {
-								battlePointsOfWinner = -siege.getDefenderBattlePoints();
-							} else {
-								battlePointsOfWinner = 0;
-							}
-
-							//Apply the battle points of the winner to the siege balance
-							siege.adjustSiegeBalance(battlePointsOfWinner);
-
-							//Propagate attacker battle contributions to siege history
-							siege.propagateSuccessfulBattleContributorsToResidentTimedPointContributors();
-
-							//Prepare result for messaging
-							battleResults.put(siege, battlePointsOfWinner);
-
+							
 							//Remove glowing effects from players in bc sessions
 							for (Player player : siege.getBannerControlSessions().keySet()) {
 								if (player.isOnline() && player.hasPotionEffect(PotionEffectType.GLOWING)) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -52,7 +52,7 @@ public class SiegeWarBattleSessionUtil {
 							if(SiegeWarSettings.isNationSiegeImmunityEnabled())
 								siege.recordPrimaryTownGovernment();
 
-							//If any battle points were gained, calculate a battle result
+							//If any battle points were gained, calculate a result
 							if(siege.getAttackerBattlePoints() > 0 && siege.getDefenderBattlePoints() > 0) {
 								//Calculate result
 								int battlePointsOfWinner;
@@ -71,7 +71,10 @@ public class SiegeWarBattleSessionUtil {
 								siege.propagateSuccessfulBattleContributorsToResidentTimedPointContributors();
 	
 								//Prepare result for messaging
-								battleResults.put(siege, battlePointsOfWinner);							
+								battleResults.put(siege, battlePointsOfWinner);
+
+								//Save siege
+								SiegeController.saveSiege(siege);							
 							}
 							
 							//Remove glowing effects from players in bc sessions
@@ -93,9 +96,6 @@ public class SiegeWarBattleSessionUtil {
 							siege.setAttackerBattlePoints(0);
 							siege.setDefenderBattlePoints(0);
 							siege.clearSuccessfulBattleContributors();
-
-							//Save siege
-							SiegeController.saveSiege(siege);
 						}
 					} catch (Throwable t) {
 						try {


### PR DESCRIPTION
#### Description: 
This PR fixes bug 278

Bug:
- If a particular battle has 0 att/def points, then at the end of the battle session,
  the banner-control variables for that siege are not cleared.
- Thus any banner-control sessions effectively continue,
  allowing banner-control to be gained immediately at the start of the next battle session

Solution:
- In this PR I fix the issue by always clearing the banner-control variables at the end of the battle session.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
Fixes #278 

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
