### PR TITLE
SW 260 - Optimized BC-Session-Glowing

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -892,7 +892,27 @@ public enum ConfigNodes {
 			"# If this setting is 0.1,",
 			"# and an attack is attempted on a nation town,",
 			"# then for every natural town (i.e. not occupied foreign towns) in that nation,",
-			"# the attack-cost (i.e. warchest) requirement is increased by 10% of the amount it would take to attack that town.");
+			"# the attack-cost (i.e. warchest) requirement is increased by 10% of the amount it would take to attack that town."),
+	BANNER_CONTROL(
+		"banner_control",
+			"",
+			"",
+			"",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |                    BANNER CONTROL                    | #",
+			"# +------------------------------------------------------+ #",
+			"#                                                          #",
+			"# FYI: Most banner-control-related settings are above,     #",
+			"# and not in this section.                                 #",
+			"############################################################",
+			""),
+	BANNER_CONTROL_CAPTURE_MESSAGE_COLOR(
+			"banner_control.capturing_message_color",
+			"yellow",
+			"",
+			"# This setting determines the color of the action bar message,",
+			"# which players see while they are capturing the banner.");
 
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -465,4 +465,8 @@ public class SiegeWarSettings {
 	public static double getNationSiegeImmunityHomeTownContributionToAttackCost() {
 		return Settings.getDouble(ConfigNodes.NATION_SIEGE_IMMUNITY_HOME_TOWN_CONTRIBUTION_TO_ATTACK_COST);
 	}
+
+	public static String getBannerControlCaptureMessageColor() {
+		return Settings.getString(ConfigNodes.BANNER_CONTROL_CAPTURE_MESSAGE_COLOR);
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -8,9 +8,7 @@ import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.objects.BannerControlSession;
 import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
-import com.gmail.goosius.siegewar.settings.ConfigNodes;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
-import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
@@ -217,13 +215,24 @@ public class SiegeWarBannerControlUtil {
 				} else {
 					//Session success
 					siege.removeBannerControlSession(bannerControlSession);
-
+					//Update beacon
+					CosmeticUtil.evaluateBeacon(bannerControlSession.getPlayer(), siege);
+					//Remove glowing effect
+					if(bannerControlSession.getPlayer().hasPotionEffect(PotionEffectType.GLOWING)) {
+						Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
+							@Override
+							public void run() {
+								bannerControlSession.getPlayer().removePotionEffect(PotionEffectType.GLOWING);
+							}
+						});
+					}
+					//Update siege
 					if(bannerControlSession.getSiegeSide() == siege.getBannerControllingSide()) {
-						//The player contributes to ongoing banner control
+						//Player contributes to ongoing banner control
 						siege.addBannerControllingResident(bannerControlSession.getResident());
 						Messaging.sendMsg(bannerControlSession.getPlayer(), Translation.of("msg_siege_war_banner_control_session_success"));
 					} else {
-						//The player gains banner control for their side
+						//Player gains banner control for their side
 						boolean reversal = false;
 						int reversalBonusScore = 0;
 						if(siege.getBannerControllingSide() != SiegeSide.NOBODY
@@ -266,7 +275,6 @@ public class SiegeWarBannerControlUtil {
 							}
 						}
 						SiegeWarNotificationUtil.informSiegeParticipants(siege, message);
-						CosmeticUtil.evaluateBeacon(bannerControlSession.getPlayer(), siege);
 					}
 				}
 			} catch (Exception e) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -8,6 +8,7 @@ import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.objects.BannerControlSession;
 import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
+import com.gmail.goosius.siegewar.settings.ConfigNodes;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownySettings;
@@ -118,7 +119,8 @@ public class SiegeWarBannerControlUtil {
 			sessionDurationText));
 
 		//Notify player in action bar
-		String actionBarMessage = ChatColor.YELLOW + Translation.of("msg_siege_war_banner_control_remaining_session_time", sessionDurationText);
+		ChatColor actionBarMessageColor = ChatColor.valueOf(SiegeWarSettings.getBannerControlCaptureMessageColor().toUpperCase());
+		String actionBarMessage = actionBarMessageColor + Translation.of("msg_siege_war_banner_control_remaining_session_time", sessionDurationText);
 		bannerControlSession.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(actionBarMessage));
 
 		CosmeticUtil.evaluateBeacon(player, siege);
