### PR TITLE
SW-327 Added ruined towns to automatic dynmap hide

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDynmapUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDynmapUtil.java
@@ -57,6 +57,10 @@ public class SiegeWarDynmapUtil {
 							} else {
 								//Town
 								if(SiegeController.hasActiveSiege(town)) {
+									//Besieged Town
+									hidePlayer = true;
+								} else if (town.isRuined()) {
+									//Ruined town
 									hidePlayer = true;
 								}
 							}


### PR DESCRIPTION
#### Description: 
Small PR to add ruined towns to the automatic dynmap hide mode

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
Closes #327

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
