### PR TITLE
Fixes registering Dynmap-Towny events before confirming Dynmap-Towny is present.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -80,7 +80,11 @@ public class SiegeWar extends JavaPlugin {
 			if (dynmap != null) {
 				info("SiegeWar found Dynmap plugin, enabling Dynmap support.");
 				DynmapTask.setupDynmapAPI((DynmapAPI) dynmap);
-				townyDynmapPluginIntegrationEnabled = true;
+				Plugin dynmaptowny = Bukkit.getPluginManager().getPlugin("Dynmap-Towny");
+				if (dynmaptowny != null) {
+					townyDynmapPluginIntegrationEnabled = true;
+					info("SiegeWar found Dynmap-Towny plugin, enabling Dynmap-Towny support.");
+				}
 			} else {
 				info("Dynmap plugin not found.");
 			}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
We chose to register the dynmap-towny listener whenever we found dynmap on the server, not accounting for servers who've neglected to install dynmap-towny. This PR adjusts it so we will check for both dynmap and dynmap-towny, enabling their features separately based on the plugins' attendance.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
None, spotted on discord.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
