### PR TITLE
Sw 314 Added "/swa revoltimmunity" command

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 
-	private static final List<String> siegewaradminTabCompletes = Arrays.asList("immunity","reload","siege","town","nation");
+	private static final List<String> siegewaradminTabCompletes = Arrays.asList("siegeimmunity","revoltimmunity","reload","siege","town","nation");
 	private static final List<String> siegewaradminSiegeImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
 	private static final List<String> siegewaradminRevoltImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
 	private static final List<String> siegewaradminSiegeTabCompletes = Arrays.asList("setbalance","end","setplundered","setinvaded","remove");
@@ -176,14 +176,22 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 	private void showHelp(CommandSender sender) {
 		sender.sendMessage(ChatTools.formatTitle("/siegewaradmin"));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "reload", Translation.of("admin_help_1")));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity town [town_name] [hours]", ""));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity nation [nation_name] [hours]", ""));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity alltowns [hours]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siegeimmunity town [town_name] [hours]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siegeimmunity nation [nation_name] [hours]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siegeimmunity alltowns [hours]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "revoltimmunity town [town_name] [hours]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "revoltimmunity nation [nation_name] [hours]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "revoltimmunity alltowns [hours]", ""));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siege [town_name] setbalance [points]", ""));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siege [town_name] end", ""));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siege [town_name] setplundered [true/false]", ""));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siege [town_name] remove", ""));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "town [town_name] setcaptured [true/false]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "town [town_name] setoccupier [town]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "town [town_name] removeoccupier", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "nation [nation_name] setplundergained [amount]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "nation [nation_name] setplunderlost [amount]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "nation [nation_name] settownsgained [amount]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "nation [nation_name] settownslost [amount]", ""));
 	}
 	
 	private void showSiegeImmunityHelp(CommandSender sender) {

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -13,7 +13,6 @@ import com.gmail.goosius.siegewar.settings.Settings;
 import com.gmail.goosius.siegewar.settings.Translation;
 import com.gmail.goosius.siegewar.timeractions.AttackerTimedWin;
 import com.gmail.goosius.siegewar.timeractions.DefenderTimedWin;
-import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -36,7 +35,8 @@ import java.util.List;
 public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 
 	private static final List<String> siegewaradminTabCompletes = Arrays.asList("immunity","reload","siege","town","nation");
-	private static final List<String> siegewaradminImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
+	private static final List<String> siegewaradminSiegeImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
+	private static final List<String> siegewaradminRevoltImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
 	private static final List<String> siegewaradminSiegeTabCompletes = Arrays.asList("setbalance","end","setplundered","setinvaded","remove");
 	private static final List<String> siegewaradminTownTabCompletes = Arrays.asList("setoccupier","removeoccupier");
 	private static final List<String> siegewaradminNationTabCompletes = Arrays.asList("setplundergained","setplunderlost","settownsgained","settownslost");
@@ -44,9 +44,9 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
 
 		switch (args[0].toLowerCase()) {
-		case "immunity":
+		case "siegeimmunity":
 			if (args.length == 2)
-				return NameUtil.filterByStart(siegewaradminImmunityTabCompletes, args[1]);
+				return NameUtil.filterByStart(siegewaradminSiegeImmunityTabCompletes, args[1]);
 			
 			if (args.length == 3) {
 				switch (args[1].toLowerCase()) {
@@ -59,6 +59,25 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 				}
 			}
 			
+			if (args.length == 4) {
+				if (args[1].equalsIgnoreCase("town") || args[1].equalsIgnoreCase("nation"))
+					return Arrays.asList("0","1","2","3","4","5","6");
+			}
+		case "revoltimmunity":
+			if (args.length == 2)
+				return NameUtil.filterByStart(siegewaradminRevoltImmunityTabCompletes, args[1]);
+
+			if (args.length == 3) {
+				switch (args[1].toLowerCase()) {
+				case "town":
+					return getTownyStartingWith(args[2], "t");
+				case "nation":
+					return getTownyStartingWith(args[2], "n");
+				case "alltowns":
+					return Arrays.asList("0","1","2","3","4","5","6");
+				}
+			}
+
 			if (args.length == 4) {
 				if (args[1].equalsIgnoreCase("town") || args[1].equalsIgnoreCase("nation"))
 					return Arrays.asList("0","1","2","3","4","5","6");
@@ -122,8 +141,11 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			case "reload":
 				parseSiegeWarReloadCommand(sender);
 				break;
-			case "immunity":
-				parseSiegeWarImmunityCommand(sender, StringMgmt.remFirstArg(args));
+			case "siegeimmunity":
+				parseSiegeWarSiegeImmunityCommand(sender, StringMgmt.remFirstArg(args));
+				break;
+			case "revoltimmunity":
+				parseSiegeWarRevoltImmunityCommand(sender, StringMgmt.remFirstArg(args));
 				break;
 			case "siege":
 				parseSiegeWarSiegeCommand(sender, StringMgmt.remFirstArg(args));
@@ -164,11 +186,18 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "town [town_name] setcaptured [true/false]", ""));
 	}
 	
