### PR TITLE
Fix Citizens NPCs being teleported to spawn.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>0.6.4</version>
+  <version>0.6.5</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>
@@ -63,6 +63,12 @@
       <groupId>at.pavlov</groupId>
       <artifactId>Cannons</artifactId>
       <version>2.5.5</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.citizensnpcs</groupId>
+      <artifactId>citizensapi</artifactId>
+      <version>2.0.28-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -33,10 +33,14 @@ import com.gmail.goosius.siegewar.playeractions.PlayerDeath;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.SiegeWarBlockUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
+import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
+
+import net.citizensnpcs.api.CitizensAPI;
+
 import com.gmail.goosius.siegewar.settings.Translation;
 
 /**
@@ -156,6 +160,10 @@ public class SiegeWarBukkitEventListener implements Listener {
 		
 		// Don't stop admins/ops. towny.admin.spawn is part of towny.admin.
 		if (event.getPlayer().hasPermission("towny.admin.spawn") || event.getPlayer().isOp())
+			return;
+		
+		// Let's ignore Citizens NPCs
+		if (Towny.getPlugin().isCitizens2() && CitizensAPI.getNPCRegistry().isNPC(event.getPlayer()))
 			return;
 		
 		if (SiegeWarSettings.getWarSiegeEnabled()


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Citizens NPCs throw PlayerTeleportEvents, which SiegeWar was picking up on, this PR ignores their teleport events.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
