### PR TITLE
Add BossBar progressbars for BattleSessions & Banner Cap timers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<dependency>
 	  <groupId>com.github.TownyAdvanced</groupId>
 	  <artifactId>Towny</artifactId>
-	  <version>0.97.2.0</version>
+	  <version>0.97.3.0</version>
 	  <scope>provided</scope>
 	</dependency>
     <dependency>

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -10,6 +10,7 @@ import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.settings.Translation;
 import com.gmail.goosius.siegewar.utils.BookUtil;
+import com.gmail.goosius.siegewar.utils.BossBarUtil;
 import com.gmail.goosius.siegewar.utils.CosmeticUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
 import com.palmergames.bukkit.towny.TownyAPI;
@@ -46,7 +47,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 
 	private static final List<String> siegewarTownTabCompletes = Arrays.asList("inviteoccupation");
 
-	private static final List<String> siegewarPreferenceTabCompletes = Arrays.asList("beacons");
+	private static final List<String> siegewarPreferenceTabCompletes = Arrays.asList("beacons", "bossbars");
 	
 	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
 
@@ -118,6 +119,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 	private void showPreferenceHelp(CommandSender sender) {
 		sender.sendMessage(ChatTools.formatTitle("/siegewar preference"));
 		sender.sendMessage(ChatTools.formatCommand("Eg", "/sw", "preference beacons [on/off]", ""));
+		sender.sendMessage(ChatTools.formatCommand("Eg", "/sw", "preference bossbars [on/off]", ""));
 	}
 	
 	public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String[] args) {
@@ -524,19 +526,27 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 
 	private void parseSiegewarPreferenceCommand(Player player, String[] args) {
 		if (args.length >= 2) {
+			if (!args[1].equalsIgnoreCase("on") && !args[1].equalsIgnoreCase("off")) {
+				Messaging.sendMsg(player, Translation.of("msg_err_invalid_bool"));
+				return;
+			}
 			Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
 			switch(args[0].toLowerCase()) {
 				case "beacons": {
-					if (!args[1].equalsIgnoreCase("on") && !args[1].equalsIgnoreCase("off")) {
-						Messaging.sendMsg(player, Translation.of("msg_err_invalid_bool"));
-						return;
-					}
 					boolean current = ResidentMetaDataController.getBeaconsDisabled(resident);
 					boolean disabled = args[1].equalsIgnoreCase("off");
 					ResidentMetaDataController.setBeaconsDisabled(resident, disabled);
 					if (current != disabled)
 						CosmeticUtil.removeFakeBeacons(player);
 					Messaging.sendMsg(player, Translation.of("msg_beacon_preference_set", args[1].toUpperCase()));
+					break;
+				}
+				case "bossbars": {
+					boolean disabled = args[1].equalsIgnoreCase("off");
+					ResidentMetaDataController.setBossBarsDisabled(resident, disabled);
+					if (disabled)
+						BossBarUtil.removeBossBars(player);
+					Messaging.sendMsg(player, Translation.of("msg_bossbar_preference_set", args[1].toUpperCase()));
 					break;
 				}
 				default:

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -19,8 +19,8 @@ public class ResidentMetaDataController {
 	private static IntegerDataField plunderAmount = new IntegerDataField("siegewar_plunder", 0, "Plunder");
 	private static IntegerDataField militarySalaryAmount = new IntegerDataField("siegewar_militarysalary", 0, "Military Salary");
 
-	static String
-		beaconsDisabled = "siegewar_beaconsdisabled";
+	static String beaconsDisabled = "siegewar_beaconsdisabled";
+	static String bossBarsDisabled = "siegewar_bossBarsdisabled";
 
 
 	public ResidentMetaDataController(SiegeWar plugin) {
@@ -154,5 +154,13 @@ public class ResidentMetaDataController {
 
 	public static boolean getBeaconsDisabled(Resident resident) {
 		return getBoolean(resident, beaconsDisabled);
+	}
+	
+	public static void setBossBarsDisabled(Resident resident, boolean disabled) {
+		setBoolean(resident, bossBarsDisabled, disabled);
+	}
+
+	public static boolean getBossBarsDisabled(Resident resident) {
+		return getBoolean(resident, bossBarsDisabled);
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -979,7 +979,7 @@ public enum ConfigNodes {
 			"banner_control.capturing_message_color",
 			"yellow",
 			"",
-			"# This setting determines the color of the action bar message,",
+			"# This setting determines the color of the boss bar message,",
 			"# which players see while they are capturing the banner.");
 
 	private final String Root;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/BossBarUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/BossBarUtil.java
@@ -1,0 +1,75 @@
+package com.gmail.goosius.siegewar.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.gmail.goosius.siegewar.objects.BannerControlSession;
+import com.gmail.goosius.siegewar.objects.BattleSession;
+import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.gmail.goosius.siegewar.settings.Translation;
+import com.palmergames.adventure.bossbar.BossBar;
+import com.palmergames.adventure.bossbar.BossBar.Color;
+import com.palmergames.adventure.bossbar.BossBar.Overlay;
+import com.palmergames.adventure.text.Component;
+import com.palmergames.adventure.text.TextComponent;
+import com.palmergames.bukkit.towny.Towny;
+
+public class BossBarUtil {
+
+	private static Map<Player, BossBar> bossBarBannerCapMap = new HashMap<>(); 
+	private static Map<Player, BossBar> bossBarBattleSessionMap = new HashMap<>();
+	
+	public static void removesBattleSessionBossBars() {
+		for (Player player : Bukkit.getOnlinePlayers()) {
+			if (bossBarBattleSessionMap.containsKey(player)) {
+				Towny.getAdventure().player(player).hideBossBar(bossBarBattleSessionMap.get(player));
+			}
+		}
+		bossBarBattleSessionMap.clear();
+	}
+	
+	public static void updateBattleSessionBossBar() {
+		BattleSession session = BattleSession.getBattleSession();
+		TextComponent comp = Component.text(Translation.of("status_town_siege_battle_time_remaining", session.getFormattedTimeRemainingUntilBattleSessionEnds()));
+		float remaining = getRemainder(session.getScheduledEndTime(), SiegeWarSettings.getWarSiegeBattleSessionDurationMinutes() * 60000);
+		for (Player player : Bukkit.getOnlinePlayers()) {
+			BossBar bossBar = bossBarBattleSessionMap.containsKey(player) ? bossBarBattleSessionMap.get(player) : BossBar.bossBar(comp, 0, Color.WHITE, Overlay.PROGRESS);
+			bossBar.progress((float) (remaining/100.0));
+			bossBar.name(comp);
+			if (!bossBarBattleSessionMap.containsKey(player)) {
+				bossBarBattleSessionMap.put(player, bossBar);
+				Towny.getAdventure().player(player).showBossBar(bossBar);
+			}
+		}
+		
+	}
+
+	public static void removesBannerCapBossBar(Player player) {
+		if (player.isOnline()) {
+			Towny.getAdventure().player(player).hideBossBar(bossBarBannerCapMap.get(player));
+		}
+		bossBarBannerCapMap.remove(player);
+	}
+
+	public static void updateBannerCapBossBar(Player player, String msg, BannerControlSession bannerControlSession) {
+		TextComponent comp = Component.text(msg);
+		float remaining = getRemainder(bannerControlSession.getSessionEndTime(), SiegeWarSettings.getWarSiegeBannerControlSessionDurationMinutes());
+		BossBar bossBar = bossBarBannerCapMap.containsKey(player) ? bossBarBannerCapMap.get(player) : BossBar.bossBar(comp, 0, Color.WHITE, Overlay.PROGRESS);
+		bossBar.progress(remaining);
+		bossBar.name(comp);
+		if (!bossBarBannerCapMap.containsKey(player)) {
+			bossBarBannerCapMap.put(player, bossBar);
+			Towny.getAdventure().player(player).showBossBar(bossBar);
+		}
+	}
+	
+	private static float getRemainder(long endTime, long duration) {
+		duration = duration * 60000;
+		double remaining = 100.0 * Math.abs(endTime - System.currentTimeMillis() - duration) / duration;
+		return (float) (remaining/100.0);
+		
+	}
+}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/BossBarUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/BossBarUtil.java
@@ -36,7 +36,7 @@ public class BossBarUtil {
 	
 	public static void updateBattleSessionBossBar() {
 		BattleSession session = BattleSession.getBattleSession();
-		TextComponent comp = Component.text(Translation.of("status_town_siege_battle_time_remaining", session.getFormattedTimeRemainingUntilBattleSessionEnds()));
+		TextComponent comp = Component.text(Translation.of("bossbar_msg_battle_time_remaining", session.getFormattedTimeRemainingUntilBattleSessionEnds()));
 		float remaining = getRemainder(session.getScheduledEndTime(), SiegeWarSettings.getWarSiegeBattleSessionDurationMinutes() * 60000);
 		for (Player player : Bukkit.getOnlinePlayers()) {
 			Resident resident = TownyAPI.getInstance().getResident(player);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -17,8 +17,6 @@ import com.palmergames.bukkit.towny.object.Resident;
 import com.gmail.goosius.siegewar.settings.Translation;
 import com.palmergames.util.TimeMgmt;
 import com.palmergames.util.TimeTools;
-import net.md_5.bungee.api.ChatMessageType;
-import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
@@ -123,7 +121,7 @@ public class SiegeWarBannerControlUtil {
 		//Notify player in action bar
 		ChatColor actionBarMessageColor = ChatColor.valueOf(SiegeWarSettings.getBannerControlCaptureMessageColor().toUpperCase());
 		String actionBarMessage = actionBarMessageColor + Translation.of("msg_siege_war_banner_control_remaining_session_time", sessionDurationText);
-		bannerControlSession.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(actionBarMessage));
+		BossBarUtil.updateBannerCapBossBar(bannerControlSession.getPlayer(), actionBarMessage, bannerControlSession);
 
 		CosmeticUtil.evaluateBeacon(player, siege);
 
@@ -188,6 +186,9 @@ public class SiegeWarBannerControlUtil {
 
 		if(!BattleSession.getBattleSession().isActive())
 			return;
+		
+		// Update the BattleSession bossbar.
+		BossBarUtil.updateBattleSessionBossBar();
 
 		for(BannerControlSession bannerControlSession: siege.getBannerControlSessions().values()) {
 			try {
@@ -215,12 +216,14 @@ public class SiegeWarBannerControlUtil {
 					//Session still in progress
 					remainingSessionTime = TimeMgmt.getFormattedTimeValue(bannerControlSession.getSessionEndTime() - System.currentTimeMillis());
 					inProgressMessage = actionBarMessageColor + Translation.of("msg_siege_war_banner_control_remaining_session_time", remainingSessionTime);
-					bannerControlSession.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(inProgressMessage));
+					BossBarUtil.updateBannerCapBossBar(bannerControlSession.getPlayer(), inProgressMessage, bannerControlSession);
 				} else {
 					//Session success
 					siege.removeBannerControlSession(bannerControlSession);
 					//Update beacon
 					CosmeticUtil.evaluateBeacon(bannerControlSession.getPlayer(), siege);
+					//Remove bossbar
+					BossBarUtil.removesBannerCapBossBar(bannerControlSession.getPlayer());
 					//Remove glowing effect
 					if(bannerControlSession.getPlayer().hasPotionEffect(PotionEffectType.GLOWING)) {
 						Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -223,7 +223,7 @@ public class SiegeWarBannerControlUtil {
 					//Update beacon
 					CosmeticUtil.evaluateBeacon(bannerControlSession.getPlayer(), siege);
 					//Remove bossbar
-					BossBarUtil.removesBannerCapBossBar(bannerControlSession.getPlayer());
+					BossBarUtil.removeBannerCapBossBar(bannerControlSession.getPlayer());
 					//Remove glowing effect
 					if(bannerControlSession.getPlayer().hasPotionEffect(PotionEffectType.GLOWING)) {
 						Bukkit.getScheduler().scheduleSyncDelayedTask(SiegeWar.getSiegeWar(), new Runnable() {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -119,8 +119,8 @@ public class SiegeWarBannerControlUtil {
 			sessionDurationText));
 
 		//Notify player in action bar
-		ChatColor actionBarMessageColor = ChatColor.valueOf(SiegeWarSettings.getBannerControlCaptureMessageColor().toUpperCase());
-		String actionBarMessage = actionBarMessageColor + Translation.of("msg_siege_war_banner_control_remaining_session_time", sessionDurationText);
+		ChatColor bossBarMessageColor = ChatColor.valueOf(SiegeWarSettings.getBannerControlCaptureMessageColor().toUpperCase());
+		String actionBarMessage = bossBarMessageColor + Translation.of("msg_siege_war_banner_control_remaining_session_time", sessionDurationText);
 		BossBarUtil.updateBannerCapBossBar(bannerControlSession.getPlayer(), actionBarMessage, bannerControlSession);
 
 		CosmeticUtil.evaluateBeacon(player, siege);
@@ -182,7 +182,7 @@ public class SiegeWarBannerControlUtil {
 	private static void evaluateExistingBannerControlSessions(Siege siege) {
 		String inProgressMessage;
 		String remainingSessionTime;
-		ChatColor actionBarMessageColor = ChatColor.valueOf(SiegeWarSettings.getBannerControlCaptureMessageColor().toUpperCase());
+		ChatColor bossBarMessageColor = ChatColor.valueOf(SiegeWarSettings.getBannerControlCaptureMessageColor().toUpperCase());
 
 		if(!BattleSession.getBattleSession().isActive())
 			return;
@@ -215,7 +215,7 @@ public class SiegeWarBannerControlUtil {
 				if((System.currentTimeMillis() / 1000) < (bannerControlSession.getSessionEndTime() / 1000)) {
 					//Session still in progress
 					remainingSessionTime = TimeMgmt.getFormattedTimeValue(bannerControlSession.getSessionEndTime() - System.currentTimeMillis());
-					inProgressMessage = actionBarMessageColor + Translation.of("msg_siege_war_banner_control_remaining_session_time", remainingSessionTime);
+					inProgressMessage = bossBarMessageColor + Translation.of("msg_siege_war_banner_control_remaining_session_time", remainingSessionTime);
 					BossBarUtil.updateBannerCapBossBar(bannerControlSession.getPlayer(), inProgressMessage, bannerControlSession);
 				} else {
 					//Session success

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -196,6 +196,7 @@ public class SiegeWarBannerControlUtil {
 				if (!doesPlayerMeetBasicSessionRequirements(siege, bannerControlSession.getPlayer(), bannerControlSession.getResident())) {
 					siege.removeBannerControlSession(bannerControlSession);
 					String errorMessage = SiegeWarSettings.isTrapWarfareMitigationEnabled() ? Translation.of("msg_siege_war_banner_control_session_failure_with_altitude") : Translation.of("msg_siege_war_banner_control_session_failure");
+					BossBarUtil.removeBannerCapBossBar(bannerControlSession.getPlayer());
 					Messaging.sendMsg(bannerControlSession.getPlayer(), errorMessage);
 					//Update beacon
 					CosmeticUtil.evaluateBeacon(bannerControlSession.getPlayer(), siege);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -122,7 +122,7 @@ public class SiegeWarBattleSessionUtil {
 		sendBattleSessionEndedMessage(battleResults);
 		
 		//Remove BossBar
-		BossBarUtil.removesBattleSessionBossBars();
+		BossBarUtil.removeBattleSessionBossBars();
 	}
        
 	public static void evaluateBattleSessions() {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -48,6 +48,8 @@ public class SiegeWarBattleSessionUtil {
 		Bukkit.getPluginManager().callEvent(new BattleSessionStartedEvent());	
 		//Send global message to let the server know that the battle session started
 		Messaging.sendGlobalMessage(Translation.of("msg_war_siege_battle_session_started"));
+		//Start the bossbar for the Battle Session
+		BossBarUtil.updateBattleSessionBossBar();
 	}
 
 	public static void endBattleSession() {
@@ -118,6 +120,9 @@ public class SiegeWarBattleSessionUtil {
 		
 		//Send message
 		sendBattleSessionEndedMessage(battleResults);
+		
+		//Remove BossBar
+		BossBarUtil.removesBattleSessionBossBars();
 	}
        
 	public static void evaluateBattleSessions() {

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.29
+version: 0.30
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -487,3 +487,6 @@ msg_err_too_soon_since_your_last_siegecamp: 'It has been too soon since you last
 msg_err_your_siegecamp_failed_you_must_wait_x: 'Your SiegeCamp failed to score enough points, you may not attempt another siege for %s.'
 attackers_scored_points_towards_siege_camp_x_of_x: '%s has scored points towards their SiegeCamp session: %s/%s.'
 attacker_has_begun_a_siegecamp_session: '%s has begun a SiegeCamp session against %s. If successful a Siege will begin! The attackers must score %s points within %s minutes.'
+
+# Added in 0.30
+msg_bossbar_preference_set: "&bBossBar preference set to %s."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -490,3 +490,4 @@ attacker_has_begun_a_siegecamp_session: '%s has begun a SiegeCamp session agains
 
 # Added in 0.30
 msg_bossbar_preference_set: "&bBossBar preference set to %s."
+bossbar_msg_battle_time_remaining: '&2Battle Session Time Remaining: &a%s'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -501,3 +501,4 @@ attacker_has_begun_a_siegecamp_session: '%s has begun a SiegeCamp session agains
 
 # Added in 0.30
 msg_bossbar_preference_set: "&bBossBar preference set to %s."
+bossbar_msg_battle_time_remaining: '&2Battle Session Time Remaining: &a%s'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.29
+version: 0.30
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -498,3 +498,6 @@ msg_err_too_soon_since_your_last_siegecamp: 'It has been too soon since you last
 msg_err_your_siegecamp_failed_you_must_wait_x: 'Your SiegeCamp failed to score enough points, you may not attempt another siege for %s.'
 attackers_scored_points_towards_siege_camp_x_of_x: '%s has scored points towards their SiegeCamp session: %s/%s.'
 attacker_has_begun_a_siegecamp_session: '%s has begun a SiegeCamp session against %s. If successful a Siege will begin! The attackers must score %s points within %s minutes.'
+
+# Added in 0.30
+msg_bossbar_preference_set: "&bBossBar preference set to %s."


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Displays the BattleSession, BannerCap times left as text and progressbars using Minecraft's BossBars via the Adventure API shaded in Towny.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

/sw preferences bossbars on/off - Allows a player to turn off the bossbars.
____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #407
Closes #334
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