-	private void showImmunityHelp(CommandSender sender) {
-		sender.sendMessage(ChatTools.formatTitle("/swa immunity"));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity town [town_name] [hours]", ""));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity nation [nation_name] [hours]", ""));
-		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "immunity alltowns [hours]", ""));
+	private void showSiegeImmunityHelp(CommandSender sender) {
+		sender.sendMessage(ChatTools.formatTitle("/swa siegeimmunity"));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siegeimmunity town [town_name] [hours]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siegeimmunity nation [nation_name] [hours]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "siegeimmunity alltowns [hours]", ""));
+	}
+
+	private void showRevoltImmunityHelp(CommandSender sender) {
+		sender.sendMessage(ChatTools.formatTitle("/swa revoltimmunity"));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "revoltimmunity town [town_name] [hours]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "revoltimmunity nation [nation_name] [hours]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/swa", "revoltimmunity alltowns [hours]", ""));
 	}
 
 	private void showSiegeHelp(CommandSender sender) {
@@ -202,9 +231,9 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 		Messaging.sendErrorMsg(sender, Translation.of("config_and_lang_file_could_not_be_loaded"));
 	}
 
-	private void parseSiegeWarImmunityCommand(CommandSender sender, String[] args) {
+	private void parseSiegeWarSiegeImmunityCommand(CommandSender sender, String[] args) {
 		if (args.length < 2) {
-			showImmunityHelp(sender);
+			showSiegeImmunityHelp(sender);
 			return;
 		}
 
@@ -215,7 +244,7 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 				Integer.parseInt(args[2]);
 		} catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
 			Messaging.sendMsg(sender, Translation.of("msg_error_must_be_num"));
-			showImmunityHelp(sender);
+			showSiegeImmunityHelp(sender);
 			return;
 		}
 
