### PR TITLE
Option to Disable Winner-Takes-All BattleSession Scoring.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -362,8 +362,8 @@ public class SiegeWarTownEventListener implements Listener {
 					case IN_PROGRESS:
 						// > Balance: 530 | Pending: +130
 						String balanceLine = Translation.of("status_town_siege_status_siege_balance", siege.getSiegeBalance());
-						// If the session is active with points add the " | Pending: +130"
-						if (battleSessionIsActive(siege)) {
+						// If the battle is active with points add the " | Pending: +130"
+						if (battleIsActive(siege)) {
 							int pending = SiegeWarBattleSessionUtil.calculateSiegeBalanceAdjustment(siege);
 							balanceLine += Translation.of("status_town_siege_pending_balance_adjustment", ((pending > 0 ? "+" : "") + pending));
 						}
@@ -387,7 +387,7 @@ public class SiegeWarTownEventListener implements Listener {
 						String warChest = TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount());
 						out.add(Translation.of("status_town_siege_status_warchest", warChest));
 
-						if(battleSessionIsActive(siege)) {
+						if(battleIsActive(siege)) {
 
 							//Battle:
 							String battle = Translation.of("status_town_siege_battle");
@@ -537,7 +537,7 @@ public class SiegeWarTownEventListener implements Listener {
 		}
 	}
 
-	private static boolean battleSessionIsActive(Siege siege) {
+	private static boolean battleIsActive(Siege siege) {
 		return BattleSession.getBattleSession().isActive()
 				&& (siege.getAttackerBattlePoints() > 0
 				 || siege.getDefenderBattlePoints() > 0

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -359,14 +359,14 @@ public class SiegeWarTownEventListener implements Listener {
 				out.add(Translation.of("status_town_siege_defender", siege.getDefenderNameForDisplay()));
 
 				switch (siegeStatus) {
-	                case IN_PROGRESS:
+					case IN_PROGRESS:
 						// > Balance: 530 | Pending: +130
-	                	String balanceLine = Translation.of("status_town_siege_status_siege_balance", siege.getSiegeBalance());
+						String balanceLine = Translation.of("status_town_siege_status_siege_balance", siege.getSiegeBalance());
 						// If the session is active with points add the " | Pending: +130"
-	                	if (battleSessionIsActive(siege)) {
-	                		int pending = SiegeWarBattleSessionUtil.calculateSiegeBalanceAdjustment(siege);
-	                		balanceLine += Translation.of("status_town_siege_pending_balance_adjustment", ((pending > 0 ? "+" : "") + pending));
-	                	}
+						if (battleSessionIsActive(siege)) {
+							int pending = SiegeWarBattleSessionUtil.calculateSiegeBalanceAdjustment(siege);
+							balanceLine += Translation.of("status_town_siege_pending_balance_adjustment", ((pending > 0 ? "+" : "") + pending));
+						}
 						out.add(balanceLine); 
 
 						if(SiegeWarSettings.isBannerXYZTextEnabled()) {

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -408,8 +408,8 @@ public class SiegeWarTownEventListener implements Listener {
 							// > Points: +90 / -220
 							out.add(Translation.of("status_town_siege_battle_points", siege.getFormattedAttackerBattlePoints(), siege.getFormattedDefenderBattlePoints()));
 							
-							// > Current Battle Session Reward: 420 points
-							out.add(Translation.of("status_town_siege_winner_gains", SiegeWarBattleSessionUtil.calcPointsForBattleSession(siege)));
+							// > Pending Balance Adjustment: 420 points
+							out.add(Translation.of("status_town_siege_winner_gains", SiegeWarBattleSessionUtil.calculateSiegeBalanceAdjustment(siege)));
 
 							// > Time Remaining: 22 minutes
 							out.add(Translation.of("status_town_siege_battle_time_remaining", BattleSession.getBattleSession().getFormattedTimeRemainingUntilBattleSessionEnds()));

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -360,8 +360,14 @@ public class SiegeWarTownEventListener implements Listener {
 
 				switch (siegeStatus) {
 	                case IN_PROGRESS:
-						// > Balance: 530
-						out.add(Translation.of("status_town_siege_status_siege_balance", siege.getSiegeBalance()));
+						// > Balance: 530 | Pending: +130
+	                	String balanceLine = Translation.of("status_town_siege_status_siege_balance", siege.getSiegeBalance());
+						// If the session is active with points add the " | Pending: +130"
+	                	if (battleSessionIsActive(siege)) {
+	                		int pending = SiegeWarBattleSessionUtil.calculateSiegeBalanceAdjustment(siege);
+	                		balanceLine += Translation.of("status_town_siege_pending_balance_adjustment", ((pending > 0 ? "+" : "") + pending));
+	                	}
+						out.add(balanceLine); 
 
 						if(SiegeWarSettings.isBannerXYZTextEnabled()) {
 							// > Banner XYZ: {2223,82,9877}
@@ -381,11 +387,7 @@ public class SiegeWarTownEventListener implements Listener {
 						String warChest = TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount());
 						out.add(Translation.of("status_town_siege_status_warchest", warChest));
 
-						if(BattleSession.getBattleSession().isActive()
-							&& (siege.getAttackerBattlePoints() > 0
-								|| siege.getDefenderBattlePoints() > 0
-								|| siege.getBannerControllingSide() != SiegeSide.NOBODY
-								|| siege.getBannerControlSessions().size() > 0)) {
+						if(battleSessionIsActive(siege)) {
 
 							//Battle:
 							String battle = Translation.of("status_town_siege_battle");
@@ -407,9 +409,6 @@ public class SiegeWarTownEventListener implements Listener {
 
 							// > Points: +90 / -220
 							out.add(Translation.of("status_town_siege_battle_points", siege.getFormattedAttackerBattlePoints(), siege.getFormattedDefenderBattlePoints()));
-							
-							// > Pending Balance Adjustment: 420 points
-							out.add(Translation.of("status_town_siege_winner_gains", SiegeWarBattleSessionUtil.calculateSiegeBalanceAdjustment(siege)));
 
 							// > Time Remaining: 22 minutes
 							out.add(Translation.of("status_town_siege_battle_time_remaining", BattleSession.getBattleSession().getFormattedTimeRemainingUntilBattleSessionEnds()));
@@ -536,5 +535,13 @@ public class SiegeWarTownEventListener implements Listener {
 			String mapColorHexCode = TownOccupationController.getTownOccupier(event.getTown()).getMapColorHexCode();
 			event.setMapColorHexCode(mapColorHexCode);
 		}
+	}
+
+	private static boolean battleSessionIsActive(Siege siege) {
+		return BattleSession.getBattleSession().isActive()
+				&& (siege.getAttackerBattlePoints() > 0
+				 || siege.getDefenderBattlePoints() > 0
+				 || siege.getBannerControllingSide() != SiegeSide.NOBODY
+				 || siege.getBannerControlSessions().size() > 0);
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -23,6 +23,7 @@ import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.settings.Translation;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.PermissionUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarBattleSessionUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarTownUtil;
 import com.palmergames.bukkit.towny.TownyFormatter;
 import com.palmergames.bukkit.towny.TownyMessaging;
@@ -406,6 +407,9 @@ public class SiegeWarTownEventListener implements Listener {
 
 							// > Points: +90 / -220
 							out.add(Translation.of("status_town_siege_battle_points", siege.getFormattedAttackerBattlePoints(), siege.getFormattedDefenderBattlePoints()));
+							
+							// > Current Battle Session Reward: 420 points
+							out.add(Translation.of("status_town_siege_winner_gains", SiegeWarBattleSessionUtil.calcPointsForBattleSession(siege)));
 
 							// > Time Remaining: 22 minutes
 							out.add(Translation.of("status_town_siege_battle_time_remaining", BattleSession.getBattleSession().getFormattedTimeRemainingUntilBattleSessionEnds()));

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -313,6 +313,13 @@ public enum ConfigNodes {
 			"# Note that the horizontal distance is always the same as the Towny townblock size."),
 
 	//Battle points
+	WAR_BATTLE_POINTS_DISTRIBUTION_WINNER_TAKES_ALL(
+			"war.siege.scoring.winner_takes_all_points",
+			"true",
+			"",
+			"# When true, at the end of a successful battle session all points go to the winner of the session.",
+			"# When false, the losing side's points are deducted from the winners side, making the losing side's",
+			"# efforts during the session matter, and winners gain points slower."),
 	WAR_BATTLE_POINTS_FOR_ATTACKER_OCCUPATION(
 			"war.siege.scoring.points_for_attacker_occupation",
 			"10",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -122,6 +122,10 @@ public class SiegeWarSettings {
 	public static double getWarSiegeMinSiegeDurationBeforeAbandonHours() {
 		return Settings.getDouble(ConfigNodes.WAR_SIEGE_MIN_SIEGE_DURATION_BEFORE_ABANDON_HOURS);
 	}
+	
+	public static boolean areBattlePointsWinnerTakesAll() {
+		return Settings.getBoolean(ConfigNodes.WAR_BATTLE_POINTS_DISTRIBUTION_WINNER_TAKES_ALL);
+	}
 
 	public static int getWarBattlePointsForAttackerOccupation() {
 		return Settings.getInt(ConfigNodes.WAR_BATTLE_POINTS_FOR_ATTACKER_OCCUPATION);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/BookUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/BookUtil.java
@@ -200,7 +200,14 @@ public class BookUtil {
 
 		//Battle sessions
 		text += "\nBATTLE SESSIONS\n\n";
-		text += "Fighting is organised into " + activeSession + " 'battle sessions'. During a battle session, each team (attackers/defenders) competes in 'battles' at each siege. Killing or banner control will give them a 'Battle Points'. When the battle session ends, at each battle, the team with the highest battle points wins the battle, and their battle points are applied to the siege balance. After a battle session ends, there is typically a break until the next battle session. In this break, nobody can gain battle points.\n\n";
+		text += "Fighting is organised into " + activeSession + " 'battle sessions'. During a battle session, each team (attackers/defenders) competes in 'battles' at each siege. Killing or banner control will give them a 'Battle Points'.\n";
+		text += "When the battle session ends, at each battle, ";
+		if (SiegeWarSettings.areBattlePointsWinnerTakesAll())
+			text += "the team with the highest battle points wins the battle, and their battle points are ";
+		else 
+			text += "the losing side's points are deducted from the winners side and the remainder is ";
+		text += "applied to the siege balance.\n";
+		text += "After a battle session ends, there is typically a break until the next battle session. In this break, nobody can gain battle points.\n\n";
 
 		return text;
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -59,14 +59,7 @@ public class SiegeWarBattleSessionUtil {
 							//If any battle points were gained, calculate a result
 							if(siege.getAttackerBattlePoints() > 0 || siege.getDefenderBattlePoints() > 0) {
 								//Calculate result
-								int battlePointsOfWinner;
-								if (siege.getAttackerBattlePoints() > siege.getDefenderBattlePoints()) {
-									battlePointsOfWinner = siege.getAttackerBattlePoints();
-								} else if (siege.getAttackerBattlePoints() < siege.getDefenderBattlePoints()) {
-									battlePointsOfWinner = -siege.getDefenderBattlePoints();
-								} else {
-									battlePointsOfWinner = 0;
-								}
+								int battlePointsOfWinner = calcPointsForBattleSession(siege);
 	
 								//Apply the battle points of the winner to the siege balance
 								siege.adjustSiegeBalance(battlePointsOfWinner);
@@ -137,6 +130,40 @@ public class SiegeWarBattleSessionUtil {
 				}
 			}
 		}
+	}
+
+	/** 
+	 * Determines how many points are awarded to the winner of a Battle Session.
+	 *
+	 * Affected by the areBattlePointsWinnerTakesAll config setting.
+	 * 
+	 * @param siege the Siege to gather BattlePoints from.
+	 * @return points awarded to the winner.
+	 */
+	public static int calcPointsForBattleSession(Siege siege) {
+		int battlePointsOfWinner;
+		
+		// Attackers won the session.
+		if (siege.getAttackerBattlePoints() > siege.getDefenderBattlePoints()) {
+			
+			if (SiegeWarSettings.areBattlePointsWinnerTakesAll())
+				battlePointsOfWinner = siege.getAttackerBattlePoints();
+			else 
+				battlePointsOfWinner = siege.getAttackerBattlePoints() - siege.getDefenderBattlePoints();
+
+		// Defenders won the session.
+		} else if (siege.getAttackerBattlePoints() < siege.getDefenderBattlePoints()) {
+
+			if (SiegeWarSettings.areBattlePointsWinnerTakesAll())
+				battlePointsOfWinner = -siege.getDefenderBattlePoints();
+			else 
+				battlePointsOfWinner = -(siege.getDefenderBattlePoints() - siege.getAttackerBattlePoints());
+
+		// Session was a draw.
+		} else {
+			return 0;
+		}
+		return battlePointsOfWinner;
 	}
 
 	/**

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -429,5 +429,5 @@ msg_err_occupied_town_cannot_move_homeblock: "&cOccupied towns cannot move their
 
 # Added in 0.20
 
-# Town status screen's winner's points
-status_town_siege_winner_gains: '&2 > Pending Balance Adjustment: &a%s points'
+# Town status screen's pending balance adjustment
+status_town_siege_pending_balance_adjustment: '&2 | Pending: &a%s'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -430,4 +430,4 @@ msg_err_occupied_town_cannot_move_homeblock: "&cOccupied towns cannot move their
 # Added in 0.20
 
 # Town status screen's winner's points
-status_town_siege_winner_gains: '&2 > Current Battle Session Reward: &a%s points'
+status_town_siege_winner_gains: '&2 > Pending Balance Adjustment: &a%s points'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.19
+version: 0.20
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -426,3 +426,8 @@ msg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their
 # Homeblock move restrictions
 msg_err_besieged_town_cannot_move_homeblock: "&cBesieged towns cannot move their homeblocks."
 msg_err_occupied_town_cannot_move_homeblock: "&cOccupied towns cannot move their homeblocks."
+
+# Added in 0.20
+
+# Town status screen's winner's points
+status_town_siege_winner_gains: '&2 > Current Battle Session Reward: &a%s points'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.19
+version: 0.20
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -437,3 +437,8 @@ msg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their
 # Homeblock move restrictions
 msg_err_besieged_town_cannot_move_homeblock: "&cBesieged towns cannot move their homeblocks."
 msg_err_occupied_town_cannot_move_homeblock: "&cOccupied towns cannot move their homeblocks."
+
+# Added in 0.20
+
+# Town status screen's winner's points
+status_town_siege_winner_gains: '&2 > Current Battle Session Reward: &a%s points'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -441,4 +441,4 @@ msg_err_occupied_town_cannot_move_homeblock: "&cOccupied towns cannot move their
 # Added in 0.20
 
 # Town status screen's winner's points
-status_town_siege_winner_gains: '&2 > Current Battle Session Reward: &a%s points'
+status_town_siege_winner_gains: '&2 > Pending Balance Adjustment: &a%s points'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -440,5 +440,5 @@ msg_err_occupied_town_cannot_move_homeblock: "&cOccupied towns cannot move their
 
 # Added in 0.20
 
-# Town status screen's winner's points
-status_town_siege_winner_gains: '&2 > Pending Balance Adjustment: &a%s points'
+# Town status screen's pending balance adjustment
+status_town_siege_pending_balance_adjustment: '&2 | Pending: &a%s'


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds the ability to count the losing side's points against the winner of
a battle session. Configs will default to using the existing system,
when new setting is false the points will be more evenly applied.

calcPointsForBattleSession(Siege siege) added to
SiegeWarBattleSessionUtil.

Displays new language string on the /town screen showing what the
current BS winner will take away as points.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New Config Option: war.siege.scoring.winner_takes_all_points
  - Default: true
  - When true, at the end of a successful battle session all points go
to the winner of the session.
  - When false, the losing side's points are deducted from the winners
side, making the losing side's efforts during the session matter, and
winners gain points slower.

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #257.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
