### PR TITLE
Add option to disable player glowing

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -184,13 +184,15 @@ public class SiegeWarBukkitEventListener implements Listener {
 
 	@EventHandler
 	public void onPlayerQuit(PlayerQuitEvent event) {
-		if (SiegeController.getPlayersInBannerControlSessions().contains(event.getPlayer()) && event.getPlayer().hasPotionEffect(PotionEffectType.GLOWING)) {
-			Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
-				@Override
-				public void run() {
-					event.getPlayer().removePotionEffect(PotionEffectType.GLOWING);
-				}
-			});
+		if (SiegeWarSettings.getWarSiegeEnablePlayerGlowing()) {
+			if (SiegeController.getPlayersInBannerControlSessions().contains(event.getPlayer()) && event.getPlayer().hasPotionEffect(PotionEffectType.GLOWING)) {
+				Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
+					@Override
+					public void run() {
+						event.getPlayer().removePotionEffect(PotionEffectType.GLOWING);
+					}
+				});
+			}
 		}
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -178,6 +178,11 @@ public enum ConfigNodes {
 			"# NOTE: ",
 			"# If you enable this feature, ",
 			"# make sure to also have a server rule preventing traps being created in the timed-point-zone BEFORE the banner is placed"),
+	WAR_SIEGE_ENABLE_PLAYER_GLOWING(
+			"war.siege.switches.enable_player_glowing",
+			"true",
+			"",
+			"# If the setting is true, players starting banner control session will acquire glow effect."),
 	WAR_SIEGE_DEATH_PENALTY_KEEP_INVENTORY_ENABLED(
 			"war.siege.switches.keep_inventory_on_siege_death",
 			"true",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -184,6 +184,10 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_BESIEGED_TOWN_UNCLAIMING_DISABLED);
 	}
 
+	public static boolean getWarSiegeEnablePlayerGlowing() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_ENABLE_PLAYER_GLOWING);
+	}
+
 	public static boolean getWarSiegeDeathPenaltyKeepInventoryEnabled() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_DEATH_PENALTY_KEEP_INVENTORY_ENABLED);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -115,15 +115,17 @@ public class SiegeWarBannerControlUtil {
 		CosmeticUtil.evaluateBeacon(player, siege);
 
 		//Make player glow (which also shows them a timer)
-		int effectDurationSeconds = (SiegeWarSettings.getWarSiegeBannerControlSessionDurationMinutes() * 60) + (int)TownySettings.getShortInterval(); 
-		final int effectDurationTicks = (int)(TimeTools.convertToTicks(effectDurationSeconds));
-		Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
-			public void run() {
-				List<PotionEffect> potionEffects = new ArrayList<>();
-				potionEffects.add(new PotionEffect(PotionEffectType.GLOWING, effectDurationTicks, 0));
-				player.addPotionEffects(potionEffects);
-			}
-		});
+		if (SiegeWarSettings.getWarSiegeEnablePlayerGlowing()) {
+			int effectDurationSeconds = (SiegeWarSettings.getWarSiegeBannerControlSessionDurationMinutes() * 60) + (int) TownySettings.getShortInterval();
+			final int effectDurationTicks = (int) (TimeTools.convertToTicks(effectDurationSeconds));
+			Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
+				public void run() {
+					List<PotionEffect> potionEffects = new ArrayList<>();
+					potionEffects.add(new PotionEffect(PotionEffectType.GLOWING, effectDurationTicks, 0));
+					player.addPotionEffects(potionEffects);
+				}
+			});
+		}
 
 		//If this is a switching session, notify participating nations/towns
 		if(siegeSide != siege.getBannerControllingSide()) {
@@ -193,14 +195,16 @@ public class SiegeWarBannerControlUtil {
 					Messaging.sendMsg(bannerControlSession.getPlayer(), errorMessage);
 					CosmeticUtil.evaluateBeacon(bannerControlSession.getPlayer(), siege);
 
-					if (bannerControlSession.getPlayer().hasPotionEffect(PotionEffectType.GLOWING)) {
-						Towny.getPlugin().getServer().getScheduler().scheduleSyncDelayedTask(Towny.getPlugin(), new Runnable() {
-							public void run() {
-								bannerControlSession.getPlayer().removePotionEffect(PotionEffectType.GLOWING);
-							}
-						});
+					if (SiegeWarSettings.getWarSiegeEnablePlayerGlowing()) {
+						if (bannerControlSession.getPlayer().hasPotionEffect(PotionEffectType.GLOWING)) {
+							Towny.getPlugin().getServer().getScheduler().scheduleSyncDelayedTask(Towny.getPlugin(), new Runnable() {
+								public void run() {
+									bannerControlSession.getPlayer().removePotionEffect(PotionEffectType.GLOWING);
+								}
+							});
+						}
+						continue;
 					}
-					continue;
 				}
 
 				//Check if session succeeded

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -75,14 +75,16 @@ public class SiegeWarBattleSessionUtil {
 							}
 							
 							//Remove glowing effects from players in bc sessions
-							for (Player player : siege.getBannerControlSessions().keySet()) {
-								if (player.isOnline() && player.hasPotionEffect(PotionEffectType.GLOWING)) {
-									Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
-										@Override
-										public void run() {
-											player.removePotionEffect(PotionEffectType.GLOWING);
-										}
-									});
+							if (SiegeWarSettings.getWarSiegeEnablePlayerGlowing()) {
+								for (Player player : siege.getBannerControlSessions().keySet()) {
+									if (player.isOnline() && player.hasPotionEffect(PotionEffectType.GLOWING)) {
+										Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
+											@Override
+											public void run() {
+												player.removePotionEffect(PotionEffectType.GLOWING);
+											}
+										});
+									}
 								}
 							}
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Basically what title says. Some players are complaining about fps drops because of glowing effect, so i decided to add a config option to disable it.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
switches.enable_player_glowing: true
____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