@@ -254,7 +283,63 @@ public class SiegeWarAdminCommand implements CommandExecutor, TabCompleter {
 			Messaging.sendGlobalMessage(Translation.of("msg_set_siege_immunities_all", args[1]));
 
 		} else {
-			showImmunityHelp(sender);
+			showSiegeImmunityHelp(sender);
+		}
+	}
+
+	private void parseSiegeWarRevoltImmunityCommand(CommandSender sender, String[] args) {
+		if (args.length < 2) {
+			showRevoltImmunityHelp(sender);
+			return;
+		}
+
+		try {
+			if (args[0].equalsIgnoreCase("alltowns"))
+				Integer.parseInt(args[1]);
+			else
+				Integer.parseInt(args[2]);
+		} catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+			Messaging.sendMsg(sender, Translation.of("msg_error_must_be_num"));
+			showRevoltImmunityHelp(sender);
+			return;
+		}
+
+		if (args.length >= 3 && args[0].equalsIgnoreCase("town")) {
+			//town {townname} {hours}
+			Town town = TownyUniverse.getInstance().getTown(args[1]);
+			if (town == null) {
+				Messaging.sendErrorMsg(sender, Translation.of("msg_err_not_registered_1", args[1]));
+				return;
+			}
+			long durationMillis = (long)(Long.parseLong(args[2]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
+			TownMetaDataController.setRevoltImmunityEndTime(town, System.currentTimeMillis() + durationMillis);
+			TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_set_revolt_immunities_town", args[1], args[2]));
+			Messaging.sendMsg(sender, Translation.of("msg_set_revolt_immunities_town", args[1], args[2]));
+
+		} else if (args.length >= 3 && args[0].equalsIgnoreCase("nation")) {
+			//nation {nationname} {hours}
+			Nation nation = TownyUniverse.getInstance().getNation(args[1]);
+			if (nation == null) {
+				Messaging.sendErrorMsg(sender, Translation.of("msg_err_not_registered_1", args[1]));
+				return;
+			}
+			long durationMillis = (long)(Long.parseLong(args[2]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
+			for (Town town : nation.getTowns()) {
+				TownMetaDataController.setRevoltImmunityEndTime(town, System.currentTimeMillis() + durationMillis);
+			}
+			TownyMessaging.sendPrefixedNationMessage(nation, Translation.of("msg_set_revolt_immunities_nation", args[1], args[2]));
+			Messaging.sendMsg(sender, Translation.of("msg_set_revolt_immunities_nation", args[1], args[2]));
+
+		} else if(args.length >= 2 && args[0].equalsIgnoreCase("alltowns")) {
+			//all towns
+			long durationMillis = (long)(Long.parseLong(args[1]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
+			for (Town town : new ArrayList<>(TownyUniverse.getInstance().getTowns()))  {
+				TownMetaDataController.setRevoltImmunityEndTime(town, System.currentTimeMillis() + durationMillis);
+			}
+			Messaging.sendGlobalMessage(Translation.of("msg_set_revolt_immunities_all", args[1]));
+
+		} else {
+			showRevoltImmunityHelp(sender);
 		}
 	}
 

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.21
+version: 0.22
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -447,3 +447,10 @@ msg_err_cannot_invite_occupation_town_already_occupied: '&cYou cannot invite occ
 msg_err_cannot_invite_occupation_king_not_online: "&cThe occupation-invitation failed because the king of %s (%s) is not online."
 msg_would_you_accept_town_request_for_occupation: '&6Would you agree to occupy %s?. This will cause the town to become occupied by your nation.'
 msg_invite_occupation_success: '&bThe town %s has come under the occupation of %s, by its own request.'
+
+# Added in 0.22
+
+#Revolt immunities
+msg_set_revolt_immunities_town: 'Revolt immunity for town %s set to %s hours.'
+msg_set_revolt_immunities_nation: 'Revolt immunities for all towns in nation %s set to %s hours.'
+msg_set_revolt_immunities_all: 'Revolt immunities for all towns set to %s hours.'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.21
+version: 0.22
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -458,3 +458,10 @@ msg_err_cannot_invite_occupation_town_already_occupied: '&cYou cannot invite occ
 msg_err_cannot_invite_occupation_king_not_online: "&cThe occupation-invitation failed because the king of %s (%s) is not online."
 msg_would_you_accept_town_request_for_occupation: '&6Would you agree to occupy %s?. This will cause the town to become occupied by your nation.'
 msg_invite_occupation_success: '&bThe town %s has come under the occupation of %s, by its own request.'
+
+# Added in 0.22
+
+#Revolt immunities
+msg_set_revolt_immunities_town: 'Revolt immunity for town %s set to %s hours.'
+msg_set_revolt_immunities_nation: 'Revolt immunities for all towns in nation %s set to %s hours.'
+msg_set_revolt_immunities_all: 'Revolt immunities for all towns set to %s hours.'


### PR DESCRIPTION
#### Description: 
- Added `/swa revoltimmunity` command, which is used for setting revolt immunity on towns
- Renamed swa-set-siege-immunity command from `/swa immunity` to `/swa siegeimmunity`
- Added some commands which were missing from the generic /swa help list
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
Closes #314 

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
