### PR TITLE
Sw 287 - Add SiegeEnd event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/events/SiegeEndEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/SiegeEndEvent.java
@@ -1,0 +1,49 @@
+package com.gmail.goosius.siegewar.events;
+
+import com.gmail.goosius.siegewar.objects.Siege;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This event is triggered immediately after a siege ends
+ *
+ * Note: If end-users want names of the town/attacker/defender,
+ *       they should be careful about getting the name via town/nation objects,
+ *       as these towns/nations may disappear after the siege.
+ *
+ *       Rather they should use:
+ *       event.getSiege().getAttackerName()
+ *       siege.getSiege().getDefenderName()
+ *       event.getBesiegedTownName()
+ */
+public class SiegeEndEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final Siege siege;
+    private final String besiegedTownName;
+
+    public SiegeEndEvent(Siege siege,
+                         String besiegedTownName) {
+        this.siege = siege;
+        this.besiegedTownName = besiegedTownName;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public Siege getSiege() {
+        return siege;
+    }
+
+    public String getBesiegedTownName() {
+        return besiegedTownName;
+    }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
@@ -63,8 +63,8 @@ public class Siege {
 	private int cannonSessionRemainingShortTicks;  //Short ticks remaining until standard cannon protections are restored
 	private int attackerBattlePoints;
 	private int defenderBattlePoints;
-	private Set<String> successfulBattleContributors;   //UUID's of residents who contributed during the current battle
-	private Map<String, Integer> residentTimedPointContributors;  //UUID:numContributions map of residents who contributed during current siege
+	private Set<String> successfulBattleContributors;   //UUID's of attacker-side residents who got BC at least once during the current battle
+	private Map<String, Integer> residentTimedPointContributors;  //UUID:numContributions map of attacker-side residents who got BC at least once during the current siege
 	private Map<UUID, Integer> primaryTownGovernments; //UUID:numBattleSessions map of governments who led the town during the siege. If town was is a nation, nation UUID will be used, otherwise town UUID will be used
 
 	public Siege(Town town) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
@@ -3,7 +3,9 @@ package com.gmail.goosius.siegewar.utils;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
+import com.gmail.goosius.siegewar.events.SiegeEndEvent;
 import com.gmail.goosius.siegewar.objects.Siege;
+import org.bukkit.Bukkit;
 
 /**
  * This class contains utility functions related to completing sieges
@@ -47,5 +49,9 @@ public class SiegeWarSiegeCompletionUtil {
 
 		//Save to db
 		SiegeController.saveSiege(siege);
+
+		//Fire SiegeEnded event
+		SiegeEndEvent siegeEndEvent = new SiegeEndEvent(siege, siege.getTown().getName());
+		Bukkit.getPluginManager().callEvent(siegeEndEvent);
 	}
 }


### PR DESCRIPTION
#### Description: 
- This PR adds a SiegeEnd event
- The event is called when the siege ends
- This Closes #287 
- This also adds the event required by [TownyHistories ticket 1](https://github.com/TownyAdvanced/TownyHistories/issues/1)

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
Closes #287

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