@@ -180,6 +182,7 @@ public class SiegeWarBannerControlUtil {
 	private static void evaluateExistingBannerControlSessions(Siege siege) {
 		String inProgressMessage;
 		String remainingSessionTime;
+		ChatColor actionBarMessageColor = ChatColor.valueOf(SiegeWarSettings.getBannerControlCaptureMessageColor().toUpperCase());
 
 		if(!BattleSession.getBattleSession().isActive())
 			return;
@@ -200,7 +203,7 @@ public class SiegeWarBannerControlUtil {
 				if(System.currentTimeMillis() < bannerControlSession.getSessionEndTime()) {
 					//Session still in progress
 					remainingSessionTime = TimeMgmt.getFormattedTimeValue(bannerControlSession.getSessionEndTime() - System.currentTimeMillis());
-					inProgressMessage = ChatColor.YELLOW + Translation.of("msg_siege_war_banner_control_remaining_session_time", remainingSessionTime);
+					inProgressMessage = actionBarMessageColor + Translation.of("msg_siege_war_banner_control_remaining_session_time", remainingSessionTime);
 					bannerControlSession.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(inProgressMessage));
 				} else {
 					//Session success

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -179,13 +179,18 @@ public class SiegeWarBannerControlUtil {
 			new BannerControlSession(resident, player, siegeSide, sessionEndTime);
 		siege.addBannerControlSession(player, bannerControlSession);
 
-		//Notify Player
+		//Notify Player in console
 		String messageKey = SiegeWarSettings.isTrapWarfareMitigationEnabled() ? "msg_siege_war_banner_control_session_started_with_altitude" : "msg_siege_war_banner_control_session_started";
+		String sessionDurationText = TimeMgmt.getFormattedTimeValue(sessionDurationMillis);
 		Messaging.sendMsg(player, String.format(
 			Translation.of(messageKey),
 			TownySettings.getTownBlockSize(),
 			SiegeWarSettings.getBannerControlVerticalDistanceBlocks(),
-			TimeMgmt.getFormattedTimeValue(sessionDurationMillis)));
+			sessionDurationText));
+
+		//Notify player in action bar
+		String actionBarMessage = ChatColor.YELLOW + Translation.of("msg_siege_war_banner_control_remaining_session_time", sessionDurationText);
+		bannerControlSession.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(actionBarMessage));
 
 		CosmeticUtil.evaluateBeacon(player, siege);
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -17,7 +17,10 @@ import com.palmergames.bukkit.towny.object.Resident;
 import com.gmail.goosius.siegewar.settings.Translation;
 import com.palmergames.util.TimeMgmt;
 import com.palmergames.util.TimeTools;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
@@ -241,6 +244,9 @@ public class SiegeWarBannerControlUtil {
 	}
 
 	private static void evaluateExistingBannerControlSessions(Siege siege) {
+		String inProgressMessage;
+		String remainingSessionTime;
+
 		if(!BattleSession.getBattleSession().isActive())
 			return;
 
@@ -256,9 +262,13 @@ public class SiegeWarBannerControlUtil {
 					continue;
 				}
 
-				//Check if session succeeded
-				if(System.currentTimeMillis() > bannerControlSession.getSessionEndTime()) {
-
+				//Check if session is in progress or succeeded
+				if(System.currentTimeMillis() < bannerControlSession.getSessionEndTime()) {
+					//Session still in progress
+					remainingSessionTime = TimeMgmt.getFormattedTimeValue(bannerControlSession.getSessionEndTime() - System.currentTimeMillis());
+					inProgressMessage = ChatColor.YELLOW + Translation.of("msg_siege_war_banner_control_remaining_session_time", remainingSessionTime);
+					bannerControlSession.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(inProgressMessage));
+				} else {
 					//Session success
 					siege.removeBannerControlSession(bannerControlSession);
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -192,10 +192,19 @@ public class SiegeWarBannerControlUtil {
 				//Check if session failed
 				if (!doesPlayerMeetBasicSessionRequirements(siege, bannerControlSession.getPlayer(), bannerControlSession.getResident())) {
 					siege.removeBannerControlSession(bannerControlSession);
-
 					String errorMessage = SiegeWarSettings.isTrapWarfareMitigationEnabled() ? Translation.of("msg_siege_war_banner_control_session_failure_with_altitude") : Translation.of("msg_siege_war_banner_control_session_failure");
 					Messaging.sendMsg(bannerControlSession.getPlayer(), errorMessage);
+					//Update beacon
 					CosmeticUtil.evaluateBeacon(bannerControlSession.getPlayer(), siege);
+					//Remove glowing effect
+					if(bannerControlSession.getPlayer().hasPotionEffect(PotionEffectType.GLOWING)) {
+						Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
+							@Override
+							public void run() {
+								bannerControlSession.getPlayer().removePotionEffect(PotionEffectType.GLOWING);
+							}
+						});
+					}
 					continue;
 				}
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -206,8 +206,8 @@ public class SiegeWarBannerControlUtil {
 					continue;
 				}
 
-				//Check if session is in progress or succeeded
-				if(System.currentTimeMillis() < bannerControlSession.getSessionEndTime()) {
+				//Check if session is in progress or succeeded. Countdown accurate to 1 second, not less
+				if((System.currentTimeMillis() / 1000) < (bannerControlSession.getSessionEndTime() / 1000)) {
 					//Session still in progress
 					remainingSessionTime = TimeMgmt.getFormattedTimeValue(bannerControlSession.getSessionEndTime() - System.currentTimeMillis());
 					inProgressMessage = actionBarMessageColor + Translation.of("msg_siege_war_banner_control_remaining_session_time", remainingSessionTime);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -54,77 +54,6 @@ public class SiegeWarBannerControlUtil {
 		}
 	}
 
-	/**
-	 * This method evaluates whether players should be made to glow
-	 * 
-	 * Glowing Rules:
-	 * - If both teams are within the timed point zone, all players in BC sessions glow.
-	 * - If no team, or just one, is within the timed point zone, nobody glows.
-	 * 
-	 * @param siege the siege
-	 */
-	private static void evaluatePlayerGlowing(Siege siege) throws Exception {
-		boolean attackersInTimedPointZone = false;
-		boolean defendersInTimedPointZone = false;
-		TownyUniverse universe = TownyUniverse.getInstance();
-		Resident resident;
-		SiegeSide siegeSide;
-	
-		PLAYER_LOOP:
-		for(Player player: Bukkit.getOnlinePlayers()) {
-			resident = universe.getResident(player.getUniqueId());
-			if (resident == null)
-				throw new TownyException(Translation.of("msg_err_not_registered_1", player.getName()));
-	
-			siegeSide = SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, resident.getTown(), siege);
-			
-			switch (siegeSide) {
-				case ATTACKERS:
-					attackersInTimedPointZone = true;
-					if(defendersInTimedPointZone)
-						break PLAYER_LOOP;
-					break;
-				case DEFENDERS:
-					defendersInTimedPointZone = true;
-					if(attackersInTimedPointZone)
-						break PLAYER_LOOP;
-					break;
-				case NOBODY:
-					break;
-			}
-		}
-		
-		//Adjust player glow effects
-		if(attackersInTimedPointZone && defendersInTimedPointZone) {
-			//Calculate glow effect duration
-			int effectDurationSeconds = SiegeWarSettings.getWarSiegeBannerControlSessionDurationMinutes() * 60; 
-			final int effectDurationTicks = (int)(TimeTools.convertToTicks(effectDurationSeconds));
-			//Ensure players in BC sessions are glowing
-			for(Player player: siege.getBannerControlSessions().keySet()) {
-				if(!player.hasPotionEffect(PotionEffectType.GLOWING)) {
-					Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
-						public void run() {
-							List<PotionEffect> potionEffects = new ArrayList<>();
-							potionEffects.add(new PotionEffect(PotionEffectType.GLOWING, effectDurationTicks, 0));
-							player.addPotionEffects(potionEffects);
-						}
-					});
-				}
-			}
-		} else {
-			//Ensure players in BC sessions are not glowing
-			for(Player player: siege.getBannerControlSessions().keySet()) {
-				if(player.hasPotionEffect(PotionEffectType.GLOWING)) {
-					Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
-						public void run() {
-							player.removePotionEffect(PotionEffectType.GLOWING);
-						}
-					});
-				}				
-			}
-		}
-	}
-
 	private static void evaluateNewBannerControlSessions(Siege siege) {
 		try {
 			TownyUniverse universe = TownyUniverse.getInstance();
@@ -364,5 +293,76 @@ public class SiegeWarBannerControlUtil {
 
 		//Record gained battle points for use by the 'Banner Control Reversal Bonus' feature
 		siege.adjustBattlePointsEarnedFromCurrentBannerControl(battlePoints);
+	}
+
+	/**
+	 * This method evaluates whether players should be made to glow
+	 * 
+	 * Glowing Rules:
+	 * - If both teams are within the timed point zone, all players in BC sessions glow.
+	 * - If no team, or just one, is within the timed point zone, nobody glows.
+	 * 
+	 * @param siege the siege
+	 */
+	private static void evaluatePlayerGlowing(Siege siege) throws Exception {
+		boolean attackersInTimedPointZone = false;
+		boolean defendersInTimedPointZone = false;
+		TownyUniverse universe = TownyUniverse.getInstance();
+		Resident resident;
+		SiegeSide siegeSide;
+	
+		PLAYER_LOOP:
+		for(Player player: Bukkit.getOnlinePlayers()) {
+			resident = universe.getResident(player.getUniqueId());
+			if (resident == null)
+				throw new TownyException(Translation.of("msg_err_not_registered_1", player.getName()));
+	
+			siegeSide = SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, resident.getTown(), siege);
+			
+			switch (siegeSide) {
+				case ATTACKERS:
+					attackersInTimedPointZone = true;
+					if(defendersInTimedPointZone)
+						break PLAYER_LOOP;
+					break;
+				case DEFENDERS:
+					defendersInTimedPointZone = true;
+					if(attackersInTimedPointZone)
+						break PLAYER_LOOP;
+					break;
+				case NOBODY:
+					break;
+			}
+		}
+		
+		//Adjust player glow effects
+		if(attackersInTimedPointZone && defendersInTimedPointZone) {
+			//Calculate glow effect duration
+			int effectDurationSeconds = SiegeWarSettings.getWarSiegeBannerControlSessionDurationMinutes() * 60; 
+			final int effectDurationTicks = (int)(TimeTools.convertToTicks(effectDurationSeconds));
+			//Ensure players in BC sessions are glowing
+			for(Player player: siege.getBannerControlSessions().keySet()) {
+				if(!player.hasPotionEffect(PotionEffectType.GLOWING)) {
+					Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
+						public void run() {
+							List<PotionEffect> potionEffects = new ArrayList<>();
+							potionEffects.add(new PotionEffect(PotionEffectType.GLOWING, effectDurationTicks, 0));
+							player.addPotionEffects(potionEffects);
+						}
+					});
+				}
+			}
+		} else {
+			//Ensure players in BC sessions are not glowing
+			for(Player player: siege.getBannerControlSessions().keySet()) {
+				if(player.hasPotionEffect(PotionEffectType.GLOWING)) {
+					Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {
+						public void run() {
+							player.removePotionEffect(PotionEffectType.GLOWING);
+						}
+					});
+				}				
+			}
+		}
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -330,13 +330,17 @@ public class SiegeWarBannerControlUtil {
 		TownyUniverse universe = TownyUniverse.getInstance();
 		Resident resident;
 		SiegeSide siegeSide;
-	
+
+		//Determine if both of the teams are within the timed point zone
 		PLAYER_LOOP:
 		for(Player player: Bukkit.getOnlinePlayers()) {
 			resident = universe.getResident(player.getUniqueId());
 			if (resident == null)
-				throw new TownyException(Translation.of("msg_err_not_registered_1", player.getName()));
-	
+				return;
+
+			if(!doesPlayerMeetBasicSessionRequirements(siege, player, resident))
+				return;
+
 			siegeSide = SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, resident.getTown(), siege);
 			
 			switch (siegeSide) {

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.22
+version: 0.23
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -454,3 +454,6 @@ msg_invite_occupation_success: '&bThe town %s has come under the occupation of %
 msg_set_revolt_immunities_town: 'Revolt immunity for town %s set to %s hours.'
 msg_set_revolt_immunities_nation: 'Revolt immunities for all towns in nation %s set to %s hours.'
 msg_set_revolt_immunities_all: 'Revolt immunities for all towns set to %s hours.'
+
+# Added in 0.23
+msg_siege_war_banner_control_remaining_session_time: 'Banner Cap Timer: %s'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.22
+version: 0.23
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -465,3 +465,6 @@ msg_invite_occupation_success: '&bThe town %s has come under the occupation of %
 msg_set_revolt_immunities_town: 'Revolt immunity for town %s set to %s hours.'
 msg_set_revolt_immunities_nation: 'Revolt immunities for all towns in nation %s set to %s hours.'
 msg_set_revolt_immunities_all: 'Revolt immunities for all towns set to %s hours.'
+
+# Added in 0.23
+msg_siege_war_banner_control_remaining_session_time: 'Banner Cap Timer: %s'


### PR DESCRIPTION
#### Description: 
- Optimized BC-Session Glowing: Now players in BC sessions only glow when enemies are in the timed point zone also.
- Added an action bar message to tell players how long they have left in their BC sessions.
 
____
#### New Nodes/Commands/ConfigOptions: 
- `banner_control.capturing_message_color='yellow'` - Determines the colour of the action bar message

____
#### Relevant Issue ticket:
Closes #260 

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
