### PR TITLE
SW-298 Added missing support for no-economy

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/hud/SiegeWarHud.java
+++ b/src/main/java/com/gmail/goosius/siegewar/hud/SiegeWarHud.java
@@ -25,7 +25,11 @@ public class SiegeWarHud {
         board.getTeam("defenders").setSuffix(SiegeHUDManager.checkLength(siege.getDefenderNameForDisplay()));
         board.getTeam("balance").setSuffix(siege.getSiegeBalance().toString());
         board.getTeam("timeRemaining").setSuffix(siege.getTimeRemaining());
-        board.getTeam("warchest").setSuffix(TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount()));
+        if(TownyEconomyHandler.isActive()) {
+            board.getTeam("warchest").setSuffix(TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount()));
+        } else {
+            board.getTeam("warchest").setSuffix("-");
+        }
         board.getTeam("bannerControl").setSuffix(siege.getBannerControllingSide().name().charAt(0) + siege.getBannerControllingSide().name().substring(1).toLowerCase());
         board.getTeam("btAttackerPoints").setSuffix(siege.getFormattedAttackerBattlePoints());
         board.getTeam("btDefenderPoints").setSuffix(siege.getFormattedDefenderBattlePoints());

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -384,8 +384,10 @@ public class SiegeWarTownEventListener implements Listener {
 						out.add(victoryTimer);
 
 						// >  War Chest: $12,800
-						String warChest = TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount());
-						out.add(Translation.of("status_town_siege_status_warchest", warChest));
+						if(TownyEconomyHandler.isActive()) {
+							String warChest = TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount());
+							out.add(Translation.of("status_town_siege_status_warchest", warChest));
+						}
 
 						if(battleIsActive(siege)) {
 

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/DynmapTask.java
@@ -157,7 +157,9 @@ public class DynmapTask {
                         lines.add(Translation.of("dynmap_siege_type", siege.getSiegeType().getName()));
                         lines.add(Translation.of("dynmap_siege_balance", siege.getSiegeBalance()));
                         lines.add(Translation.of("dynmap_siege_time_left", siege.getTimeRemaining()));
-                        lines.add(Translation.of("dynmap_siege_war_chest", TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount())));
+                        if(TownyEconomyHandler.isActive()) {
+                            lines.add(Translation.of("dynmap_siege_war_chest", TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount())));
+                        }
                         lines.add(Translation.of("dynmap_siege_banner_control", siege.getBannerControllingSide().name().charAt(0) + siege.getBannerControllingSide().name().substring(1).toLowerCase()));
                         lines.add(Translation.of("dynmap_siege_battle_points", siege.getFormattedAttackerBattlePoints(), siege.getFormattedDefenderBattlePoints()));
                         lines.add(Translation.of("dynmap_siege_battle_time_left", siege.getFormattedBattleTimeRemaining()));


### PR DESCRIPTION
#### Description: 
- Adds some missing support for no-economy
  - From town screen
  - From dynmap
  - From hud
    - Note that in the PR, due to the relative complexity of supporting multiple row arrangements, 
      and because of the urgency of this ticket,   
      and because my chicken with cashew nuts is nearly here,
      we don't completely remove the warchest row,
      but rather just set it to show "-"

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
Closes #298 

____
- [N/A] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
