### PR TITLE
Added unsiegeable towns

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -210,7 +210,7 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 		try {
 			if (args[0].equalsIgnoreCase("alltowns") && !args[1].equalsIgnoreCase("permanent")) {
 				Integer.parseInt(args[1]);
-			} else if (!args[2].equalsIgnoreCase("permanent")){
+			} else if (!args[0].equalsIgnoreCase("alltowns") && !args[2].equalsIgnoreCase("permanent")){
 				Integer.parseInt(args[2]);
 			}
 		} catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
@@ -219,6 +219,7 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			return;
 		}
 
+		String timeDuration;
 		if (args.length >= 3 && args[0].equalsIgnoreCase("town")) {
 			//town {townname} {hours}
 			Town town = TownyUniverse.getInstance().getTown(args[1]);
@@ -228,14 +229,14 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			}
 			if (args[2].equalsIgnoreCase("permanent")) {
 				TownMetaDataController.setSiegeImmunityEndTime(town, -1l);
-				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_swa_town_unsiegeable_set", args[1]));
-				Messaging.sendMsg(sender, Translation.of("msg_swa_town_unsiegeable_set", args[1])); //this one
+				timeDuration = "permanent";
 			} else {
 				long durationMillis = (long)(Long.parseLong(args[2]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
 				TownMetaDataController.setSiegeImmunityEndTime(town, System.currentTimeMillis() + durationMillis);
-				TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_set_siege_immunities_town", args[1], args[2]));
-				Messaging.sendMsg(sender, Translation.of("msg_set_siege_immunities_town", args[1], args[2]));
+				timeDuration = (Long.parseLong(args[2]) == 1L) ? "1 hour" : String.format("%s hours", args[2]);
 			}
+			TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_set_siege_immunities_town", args[1], timeDuration));
+			Messaging.sendMsg(sender, Translation.of("msg_set_siege_immunities_town", args[1], timeDuration));
 		}
 		else if (args.length >= 3 && args[0].equalsIgnoreCase("nation")) {
 			//nation {nationname} {hours}
@@ -247,29 +248,33 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			long endTime;
 			if (args[2].equalsIgnoreCase("permanent")) {
 				endTime = -1l;
+				timeDuration = "permanent";
 			} else {
 				long durationMillis = (long)(Long.parseLong(args[2]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
 				endTime = System.currentTimeMillis() + durationMillis;
+				timeDuration = (Long.parseLong(args[2]) == 1L) ? "1 hour" : String.format("%s hours", args[2]);
 			}
 			for (Town town : nation.getTowns()) {
 				TownMetaDataController.setSiegeImmunityEndTime(town, endTime);
 			}
-			TownyMessaging.sendPrefixedNationMessage(nation, Translation.of("msg_set_siege_immunities_nation", args[1], args[2]));
-			Messaging.sendMsg(sender, Translation.of("msg_set_siege_immunities_nation", args[1], args[2]));
+			TownyMessaging.sendPrefixedNationMessage(nation, Translation.of("msg_set_siege_immunities_nation", args[1], timeDuration));
+			Messaging.sendMsg(sender, Translation.of("msg_set_siege_immunities_nation", args[1], timeDuration));
 
 		} else if(args.length >= 2 && args[0].equalsIgnoreCase("alltowns")) {
 			//all towns
 			long endTime;
 			if (args[1].equalsIgnoreCase("permanent")) {
 				endTime = -1l;
+				timeDuration = "permanent";
 			} else {
-				long durationMillis = (long)(Long.parseLong(args[2]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
+				long durationMillis = (long)(Long.parseLong(args[1]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
 				endTime = System.currentTimeMillis() + durationMillis;
+				timeDuration = (Long.parseLong(args[1]) == 1L) ? "1 hour" : String.format("%s hours", args[1]);
 			}
 			for (Town town : new ArrayList<>(TownyUniverse.getInstance().getTowns()))  {
 				TownMetaDataController.setSiegeImmunityEndTime(town, endTime);
 			}
-			Messaging.sendGlobalMessage(Translation.of("msg_set_siege_immunities_all", args[1]));
+			Messaging.sendGlobalMessage(Translation.of("msg_set_siege_immunities_all", timeDuration));
 
 		} else {
 			showImmunityHelp(sender);

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -251,7 +251,7 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 				Integer.parseInt(args[2]);
 			}
 		} catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
-			Messaging.sendMsg(sender, Translation.of("msg_error_must_be_num"));
+			Messaging.sendMsg(sender, Translation.of("msg_error_must_be_num_or_permanent"));
 			showSiegeImmunityHelp(sender);
 			return;
 		}
@@ -266,11 +266,11 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			}
 			if (args[2].equalsIgnoreCase("permanent")) {
 				TownMetaDataController.setSiegeImmunityEndTime(town, -1l);
-				timeDuration = "permanent";
+				timeDuration = Translation.of("msg_permanent");
 			} else {
 				long durationMillis = (long)(Long.parseLong(args[2]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
 				TownMetaDataController.setSiegeImmunityEndTime(town, System.currentTimeMillis() + durationMillis);
-				timeDuration = (Long.parseLong(args[2]) == 1L) ? "1 hour" : String.format("%s hours", args[2]);
+				timeDuration = Long.parseLong(args[2]) + com.palmergames.bukkit.towny.object.Translation.of("msg_hours");
 			}
 			TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_set_siege_immunities_town", args[1], timeDuration));
 			Messaging.sendMsg(sender, Translation.of("msg_set_siege_immunities_town", args[1], timeDuration));
@@ -285,11 +285,11 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			long endTime;
 			if (args[2].equalsIgnoreCase("permanent")) {
 				endTime = -1l;
-				timeDuration = "permanent";
+				timeDuration = Translation.of("msg_permanent");
 			} else {
 				long durationMillis = (long)(Long.parseLong(args[2]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
 				endTime = System.currentTimeMillis() + durationMillis;
-				timeDuration = (Long.parseLong(args[2]) == 1L) ? "1 hour" : String.format("%s hours", args[2]);
+				timeDuration = Long.parseLong(args[2]) + com.palmergames.bukkit.towny.object.Translation.of("msg_hours");
 			}
 			for (Town town : nation.getTowns()) {
 				TownMetaDataController.setSiegeImmunityEndTime(town, endTime);
@@ -302,11 +302,11 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			long endTime;
 			if (args[1].equalsIgnoreCase("permanent")) {
 				endTime = -1l;
-				timeDuration = "permanent";
+				timeDuration = Translation.of("msg_permanent");
 			} else {
 				long durationMillis = (long)(Long.parseLong(args[1]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
 				endTime = System.currentTimeMillis() + durationMillis;
-				timeDuration = (Long.parseLong(args[1]) == 1L) ? "1 hour" : String.format("%s hours", args[1]);
+				timeDuration = Long.parseLong(args[1]) + com.palmergames.bukkit.towny.object.Translation.of("msg_hours");
 			}
 			for (Town town : new ArrayList<>(TownyUniverse.getInstance().getTowns()))  {
 				TownMetaDataController.setSiegeImmunityEndTime(town, endTime);

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -38,7 +38,7 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 	private static final List<String> siegewaradminTabCompletes = Arrays.asList("immunity","reload","siege","town","nation");
 	private static final List<String> siegewaradminImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
 	private static final List<String> siegewaradminSiegeTabCompletes = Arrays.asList("setbalance","end","setplundered","setinvaded","remove");
-	private static final List<String> siegewaradminTownTabCompletes = Arrays.asList("setoccupier","removeoccupier","setunsiegeable");
+	private static final List<String> siegewaradminTownTabCompletes = Arrays.asList("setoccupier","removeoccupier");
 	private static final List<String> siegewaradminNationTabCompletes = Arrays.asList("setplundergained","setplunderlost","settownsgained","settownslost");
 
 	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
@@ -88,9 +88,6 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			if (args.length == 4) {
 				if (args[2].equalsIgnoreCase("setoccupier")) {
 					return getTownyStartingWith(args[3], "n");
-				}
-				if (args[2].equalsIgnoreCase("setunsiegeable")) {
-					return Arrays.asList("true","false");
 				}
 			}
 		case "nation":

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -154,9 +154,9 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 	private void showHelp(CommandSender sender) {
 		sender.sendMessage(ChatTools.formatTitle("/siegewaradmin"));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "reload", Translation.of("admin_help_1")));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity town [town_name] [hours]", ""));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity nation [nation_name] [hours]", ""));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity alltowns [hours]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity town [town_name] [hours|permanent]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity nation [nation_name] [hours|permanent]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity alltowns [hours|permanent]", ""));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siege [town_name] setbalance [points]", ""));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siege [town_name] end", ""));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siege [town_name] setplundered [true/false]", ""));
@@ -183,7 +183,6 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 		sender.sendMessage(ChatTools.formatTitle("/swa town"));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "town [town_name] setoccupier [town]", ""));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "town [town_name] removeoccupier", ""));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "town [town_name] setunsiegeable", ""));
 	}
 
 	private void showNationHelp(CommandSender sender) {

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -229,7 +229,7 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			}
 			if (args[2].equalsIgnoreCase("permanent")) {
 				TownMetaDataController.setSiegeImmunityEndTime(town, -1l);
-				timeDuration = "permanent";
+				timeDuration = Translation.of("msg_permanent");
 			} else {
 				long durationMillis = (long)(Long.parseLong(args[2]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
 				TownMetaDataController.setSiegeImmunityEndTime(town, System.currentTimeMillis() + durationMillis);
@@ -248,7 +248,7 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			long endTime;
 			if (args[2].equalsIgnoreCase("permanent")) {
 				endTime = -1l;
-				timeDuration = "permanent";
+				timeDuration = Translation.of("msg_permanent");
 			} else {
 				long durationMillis = (long)(Long.parseLong(args[2]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
 				endTime = System.currentTimeMillis() + durationMillis;
@@ -265,7 +265,7 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			long endTime;
 			if (args[1].equalsIgnoreCase("permanent")) {
 				endTime = -1l;
-				timeDuration = "permanent";
+				timeDuration = Translation.of("msg_permanent");
 			} else {
 				long durationMillis = (long)(Long.parseLong(args[1]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
 				endTime = System.currentTimeMillis() + durationMillis;

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -38,7 +38,7 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 	private static final List<String> siegewaradminTabCompletes = Arrays.asList("immunity","reload","siege","town","nation");
 	private static final List<String> siegewaradminImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
 	private static final List<String> siegewaradminSiegeTabCompletes = Arrays.asList("setbalance","end","setplundered","setinvaded","remove");
-	private static final List<String> siegewaradminTownTabCompletes = Arrays.asList("setoccupier","removeoccupier");
+	private static final List<String> siegewaradminTownTabCompletes = Arrays.asList("setoccupier","removeoccupier","setunsiegeable");
 	private static final List<String> siegewaradminNationTabCompletes = Arrays.asList("setplundergained","setplunderlost","settownsgained","settownslost");
 
 	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
@@ -88,6 +88,9 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			if (args.length == 4) {
 				if (args[2].equalsIgnoreCase("setoccupier")) {
 					return getTownyStartingWith(args[3], "n");
+				}
+				if (args[2].equalsIgnoreCase("setunsiegeable")) {
+					return Arrays.asList("true","false");
 				}
 			}
 		case "nation":
@@ -183,6 +186,7 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 		sender.sendMessage(ChatTools.formatTitle("/swa town"));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "town [town_name] setoccupier [town]", ""));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "town [town_name] removeoccupier", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "town [town_name] setunsiegeable", ""));
 	}
 
 	private void showNationHelp(CommandSender sender) {
@@ -382,6 +386,15 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 					TownOccupationController.removeTownOccupation(town);
 					Messaging.sendMsg(sender, Translation.of("msg_swa_town_occupation_removal_success", town.getName()));
 					break;
+
+				case "setunsiegeable":
+					/*
+					 * This handles setting a town as unsiegeable
+					 */
+					Boolean unsiegeable = Boolean.parseBoolean(args[2]);
+					TownMetaDataController.setUnsiegeable(town, unsiegeable);
+					Messaging.sendMsg(sender, Translation.of("msg_swa_town_unsiegeable_set", unsiegeable, town.getName()));
+
 			}
 		} else
 			showTownHelp(sender);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -342,7 +342,6 @@ public class SiegeWarTownEventListener implements Listener {
 				Siege siege = SiegeController.getSiege(town);
 				SiegeStatus siegeStatus= siege.getStatus();
 				String time = TimeMgmt.getFormattedTimeValue(TownMetaDataController.getSiegeImmunityEndTime(town)- System.currentTimeMillis());
-
 				//Siege:
 				out.add(Translation.of("status_town_siege"));
 
@@ -436,11 +435,17 @@ public class SiegeWarTownEventListener implements Listener {
 	            }
 	        } else {
 	            if(!SiegeController.hasActiveSiege(town)
-	            	&& System.currentTimeMillis() < TownMetaDataController.getSiegeImmunityEndTime(town)) {
+	            	&& (System.currentTimeMillis() < TownMetaDataController.getSiegeImmunityEndTime(town)
+					|| TownMetaDataController.getSiegeImmunityEndTime(town) == -1l)) {
 	                //Siege:
 	                // > Immunity Timer: 40.8 hours
 	                out.add(Translation.of("status_town_siege"));
-	                String time = TimeMgmt.getFormattedTimeValue(TownMetaDataController.getSiegeImmunityEndTime(town)- System.currentTimeMillis()); 
+					String time;
+	                if (TownMetaDataController.getSiegeImmunityEndTime(town) != -1l) {
+						time = TimeMgmt.getFormattedTimeValue(TownMetaDataController.getSiegeImmunityEndTime(town)- System.currentTimeMillis());
+					} else {
+	                	time = "Permanent";
+					}
 	                out.add(Translation.of("status_town_siege_immunity_timer", time));
 	            }
 	        }

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -341,7 +341,12 @@ public class SiegeWarTownEventListener implements Listener {
 	        if (SiegeController.hasSiege(town)) {
 				Siege siege = SiegeController.getSiege(town);
 				SiegeStatus siegeStatus= siege.getStatus();
-				String time = TimeMgmt.getFormattedTimeValue(TownMetaDataController.getSiegeImmunityEndTime(town)- System.currentTimeMillis());
+				String time;
+				if (TownMetaDataController.getSiegeImmunityEndTime(town) != -1l) {
+					time = TimeMgmt.getFormattedTimeValue(TownMetaDataController.getSiegeImmunityEndTime(town)- System.currentTimeMillis());
+				} else {
+					time = "Permanent";
+				}
 				//Siege:
 				out.add(Translation.of("status_town_siege"));
 

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
@@ -22,6 +22,7 @@ public class TownMetaDataController {
 	private static LongDataField revoltImmunityEndTime = new LongDataField("siegewar_revoltImmunityEndTime", 0l);
 	private static LongDataField siegeImmunityEndTime = new LongDataField("siegewar_siegeImmunityEndTime", 0l);
 	private static StringDataField occupyingNationUUID = new StringDataField("siegewar_occupyingNationUUID", "");
+	private static BooleanDataField unsiegeable = new BooleanDataField("siegewar_unsiegeable", false);
 	//The nation who was the occupier prior to peacefulness confirmation
 	private static StringDataField prePeacefulOccupierUUID = new StringDataField("siegewar_prePeacefulOccupierUUID", "");
 
@@ -64,6 +65,23 @@ public class TownMetaDataController {
 			MetaDataUtil.setBoolean(town, bdf, bool);
 		} else {
 			town.addMetaData(new BooleanDataField("siegewar_desiredPeaceSetting", bool));
+		}
+	}
+
+	public static boolean getUnsiegeable(Town town) {
+		BooleanDataField bdf = (BooleanDataField) unsiegeable.clone();
+		if(town.hasMeta(bdf.getKey())) {
+			return MetaDataUtil.getBoolean(town, bdf);
+		}
+		return false;
+	}
+
+	public static void setUnsiegeable(Town town, boolean bool) {
+		BooleanDataField bdf = (BooleanDataField) unsiegeable.clone();
+		if(town.hasMeta(bdf.getKey())) {
+			MetaDataUtil.setBoolean(town, bdf, bool);
+		} else {
+			town.addMetaData(new BooleanDataField("siegewar_unsiegeable", bool));
 		}
 	}
 	

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
@@ -22,7 +22,6 @@ public class TownMetaDataController {
 	private static LongDataField revoltImmunityEndTime = new LongDataField("siegewar_revoltImmunityEndTime", 0l);
 	private static LongDataField siegeImmunityEndTime = new LongDataField("siegewar_siegeImmunityEndTime", 0l);
 	private static StringDataField occupyingNationUUID = new StringDataField("siegewar_occupyingNationUUID", "");
-	private static BooleanDataField unsiegeable = new BooleanDataField("siegewar_unsiegeable", false);
 	//The nation who was the occupier prior to peacefulness confirmation
 	private static StringDataField prePeacefulOccupierUUID = new StringDataField("siegewar_prePeacefulOccupierUUID", "");
 
@@ -65,23 +64,6 @@ public class TownMetaDataController {
 			MetaDataUtil.setBoolean(town, bdf, bool);
 		} else {
 			town.addMetaData(new BooleanDataField("siegewar_desiredPeaceSetting", bool));
-		}
-	}
-
-	public static boolean getUnsiegeable(Town town) {
-		BooleanDataField bdf = (BooleanDataField) unsiegeable.clone();
-		if(town.hasMeta(bdf.getKey())) {
-			return MetaDataUtil.getBoolean(town, bdf);
-		}
-		return false;
-	}
-
-	public static void setUnsiegeable(Town town, boolean bool) {
-		BooleanDataField bdf = (BooleanDataField) unsiegeable.clone();
-		if(town.hasMeta(bdf.getKey())) {
-			MetaDataUtil.setBoolean(town, bdf, bool);
-		} else {
-			town.addMetaData(new BooleanDataField("siegewar_unsiegeable", bool));
 		}
 	}
 	

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -226,14 +226,13 @@ public class PlaceBlock {
 														   Block bannerBlock) throws TownyException {
 
 		//Check whether nearby town has a current or recent siege or is unsiegeable altogether
-		if (TownMetaDataController.getUnsiegeable(nearbyTown)) {
+		if (TownMetaDataController.getSiegeImmunityEndTime(nearbyTown) == -1l) {
 			throw new TownyException(Translation.of("msg_err_cannot_start_siege_at_unsiegeable_town"));
 		} else if (SiegeController.hasSiege(nearbyTown)) {
 			//If there is no siege, it is an attempt to invade the town
 			Siege siege = SiegeController.getSiege(nearbyTown);
 			InvadeTown.processInvadeTownRequest(player, residentsNation, nearbyTown, siege);
-		}
-		else {
+		} else {
 			//If there is no siege, it is an attempt to start a new siege
 			evaluateStartNewSiegeAttempt(player, residentsTown, residentsNation, nearbyTownBlock, nearbyTown, bannerBlock);
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -225,12 +225,15 @@ public class PlaceBlock {
 														   Town nearbyTown,
 														   Block bannerBlock) throws TownyException {
 
-		//Check whether nearby town has a current or recent siege
-		if (SiegeController.hasSiege(nearbyTown)) {
+		//Check whether nearby town has a current or recent siege or is unsiegeable altogether
+		if (TownMetaDataController.getUnsiegeable(nearbyTown)) {
+			throw new TownyException(Translation.of("msg_err_cannot_start_siege_at_unsiegeable_town"));
+		} else if (SiegeController.hasSiege(nearbyTown)) {
 			//If there is no siege, it is an attempt to invade the town
 			Siege siege = SiegeController.getSiege(nearbyTown);
 			InvadeTown.processInvadeTownRequest(player, residentsNation, nearbyTown, siege);
-		} else {
+		}
+		else {
 			//If there is no siege, it is an attempt to start a new siege
 			evaluateStartNewSiegeAttempt(player, residentsTown, residentsNation, nearbyTownBlock, nearbyTown, bannerBlock);
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -225,10 +225,8 @@ public class PlaceBlock {
 														   Town nearbyTown,
 														   Block bannerBlock) throws TownyException {
 
-		//Check whether nearby town has a current or recent siege or is unsiegeable altogether
-		if (TownMetaDataController.getSiegeImmunityEndTime(nearbyTown) == -1l) {
-			throw new TownyException(Translation.of("msg_err_cannot_start_siege_at_unsiegeable_town"));
-		} else if (SiegeController.hasSiege(nearbyTown)) {
+		//Check whether nearby town has a current or recent siege
+		if (SiegeController.hasSiege(nearbyTown)) {
 			//If there is no siege, it is an attempt to invade the town
 			Siege siege = SiegeController.getSiege(nearbyTown);
 			InvadeTown.processInvadeTownRequest(player, residentsNation, nearbyTown, siege);
@@ -270,7 +268,8 @@ public class PlaceBlock {
 			if (residentsNation == null)
 				throw new TownyException(Translation.of("msg_err_action_disable"));
 
-			if (System.currentTimeMillis() < TownMetaDataController.getSiegeImmunityEndTime(nearbyTown))
+			if (System.currentTimeMillis() < TownMetaDataController.getSiegeImmunityEndTime(nearbyTown)
+			|| TownMetaDataController.getSiegeImmunityEndTime(nearbyTown) == -1l)
 				throw new TownyException(Translation.of("msg_err_cannot_start_siege_due_to_siege_immunity"));
 
 			if (TownyEconomyHandler.isActive() && !residentsNation.getAccount().canPayFromHoldings(SiegeWarMoneyUtil.calculateSiegeCost(nearbyTown)))

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -112,11 +112,6 @@ msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident: '&cUnable to
 msg_war_siege_peaceful_player_punished_for_being_in_siegezone: '&cWar-allergy active. To remove this effect, leave the siege-zone immediately.'
 msg_war_siege_err_cannot_attack_peaceful_town: '&cYou cannot attack a peaceful town.'
 
-#Siege immunities
-msg_set_siege_immunities_town: 'Siege immunity for town %s set to %s.'
-msg_set_siege_immunities_nation: 'Siege immunities for all towns in nation %s set to %s.'
-msg_set_siege_immunities_all: 'Siege immunities for all towns set to %s.'
-
 #Siege-zone block placement restrictions
 msg_war_siege_zone_block_placement_forbidden: '&cYou cannot place this type of block in the wilderness area of a siege zone.'
 msg_war_siege_zone_bucket_emptying_forbidden: '&cYou cannot use this type of bucket in the wilderness area of a siege zone.'
@@ -460,3 +455,8 @@ msg_set_revolt_immunities_all: 'Revolt immunities for all towns set to %s hours.
 #Unsiegeable towns strings
 msg_permanent: "permanent"
 msg_error_must_be_num_or_permanent: '&cAmount must be a number or ''permanent''.'
+
+#Siege immunities
+msg_set_siege_immunities_town: 'Siege immunity for town %s set to %s.'
+msg_set_siege_immunities_nation: 'Siege immunities for all towns in nation %s set to %s.'
+msg_set_siege_immunities_all: 'Siege immunities for all towns set to %s.'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -113,9 +113,9 @@ msg_war_siege_peaceful_player_punished_for_being_in_siegezone: '&cWar-allergy ac
 msg_war_siege_err_cannot_attack_peaceful_town: '&cYou cannot attack a peaceful town.'
 
 #Siege immunities
-msg_set_siege_immunities_town: 'Siege immunity for town %s set to %s hours.'
-msg_set_siege_immunities_nation: 'Siege immunities for all towns in nation %s set to %s hours.'
-msg_set_siege_immunities_all: 'Siege immunities for all towns set to %s hours.'
+msg_set_siege_immunities_town: 'Siege immunity for town %s set to %s.'
+msg_set_siege_immunities_nation: 'Siege immunities for all towns in nation %s set to %s.'
+msg_set_siege_immunities_all: 'Siege immunities for all towns set to %s.'
 
 #Siege-zone block placement restrictions
 msg_war_siege_zone_block_placement_forbidden: '&cYou cannot place this type of block in the wilderness area of a siege zone.'
@@ -251,8 +251,8 @@ msg_siege_war_banner_control_session_failure: '&cBanner control session failed!.
 msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going below the altitude of the banner, going into the town, or flying.'
 
 #Unsiegeable towns strings
-msg_swa_town_unsiegeable_set: "&bSuccessfully set town %s as unsiegeable"
-msg_err_cannot_start_siege_at_unsiegeable_town: "&cCannot start siege at an unsiegeable town"
+msg_swa_town_unsiegeable_set: "&bSuccessfully set town %s as unsiegeable."
+msg_err_cannot_start_siege_at_unsiegeable_town: "&cCannot start siege at an unsiegeable town."
 
 ##### Added in 0.15
 

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -251,9 +251,8 @@ msg_siege_war_banner_control_session_failure: '&cBanner control session failed!.
 msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going below the altitude of the banner, going into the town, or flying.'
 
 #Unsiegeable towns strings
-msg_swa_town_unsiegeable_set: "&bSuccessfully set town %s as unsiegeable."
-msg_err_cannot_start_siege_at_unsiegeable_town: "&cCannot start siege at an unsiegeable town."
 msg_permanent: "permanent"
+msg_error_must_be_num_or_permanent: '&cAmount must be a number or ''permanent''.'
 
 ##### Added in 0.15
 

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -250,8 +250,8 @@ msg_siege_war_banner_control_session_started_with_altitude: '&bBanner control se
 msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going into the town, or flying.'
 msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going below the altitude of the banner, going into the town, or flying.'
 
-#Added in poilet fork
-msg_swa_town_unsiegeable_set: "&bSuccessfully set town unsiegeable to %s for %s"
+#Unsiegeable towns strings
+msg_swa_town_unsiegeable_set: "&bSuccessfully set town %s as unsiegeable"
 msg_err_cannot_start_siege_at_unsiegeable_town: "&cCannot start siege at an unsiegeable town"
 
 ##### Added in 0.15

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -253,6 +253,7 @@ msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control se
 #Unsiegeable towns strings
 msg_swa_town_unsiegeable_set: "&bSuccessfully set town %s as unsiegeable."
 msg_err_cannot_start_siege_at_unsiegeable_town: "&cCannot start siege at an unsiegeable town."
+msg_permanent: "permanent"
 
 ##### Added in 0.15
 

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -250,6 +250,10 @@ msg_siege_war_banner_control_session_started_with_altitude: '&bBanner control se
 msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going into the town, or flying.'
 msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going below the altitude of the banner, going into the town, or flying.'
 
+#Added in poilet fork
+msg_swa_town_unsiegeable_set: "&bSuccessfully set town unsiegeable to %s for %s"
+msg_err_cannot_start_siege_at_unsiegeable_town: "&cCannot start siege at an unsiegeable town"
+
 ##### Added in 0.15
 
 # Town Merging

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.22
+version: 0.23
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -250,10 +250,6 @@ msg_siege_war_banner_control_session_started_with_altitude: '&bBanner control se
 msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going into the town, or flying.'
 msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going below the altitude of the banner, going into the town, or flying.'
 
-#Unsiegeable towns strings
-msg_permanent: "permanent"
-msg_error_must_be_num_or_permanent: '&cAmount must be a number or ''permanent''.'
-
 ##### Added in 0.15
 
 # Town Merging
@@ -458,3 +454,9 @@ msg_invite_occupation_success: '&bThe town %s has come under the occupation of %
 msg_set_revolt_immunities_town: 'Revolt immunity for town %s set to %s hours.'
 msg_set_revolt_immunities_nation: 'Revolt immunities for all towns in nation %s set to %s hours.'
 msg_set_revolt_immunities_all: 'Revolt immunities for all towns set to %s hours.'
+
+#Added in 0.23
+
+#Unsiegeable towns strings
+msg_permanent: "permanent"
+msg_error_must_be_num_or_permanent: '&cAmount must be a number or ''permanent''.'


### PR DESCRIPTION
Adds an unsiegeable flag to towns, run the following command to toggle unsiegeability:
/swa town <town> setunsiegeable <true|false>

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

So that admins can easier create admin towns that are unsiegeable and just toggle this setting, rather than having to unecessarily give large amounts of immunity timer.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

2 new lines in english.yml that'll need translating, they can be found under the names:
msg_swa_town_unsiegeable_set and msg_err_cannot_start_siege_at_unsiegeable_town

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
