### PR TITLE
Fix banner not being placed inside of NationZones upon Siege start.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -68,7 +68,8 @@ public class PlaceBlock {
 			//Standing Banner placement
 			if (Tag.BANNERS.isTagged(mat) && !mat.toString().contains("_W")) {
 				try {
-					evaluatePlaceStandingBanner(player, block);
+					if (evaluatePlaceStandingBanner(player, block))
+						event.setCancelled(false);
 				} catch (TownyException e1) {
 					Messaging.sendErrorMsg(player, e1.getMessage());
 				}
@@ -102,10 +103,10 @@ public class PlaceBlock {
 	 * Evaluates placing a standing banner
 	 * @throws TownyException if the banner will not be allowed.
 	 */
-	private static void evaluatePlaceStandingBanner(Player player, Block block) throws TownyException {
+	private static boolean evaluatePlaceStandingBanner(Player player, Block block) throws TownyException {
 		//Ensure the the banner is placed in wilderness
 		if (!TownyAPI.getInstance().isWilderness(block))
-			return;
+			return false;
 
 		//Ensure the player has a town
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
@@ -122,7 +123,7 @@ public class PlaceBlock {
 		List<TownBlock> adjacentCardinalTownBlocks = SiegeWarBlockUtil.getCardinalAdjacentTownBlocks(block);
 		List<TownBlock> adjacentNonCardinalTownBlocks = SiegeWarBlockUtil.getNonCardinalAdjacentTownBlocks(block);
 		if(adjacentCardinalTownBlocks.size() == 0 && adjacentNonCardinalTownBlocks.size() == 0)
-			return;
+			return false;
 
 		//Ensure there is just one cardinal town block
 		if (adjacentCardinalTownBlocks.size() > 1)
@@ -141,6 +142,7 @@ public class PlaceBlock {
 		} else {
 			evaluatePlaceColouredBannerNearTown(player, residentsTown, residentsNation, townBlock, townBlock.getTownOrNull(), block);
 		}
+		return true;
 	}
 
 		/**


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
When nationzones are enabled, sieges can be started but the banner used to start one is removed by Towny. 

This PR changes the logic of the evaluatePlaceStandingBanner method, turning it into a boolean, which returns true when a banner is successfully placed to start a siege. All other scenarios either return false or end up throwing an exception which doesn't result in the TownyBuildEvent being un-cancelled.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #397
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
