### PR TITLE
Split vertical distance requirements surrounding capping into separate up and down values.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -417,11 +417,17 @@ public enum ConfigNodes {
 			"# The radius of the 'siege zone'.",
 			"# This radius applies only horizontally, so players can never get above a siegezone (e.g. to place lava there or something).",
 			"# Various siege related effects can apply in this zone e.g. lose points on death, keep inv on death, cannot claim here."),
-	WAR_SIEGE_BANNER_CONTROL_VERTICAL_DISTANCE_BLOCKS(
-			"war.siege.distances.banner_control_vertical_distance_blocks",
+	WAR_SIEGE_BANNER_CONTROL_VERTICAL_DISTANCE_UP_BLOCKS(
+			"war.siege.distances.banner_control_vertical_distance_blocks_up",
 			"16",
 			"",
-			"# This is the vertical distance a soldier must be from the banner to get banner control.",
+			"# This is the vertical distance a soldier must be within above the Banner.",
+			"# Note that the horizontal distance is always the same as the Towny townblock size."),
+	WAR_SIEGE_BANNER_CONTROL_VERTICAL_DISTANCE_DOWN_BLOCKS(
+			"war.siege.distances.banner_control_vertical_distance_blocks_down",
+			"4",
+			"",
+			"# This is the vertical distance a soldier must be within below the Banner.",
 			"# Note that the horizontal distance is always the same as the Towny townblock size."),
 	WAR_SIEGE_SCORING(
 			"war.siege.scoring",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -422,8 +422,12 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.PEACEFUL_TOWNS_NEW_TOWN_CONFIRMATION_REQUIREMENT_DAYS);
 	}
 
