### PR TITLE
SW-353 Fix to prevent XP farming

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -209,6 +209,7 @@ public class PlayerDeath {
 	private static void keepLevel(PlayerDeathEvent playerDeathEvent) {
 		if(SiegeWarSettings.getWarSiegeDeathPenaltyKeepLevelEnabled() && !playerDeathEvent.getKeepLevel()) {
 			playerDeathEvent.setKeepLevel(true);
+			playerDeathEvent.setDroppedExp(0);
 		}
 	}
 


### PR DESCRIPTION
#### Description: 
- Currently players keep level if killed on death during battles (which is good).
- However they also drop some XP which can be taken the pplayer who killed them.
- This allows two collaborating players to (rather noisily) farm XP, by repeatedly killing each other, losing no XP, but continuing to gain XP.
- In this PR I fix the exploit by ensuring that players killed in battle drop no XP.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
Closes #353 

____
- [N/A] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
