### PR TITLE
Fix Liberation siege incorrectly choosing SiegeSide for Siege

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
@@ -19,11 +19,11 @@ public class SiegeWarAllegianceUtil {
         switch (candidateSiege.getSiegeType()) {
             case CONQUEST:
             case SUPPRESSION:
+            case LIBERATION:
                 //In the above sieges, defenders can be town guards
                 if (isTownGuard(deadPlayer, deadResidentTown, defendingGovernment))
                     return SiegeSide.DEFENDERS;
             case REVOLT:
-            case LIBERATION:
                 //In the above sieges, defenders can be nation/allied soldiers
                 if (isNationSoldierOrAlliedSoldier(deadPlayer, deadResidentTown, defendingGovernment))
                     return SiegeSide.DEFENDERS;


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Solves for siegesickness being given to the defending town's mayors,
assistants and guard, when that town doesn't have a nation.

They were only being tested for the nation battle points node.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #408.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