-	public static int getBannerControlVerticalDistanceBlocks() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_BANNER_CONTROL_VERTICAL_DISTANCE_BLOCKS);
+	public static int getBannerControlVerticalDistanceUpBlocks() {
+		return Settings.getInt(ConfigNodes.WAR_SIEGE_BANNER_CONTROL_VERTICAL_DISTANCE_UP_BLOCKS);
+	}
+	
+	public static int getBannerControlVerticalDistanceDownBlocks() {
+		return Settings.getInt(ConfigNodes.WAR_SIEGE_BANNER_CONTROL_VERTICAL_DISTANCE_DOWN_BLOCKS);
 	}
 
 	public static boolean getWarCommonPeacefulTownsAllowedToTogglePVP() {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -117,7 +117,8 @@ public class SiegeWarBannerControlUtil {
 		Messaging.sendMsg(player, String.format(
 			Translation.of(messageKey),
 			TownySettings.getTownBlockSize(),
-			SiegeWarSettings.getBannerControlVerticalDistanceBlocks(),
+			SiegeWarSettings.getBannerControlVerticalDistanceUpBlocks(),
+			SiegeWarSettings.getBannerControlVerticalDistanceDownBlocks(),
 			sessionDurationText));
 
 		//Notify player in action bar

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -11,6 +11,7 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownyWorld;
 import com.palmergames.bukkit.towny.object.WorldCoord;
+import com.palmergames.util.MathUtil;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -86,7 +87,7 @@ public class SiegeWarDistanceUtil {
 	}
 
 	public static boolean isInTimedPointZone(Location location, Siege siege) {
-		return areLocationsClose(location, siege.getFlagLocation(), TownySettings.getTownBlockSize(), SiegeWarSettings.getBannerControlVerticalDistanceBlocks());
+		return areLocationsClose(location, siege.getFlagLocation(), TownySettings.getTownBlockSize());
 	}
 
 	public static boolean areTownsClose(Town town1, Town town2, int radiusTownblocks) {
@@ -116,18 +117,21 @@ public class SiegeWarDistanceUtil {
 		return distanceTownblocks < radiusTownblocks;
 	}
 
-	private static boolean areLocationsClose(Location location1, Location location2, int maxHorizontalDistance, int maxVerticalDistance) {
+	private static boolean areLocationsClose(Location location1, Location location2, int maxHorizontalDistance) {
 		if(!location1.getWorld().getName().equalsIgnoreCase(location2.getWorld().getName()))
 			return false;
 
 		//Check horizontal distance
-		double xzDistance = Math.sqrt(Math.pow(location1.getX() - location2.getX(), 2) + Math.pow(location1.getZ() - location2.getZ(), 2));
+		double xzDistance = MathUtil.distance(location1.getX(), location2.getX(), location1.getZ(), location2.getZ());
 		if(xzDistance > maxHorizontalDistance)
 			return false;
 
 		//Check vertical distance
-		double yDistance = Math.abs(Math.abs(location1.getY() - location2.getY()));
-		if(yDistance > maxVerticalDistance)
+		if (location1.getY() == location2.getY())
+			return true;
+		if (location1.getY() > location2.getY() && location1.getY() - location2.getY() > SiegeWarSettings.getBannerControlVerticalDistanceUpBlocks())
+			return false;
+		if (location2.getY() > location1.getY() && location2.getY() - location1.getY() > SiegeWarSettings.getBannerControlVerticalDistanceDownBlocks())
 			return false;
 
 		return true;
@@ -139,8 +143,7 @@ public class SiegeWarDistanceUtil {
 			return false;
 
 		//Check horizontal distance
-		double xzDistance = Math.sqrt(Math.pow(location1.getX() - location2.getX(), 2) + Math.pow(location1.getZ() - location2.getZ(), 2));
-		return xzDistance < radius;
+		return MathUtil.distance(location1.getX(), location2.getX(), location1.getZ(), location2.getZ()) < radius;
 	}
 
 	private static Location getTopNorthWestCornerLocation(WorldCoord worldCoord) {
@@ -188,6 +191,6 @@ public class SiegeWarDistanceUtil {
 	 * @param camp {@link SiegeCamp} to check against.
 	 */
 	public static boolean isInSiegeCampZone(Location location, SiegeCamp camp) {
-		return areLocationsClose(location, camp.getBannerBlock().getLocation(), TownySettings.getTownBlockSize(), SiegeWarSettings.getBannerControlVerticalDistanceBlocks());
+		return areLocationsClose(location, camp.getBannerBlock().getLocation(), TownySettings.getTownBlockSize());
 	}
 }

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -240,7 +240,7 @@ msg_siege_war_version: '&bThe current SiegeWar version is: %s.'
 #Added in 0.14
 msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below banner altitude in the timed point zone.'
 msg_siege_war_banner_control_session_started: '&bBanner control session started. Remain close to the siege-banner (%d blocks horizonally, %d blocks vertically), not in the town, and not flying, for %s. If your session succeeds, you will gain banner control for your side (or be added to the banner control list).'
-msg_siege_war_banner_control_session_started_with_altitude: '&bBanner control session started. Remain close to the siege-banner (%d blocks horizonally, %d blocks vertically), not below its altitude, not in the town, and not flying, for %s. If your session succeeds, you will gain banner control for your side (or be added to the banner control list).'
+msg_siege_war_banner_control_session_started_with_altitude: '&bBanner control session started. Remain close to the siege-banner (%d blocks horizonally, %d blocks above, %d blocks below), not below its altitude, not in the town, and not flying, for %s. If your session succeeds, you will gain banner control for your side (or be added to the banner control list).'
 msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going into the town, or flying.'
 msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going below the altitude of the banner, going into the town, or flying.'
 

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -250,7 +250,7 @@ msg_swa_set_siege_balance_success: '&bSuccessfully set siege balance to %d for %
 #Added in 0.14
 msg_err_cannot_alter_blocks_below_banner_in_timed_point_zone: 'You cannot place/destroy blocks below banner altitude in the timed point zone.'
 msg_siege_war_banner_control_session_started: '&bBanner control session started. Remain close to the siege-banner (%d blocks horizonally, %d blocks vertically), not in the town, and not flying, for %s. If your session succeeds, you will gain banner control for your side (or be added to the banner control list).'
-msg_siege_war_banner_control_session_started_with_altitude: '&bBanner control session started. Remain close to the siege-banner (%d blocks horizonally, %d blocks vertically), not below its altitude, not in the town, and not flying, for %s. If your session succeeds, you will gain banner control for your side (or be added to the banner control list).'
+msg_siege_war_banner_control_session_started_with_altitude: '&bBanner control session started. Remain close to the siege-banner (%d blocks horizonally, %d blocks above, %d blocks below), not below its altitude, not in the town, and not flying, for %s. If your session succeeds, you will gain banner control for your side (or be added to the banner control list).'
 msg_siege_war_banner_control_session_failure: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going into the town, or flying.'
 msg_siege_war_banner_control_session_failure_with_altitude: '&cBanner control session failed!. Common causes for this include: dying, going too far from the banner, going below the altitude of the banner, going into the town, or flying.'
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Good for keeping players from being underneath the banner in pre-dug-out caves.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New Config Options:
- war.siege.distances.banner_control_vertical_distance_blocks_up",
  - 16
  - This is the vertical distance a soldier must be within above the
Banner.
  - Note that the horizontal distance is always the same as the Towny
townblock size.
- war.siege.distances.banner_control_vertical_distance_blocks_down",
  - 4
  - This is the vertical distance a soldier must be within below the
Banner.
  - Note that the horizontal distance is always the same as the Towny
townblock size.

Removed Config Option:
war.siege.distances.banner_control_vertical_distance_blocks

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #405.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
