### PR TITLE
Add ice to blocks list

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -537,7 +537,7 @@ public enum ConfigNodes {
 			"# This setting is useful to help prevent extreme siege-zone grief such as obsidian forts."),
 	WAR_SIEGE_ZONE_BLOCK_PLACEMENT_RESTRICTIONS_MATERIALS(
 			"war.siege.zone_block_placement_restrictions.materials",
-			"obsidian",
+			"obsidian, ice, blue_ice",
 			"",
 			"# This setting is used to indicate the list of forbidden materials",
 			"# WARNING: Avoid putting 'common' blocks on this list as that may cause lag."),

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -537,7 +537,7 @@ public enum ConfigNodes {
 			"# This setting is useful to help prevent extreme siege-zone grief such as obsidian forts."),
 	WAR_SIEGE_ZONE_BLOCK_PLACEMENT_RESTRICTIONS_MATERIALS(
 			"war.siege.zone_block_placement_restrictions.materials",
-			"obsidian, ice, blue_ice",
+			"obsidian, ice",
 			"",
 			"# This setting is used to indicate the list of forbidden materials",
 			"# WARNING: Avoid putting 'common' blocks on this list as that may cause lag."),


### PR DESCRIPTION
#### Description: 
- Players can melt ice in siegezone to get water, which is not popular in siegezones on most servers.
- This PR adds ice to the default siegezone forbidden block list.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
