### PR TITLE
Let admins toggle town neutrality, even when peaceful_towns is disabled in the config.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -144,7 +144,7 @@ public class SiegeWarTownEventListener implements Listener {
 		if (!SiegeWarSettings.getWarSiegeEnabled())
 			return;
 		
-		if(!SiegeWarSettings.getWarCommonPeacefulTownsEnabled()) {
+		if(!SiegeWarSettings.getWarCommonPeacefulTownsEnabled() && !event.isAdminAction()) {
 			event.setCancellationMsg(Translation.of("msg_err_command_disable"));
 			event.setCancelled(true);
 			return;


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Currently (when peaceful_towns is disabled in teh SW config,) even using `/ta town NAME toggle neutral` an admin is unable to toggle a town's neutrality. This PR lets admins override the SW config.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
