### PR TITLE
Adds "axolotl_bucket" as default option in config.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -549,7 +549,7 @@ public enum ConfigNodes {
 			"# This setting is useful to help prevent extreme siege-zone grief such as obsidian forts or cobble monsters."),
 	WAR_SIEGE_ZONE_BUCKET_EMPTYING_RESTRICTIONS_MATERIALS(
 			"war.siege.zone_bucket_usage_restrictions.materials",
-			"lava_bucket, water_bucket, cod_bucket, pufferfish_bucket, salmon_bucket, tropical_fish_bucket",
+			"lava_bucket, water_bucket, cod_bucket, pufferfish_bucket, salmon_bucket, tropical_fish_bucket, axolotl_bucket",
 			"",
 			"# This setting is used to indicate the list of forbidden buckets"),
 	WAR_SIEGE_MAP_HIDING(


### PR DESCRIPTION

#### Description: 
Fresh SiegeWar builds in 1.17+ do not have axolotl buckets accounted for by default, which allows users to place water (and a cute little axolotl) in the middle of a war siege zone. 

This simply just adds "axolotl_bucket" to default WAR_SIEGE_ZONE_BUCKET_EMPTYING_RESTRICTIONS_MATERIALS
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
Adds "axolotl_bucket" to default WAR_SIEGE_ZONE_BUCKET_EMPTYING_RESTRICTIONS_MATERIALS
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [X] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
