### PR TITLE
Use Towny's new StatusScreen components.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -11,6 +11,7 @@ import com.palmergames.bukkit.util.Colors;
 import com.palmergames.bukkit.util.Version;
 import com.gmail.goosius.siegewar.command.SiegeWarAdminCommand;
 import com.gmail.goosius.siegewar.command.SiegeWarCommand;
+import com.gmail.goosius.siegewar.command.SiegeWarNationAddonCommand;
 import com.gmail.goosius.siegewar.hud.SiegeHUDManager;
 import com.gmail.goosius.siegewar.integration.cannons.CannonsIntegration;
 import com.gmail.goosius.siegewar.integration.dynmap.DynmapIntegration;
@@ -143,6 +144,7 @@ public class SiegeWar extends JavaPlugin {
 		} else {
 			getCommand("siegewar").setExecutor(new SiegeWarCommand());
 			getCommand("siegewaradmin").setExecutor(new SiegeWarAdminCommand());
+			new SiegeWarNationAddonCommand();
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -19,6 +19,7 @@ import com.gmail.goosius.siegewar.listeners.SiegeWarBukkitEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarNationEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarPlotEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarSafeModeListener;
+import com.gmail.goosius.siegewar.listeners.SiegeWarStatusScreenListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarTownEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarTownyEventListener;
 
@@ -129,9 +130,10 @@ public class SiegeWar extends JavaPlugin {
 			pm.registerEvents(new SiegeWarActionListener(this), this);
 			pm.registerEvents(new SiegeWarBukkitEventListener(this), this);		
 			pm.registerEvents(new SiegeWarTownyEventListener(this), this);
-			pm.registerEvents(new SiegeWarNationEventListener(this), this);
+			pm.registerEvents(new SiegeWarNationEventListener(), this);
 			pm.registerEvents(new SiegeWarTownEventListener(this), this);
 			pm.registerEvents(new SiegeWarPlotEventListener(this), this);
+			pm.registerEvents(new SiegeWarStatusScreenListener(), this);
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarNationAddonCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarNationAddonCommand.java
@@ -1,0 +1,121 @@
+package com.gmail.goosius.siegewar.command;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+
+import com.gmail.goosius.siegewar.Messaging;
+import com.gmail.goosius.siegewar.TownOccupationController;
+import com.gmail.goosius.siegewar.settings.Translation;
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.TownyCommandAddonAPI;
+import com.palmergames.bukkit.towny.TownyCommandAddonAPI.CommandType;
+import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.object.AddonCommand;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.Translatable;
+import com.palmergames.bukkit.towny.utils.NameUtil;
+import com.palmergames.bukkit.util.ChatTools;
+import com.palmergames.util.StringMgmt;
+
+public class SiegeWarNationAddonCommand implements TabExecutor {
+
+	public SiegeWarNationAddonCommand() {
+		AddonCommand nationSiegeWarCommand = new AddonCommand(CommandType.NATION, "siegewar", this);
+		TownyCommandAddonAPI.addSubCommand(nationSiegeWarCommand);
+	}
+	
+	private CommandSender sender;
+
+	private static final List<String> nationSiegeWarTabCompletes = Arrays.asList(
+			"occupiedhometowns",
+			"occupiedforeigntowns"
+	);
+
+	@Override
+	public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+		
+		switch (args[0].toLowerCase()) {
+		case "occupiedhometowns":
+		case "occupiedforeigntowns":
+			if (args.length == 2)
+				return SiegeWarAdminCommand.getTownyStartingWith(args[1], "n");
+		}
+		
+		if (args.length == 1)
+			return NameUtil.filterByStart(nationSiegeWarTabCompletes, args[0]);
+		else
+			return Collections.emptyList();
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		this.sender = sender;
+		parseNationSiegeWarCommand(args);
+		return true;
+	}
+
+	private void parseNationSiegeWarCommand(String[] args) {
+		if (args.length == 0) {
+			showHelp();
+			return;
+		}
+		Nation nation = null;
+		if (args.length == 1 && sender instanceof Player) {
+			nation = TownyAPI.getInstance().getResident((Player) sender).getNationOrNull();
+			if (nation == null) {
+				TownyMessaging.sendErrorMsg(Translatable.of("msg_err_dont_belong_nation"));
+				return;
+			}
+		} else if (args.length == 1) {
+			showHelp();
+			return;
+		} else if (args.length == 2) {
+			nation = TownyAPI.getInstance().getNation(args[1]);
+			if (nation == null) {
+				TownyMessaging.sendErrorMsg(Translatable.of("msg_err_invalid_name", args[2]));
+				return;
+			}
+		}		
+		
+		switch (args[0].toLowerCase()) {
+		case "occupiedhometowns":
+			Messaging.sendMsg(sender, getFormattedStrings(Translation.of("status_nation_occupied_home_towns"), TownOccupationController.getOccupiedHomeTowns(nation)));
+			break;
+		case "occupiedforeigntowns":
+			Messaging.sendMsg(sender, getFormattedStrings(Translation.of("status_nation_occupied_foreign_towns"), TownOccupationController.getOccupiedForeignTowns(nation)));
+			break;
+		default:
+			showHelp();
+		}
+		
+	}
+
+	private String getFormattedStrings(String prefix, List<Town> list) {
+		return String.format(prefix, list.size()) + getFormattedTownList(list);
+	}
+
+	private static String getFormattedTownList(List<Town> towns) {
+		List<String> lines = new ArrayList<>();
+		boolean longname = towns.size() < 20;
+		for (Town town : towns) {
+			lines.add(longname ? town.getFormattedName() : town.getName());
+		}
+		return StringMgmt.join(lines, ", ");
+	}
+
+	private void showHelp() {
+		sender.sendMessage(ChatTools.formatTitle("/nation siegewar"));
+		sender.sendMessage(ChatTools.formatCommand("/nation siegewar", "occupiedhometowns [nation]", ""));
+		sender.sendMessage(ChatTools.formatCommand("/nation siegewar", "occupiedforeigntowns [nation]", ""));		
+	}
+
+}
+

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -1,22 +1,18 @@
 package com.gmail.goosius.siegewar.listeners;
 
 import com.gmail.goosius.siegewar.SiegeController;
-import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.TownOccupationController;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
-import com.gmail.goosius.siegewar.metadata.NationMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.settings.Translation;
-import com.gmail.goosius.siegewar.utils.ChatTools;
 import com.gmail.goosius.siegewar.utils.PermissionUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarNationUtil;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
-import com.palmergames.bukkit.towny.TownyFormatter;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.event.NationBonusCalculationEvent;
@@ -31,19 +27,15 @@ import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumResidents
 import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumTownBlocksCalculationEvent;
 import com.palmergames.bukkit.towny.event.nation.DisplayedNationsListSortEvent;
 
-import com.palmergames.bukkit.towny.event.statusscreen.NationStatusScreenEvent;
 import com.palmergames.bukkit.towny.event.townblockstatus.NationZoneTownBlockStatusEvent;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
-import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.util.BukkitTools;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
@@ -54,8 +46,6 @@ import java.util.List;
  */
 public class SiegeWarNationEventListener implements Listener {
 
-	@SuppressWarnings("unused")
-	private final SiegeWar plugin;
 
 	private static final Comparator<Nation> BY_NUM_RESIDENTS = (n1, n2) -> {
         return SiegeWarNationUtil.getEffectiveNation(n2).getResidents().size() 
@@ -76,11 +66,6 @@ public class SiegeWarNationEventListener implements Listener {
 		return TownyAPI.getInstance().getOnlinePlayers(SiegeWarNationUtil.getEffectiveNation(n2)).size() 
 			   - TownyAPI.getInstance().getOnlinePlayers(SiegeWarNationUtil.getEffectiveNation(n1)).size();
     };
-
-	public SiegeWarNationEventListener(SiegeWar instance) {
-
-		plugin = instance;
-	}
 
 	@EventHandler
 	public void onNationRankGivenToPlayer(NationRankAddEvent event) {
@@ -106,43 +91,6 @@ public class SiegeWarNationEventListener implements Listener {
 		}
 	}
 	
-	/*
-	 * SiegeWar will add lines to Nation which have a siege
-	 */
-    @EventHandler
-	public void onNationStatusScreen(NationStatusScreenEvent event) {
-		if (SiegeWarSettings.getWarSiegeEnabled()) {
-			Nation nation = event.getNation();
-
-			// Occupied Home Towns[3]: Town1, Town2, Town3
-			List<Town> occupiedHomeTowns = TownOccupationController.getOccupiedHomeTowns(nation);
-			String[] formattedOccupiedHomeTowns = TownyFormatter.getFormattedNames(occupiedHomeTowns.toArray(new Town[0]));
-			List<String> out = new ArrayList<>(ChatTools.listArr(formattedOccupiedHomeTowns, Translation.of("status_nation_occupied_home_towns", occupiedHomeTowns.size())));
-
-			// Occupied Foreign Towns[3]: Town4, Town5, Town6
-			List<Town> occupiedForeignTowns = TownOccupationController.getOccupiedForeignTowns(nation);
-			String[] formattedOccupiedForeignTowns = TownyFormatter.getFormattedNames(occupiedForeignTowns.toArray(new Town[0]));
-			out.addAll(new ArrayList<>(ChatTools.listArr(formattedOccupiedForeignTowns, Translation.of("status_nation_occupied_foreign_towns", occupiedForeignTowns.size()))));
-
-			// Offensive Sieges [3]: TownA, TownB, TownC
-	        List<Town> siegeAttacks = new ArrayList<>(SiegeController.getActiveOffensiveSieges(nation).values());
-	        String[] formattedSiegeAttacks = TownyFormatter.getFormattedNames(siegeAttacks.toArray(new Town[0]));
-	        out.addAll(new ArrayList<>(ChatTools.listArr(formattedSiegeAttacks, Translation.of("status_nation_offensive_sieges", siegeAttacks.size()))));
-
-	        // Defensive Sieges [3]: TownX, TownY, TownZ
-	        List<Town> siegeDefences = new ArrayList<>(SiegeController.getActiveDefensiveSieges(nation).values());
-	        String[] formattedSiegeDefences = TownyFormatter.getFormattedNames(siegeDefences.toArray(new Town[0]));
-	        out.addAll(ChatTools.listArr(formattedSiegeDefences, Translation.of("status_nation_defensive_sieges", siegeDefences.size())));
-	        
-	        event.addLines(out);
-
-			if (SiegeWarSettings.getWarSiegeNationStatisticsEnabled()) {
-				event.addLines(Arrays.asList(Translation.of("status_nation_town_stats", NationMetaDataController.getTotalTownsGained(nation), NationMetaDataController.getTotalTownsLost(nation)),
-											Translation.of("status_nation_plunder_stats", NationMetaDataController.getTotalPlunderGained(nation), NationMetaDataController.getTotalPlunderLost(nation))));
-			}
-		}
-	}
-
 	/*
 	 * A nation being deleted with a siege means the siege ends,
 	 * and a king may receive a refund.

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -71,22 +71,32 @@ public class SiegeWarStatusScreenListener implements Listener {
 	/*
 	 * SiegeWar will add lines to Nation which have a siege
 	 */
-    @EventHandler
+	@EventHandler
 	public void onNationStatusScreen(NationStatusScreenEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			Nation nation = event.getNation();
 			List<String> out = new ArrayList<>();
 			// Occupied Home Towns[3]: Town1, Town2, Town3
 			List<Town> occupiedHomeTowns = TownOccupationController.getOccupiedHomeTowns(nation);
-			if (occupiedHomeTowns.size() > 0)
-				out.add(Translation.of("status_nation_occupied_home_towns", occupiedHomeTowns.size())
-					+ getFormattedTownList(occupiedHomeTowns));
+			if (occupiedHomeTowns.size() > 0) {
+				TextComponent comp = Component.newline()
+						.append(Component.text(Translation.of("status_nation_occupied_home_towns", occupiedHomeTowns.size())
+							+ getFormattedTownList(occupiedHomeTowns))
+						.clickEvent(ClickEvent.runCommand("/nation siegewar occupiedhometowns " + nation.getName()))
+						.hoverEvent(HoverEvent.showText(Component.text(com.palmergames.bukkit.towny.object.Translation.of("status_hover_click_for_more")))));
+				event.getStatusScreen().addComponentOf("siegeWarNationOccupiedHomeTowns", comp);
+			}
 
 			// Occupied Foreign Towns[3]: Town4, Town5, Town6
 			List<Town> occupiedForeignTowns = TownOccupationController.getOccupiedForeignTowns(nation);
-			if (occupiedForeignTowns.size() > 0)
-				out.add(Translation.of("status_nation_occupied_foreign_towns", occupiedForeignTowns.size()) 
-					+ getFormattedTownList(occupiedForeignTowns));
+			if (occupiedForeignTowns.size() > 0) {
+				TextComponent comp = Component.newline()
+						.append(Component.text(Translation.of("status_nation_occupied_foreign_towns", occupiedForeignTowns.size())
+							+ getFormattedTownList(occupiedForeignTowns))
+						.clickEvent(ClickEvent.runCommand("/nation siegewar occupiedforeigntowns " + nation.getName()))
+						.hoverEvent(HoverEvent.showText(Component.text(com.palmergames.bukkit.towny.object.Translation.of("status_hover_click_for_more")))));
+				event.getStatusScreen().addComponentOf("siegeWarNationOccupiedForeignTowns", comp);
+			}
 
 			// Offensive Sieges [3]: TownA, TownB, TownC
 	        List<Town> siegeAttacks = new ArrayList<>(SiegeController.getActiveOffensiveSieges(nation).values());
@@ -105,10 +115,10 @@ public class SiegeWarStatusScreenListener implements Listener {
 				out.add(Translation.of("status_nation_plunder_stats", NationMetaDataController.getTotalPlunderGained(nation), NationMetaDataController.getTotalPlunderLost(nation)));
 			}
 			
-			TextComponent comp = Component.newline();
+			TextComponent comp = Component.empty();
 			for (String line : out)
 				comp = comp.append(Component.text(line)).append(Component.newline());
-			event.getStatusScreen().addComponentOf("siegeWarOccupiedForeignTowns", comp);
+			event.getStatusScreen().addComponentOf("siegeWarNation", comp);
 		}
 	}
 	
@@ -347,9 +357,14 @@ public class SiegeWarStatusScreenListener implements Listener {
 	
 	private static String getFormattedTownList(List<Town> towns) {
 		List<String> lines = new ArrayList<>();
-		boolean longname = towns.size() < 20;
+		int i = 0;
 		for (Town town : towns) {
-			lines.add(longname ? town.getFormattedName() : town.getName());
+			i++;
+			if (i == 11) {
+				lines.add(com.palmergames.bukkit.towny.object.Translation.of("status_town_reslist_overlength"));
+				return StringMgmt.join(lines, ", ");
+			}
+			lines.add(town.getName());
 		}
 		return StringMgmt.join(lines, ", ");
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -38,6 +38,11 @@ import com.palmergames.util.TimeMgmt;
 
 public class SiegeWarStatusScreenListener implements Listener {
 
+	/*
+	 * SiegeWar will show a resident if they can collect their nation refund, plunder
+	 * or military salary, via the resident status screen. Components are clickable to
+	 * claim monies owed.
+	 */
 	@EventHandler
 	public void onResidentStatusScreen(ResidentStatusScreenEvent event) {
 		int refund = ResidentMetaDataController.getNationRefundAmount(event.getResident());
@@ -243,7 +248,7 @@ public class SiegeWarStatusScreenListener implements Listener {
 							.append(Component.text(Translation.of("status_town_siege")))
 							.append(Component.newline())
 							.append(Component.text(Translation.of("status_town_siege_immunity_timer", time))); 
-	                event.getStatusScreen().addComponentOf("siegeWar_siegeImmunity", immunityComp);
+					event.getStatusScreen().addComponentOf("siegeWar_siegeImmunity", immunityComp);
 	            }
 	        }
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -1,0 +1,355 @@
+package com.gmail.goosius.siegewar.listeners;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+
+import com.gmail.goosius.siegewar.SiegeController;
+import com.gmail.goosius.siegewar.TownOccupationController;
+import com.gmail.goosius.siegewar.enums.SiegeSide;
+import com.gmail.goosius.siegewar.enums.SiegeStatus;
+import com.gmail.goosius.siegewar.enums.SiegeType;
+import com.gmail.goosius.siegewar.metadata.NationMetaDataController;
+import com.gmail.goosius.siegewar.metadata.ResidentMetaDataController;
+import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
+import com.gmail.goosius.siegewar.objects.BattleSession;
+import com.gmail.goosius.siegewar.objects.Siege;
+import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.gmail.goosius.siegewar.settings.Translation;
+import com.gmail.goosius.siegewar.utils.ChatTools;
+import com.gmail.goosius.siegewar.utils.SiegeWarBattleSessionUtil;
+import com.palmergames.adventure.text.Component;
+import com.palmergames.adventure.text.TextComponent;
+import com.palmergames.adventure.text.event.ClickEvent;
+import com.palmergames.adventure.text.event.HoverEvent;
+import com.palmergames.bukkit.towny.TownyEconomyHandler;
+import com.palmergames.bukkit.towny.TownyFormatter;
+import com.palmergames.bukkit.towny.event.statusscreen.NationStatusScreenEvent;
+import com.palmergames.bukkit.towny.event.statusscreen.ResidentStatusScreenEvent;
+import com.palmergames.bukkit.towny.event.statusscreen.TownStatusScreenEvent;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.util.StringMgmt;
+import com.palmergames.util.TimeMgmt;
+
+public class SiegeWarStatusScreenListener implements Listener {
+
+	@EventHandler
+	public void onResidentStatusScreen(ResidentStatusScreenEvent event) {
+		int refund = ResidentMetaDataController.getNationRefundAmount(event.getResident());
+		if (refund > 0) {
+			event.getStatusScreen().addComponentOf("siegeWarNationRefund",
+					formatKeyValue(Translation.of("status_nation_refund"), formatMoney(refund)),
+					HoverEvent.showText(Component.text(Translation.of("hover_message_click_to_claim"))),
+					ClickEvent.runCommand("/sw collect"));
+		}
+		int plunder = ResidentMetaDataController.getPlunderAmount(event.getResident());
+		if (plunder > 0) {
+			event.getStatusScreen().addComponentOf("siegeWarNationPlunder",
+					formatKeyValue(Translation.of("status_plunder"), formatMoney(plunder)),
+					HoverEvent.showText(Component.text(Translation.of("hover_message_click_to_claim"))),
+					ClickEvent.runCommand("/sw collect"));
+		}
+		int salary = ResidentMetaDataController.getMilitarySalaryAmount(event.getResident());
+		if (salary > 0) {
+			event.getStatusScreen().addComponentOf("siegeWarNationSalary",
+					formatKeyValue(Translation.of("status_military_salary"), formatMoney(salary)),
+					HoverEvent.showText(Component.text(Translation.of("hover_message_click_to_claim"))),
+					ClickEvent.runCommand("/sw collect"));
+		}
+	}
+	
+	/*
+	 * SiegeWar will add lines to Nation which have a siege
+	 */
+    @EventHandler
+	public void onNationStatusScreen(NationStatusScreenEvent event) {
+		if (SiegeWarSettings.getWarSiegeEnabled()) {
+			Nation nation = event.getNation();
+			List<String> out = new ArrayList<>();
+			// Occupied Home Towns[3]: Town1, Town2, Town3
+			List<Town> occupiedHomeTowns = TownOccupationController.getOccupiedHomeTowns(nation);
+			if (occupiedHomeTowns.size() > 0)
+				out.add(Translation.of("status_nation_occupied_home_towns", occupiedHomeTowns.size())
+					+ getFormattedTownList(occupiedHomeTowns));
+
+			// Occupied Foreign Towns[3]: Town4, Town5, Town6
+			List<Town> occupiedForeignTowns = TownOccupationController.getOccupiedForeignTowns(nation);
+			if (occupiedForeignTowns.size() > 0)
+				out.add(Translation.of("status_nation_occupied_foreign_towns", occupiedForeignTowns.size()) 
+					+ getFormattedTownList(occupiedForeignTowns));
+
+			// Offensive Sieges [3]: TownA, TownB, TownC
+	        List<Town> siegeAttacks = new ArrayList<>(SiegeController.getActiveOffensiveSieges(nation).values());
+			if (siegeAttacks.size() > 0)
+				out.add(Translation.of("status_nation_offensive_sieges", siegeAttacks.size())
+					+ getFormattedTownList(siegeAttacks));
+
+	        // Defensive Sieges [3]: TownX, TownY, TownZ
+	        List<Town> siegeDefences = new ArrayList<>(SiegeController.getActiveDefensiveSieges(nation).values());
+			if (siegeDefences.size() > 0)
+				out.add(Translation.of("status_nation_defensive_sieges", siegeDefences.size())
+					+ getFormattedTownList(siegeDefences));
+
+			if (SiegeWarSettings.getWarSiegeNationStatisticsEnabled()) {
+				out.add(Translation.of("status_nation_town_stats", NationMetaDataController.getTotalTownsGained(nation), NationMetaDataController.getTotalTownsLost(nation)));
+				out.add(Translation.of("status_nation_plunder_stats", NationMetaDataController.getTotalPlunderGained(nation), NationMetaDataController.getTotalPlunderLost(nation)));
+			}
+			
+			TextComponent comp = Component.newline();
+			for (String line : out)
+				comp = comp.append(Component.text(line)).append(Component.newline());
+			event.getStatusScreen().addComponentOf("siegeWarOccupiedForeignTowns", comp);
+		}
+	}
+	
+	/*
+	 * SiegeWar will add lines to towns which have a siege
+	 */
+	@EventHandler
+	public void onTownStatusScreen(TownStatusScreenEvent event) {
+		if (SiegeWarSettings.getWarSiegeEnabled()) {
+			
+			Town town = event.getTown();
+
+			//Occupying Nation: Empire of the Fluffy Bunnies
+			if(SiegeWarSettings.getWarSiegeInvadeEnabled() && TownOccupationController.isTownOccupied(town)) {
+				Nation townOccupier = TownOccupationController.getTownOccupier(town);
+				event.getStatusScreen().addComponentOf("siegeWar_townOccupier", Translation.of("status_town_occupying_nation", townOccupier.getFormattedName()));
+			}
+			
+	        //Revolt Immunity Timer: 71.8 hours
+	        long immunity = TownMetaDataController.getRevoltImmunityEndTime(town);
+	        if (SiegeWarSettings.getRevoltSiegesEnabled() && immunity == -1l || System.currentTimeMillis() < immunity) {
+	            String time = immunity == -1l ? Translation.of("msg_permanent") : TimeMgmt.getFormattedTimeValue(immunity- System.currentTimeMillis());
+	            event.getStatusScreen().addComponentOf("siegeWar_revoltImmunityTimer", Translation.of("status_town_revolt_immunity_timer", time));
+	        }
+
+	        immunity = TownMetaDataController.getSiegeImmunityEndTime(town);
+	        if (SiegeController.hasSiege(town)) {
+	        	List<String> out = new ArrayList<>();
+				Siege siege = SiegeController.getSiege(town);
+				SiegeStatus siegeStatus= siege.getStatus();
+				String time = immunity == -1l ? Translation.of("msg_permanent") : TimeMgmt.getFormattedTimeValue(immunity- System.currentTimeMillis()); 
+
+				// > Type: Conquest
+				out.add(Translation.of("status_town_siege_type", siege.getSiegeType().getName()));
+
+				// > Status: In Progress
+				out.add(Translation.of("status_town_siege_status", getStatusTownSiegeSummary(siege)));
+
+				// > Attacker: Darkness
+				out.add(Translation.of("status_town_siege_attacker", siege.getAttackerNameForDisplay()));
+
+				// > Defender: Light
+				out.add(Translation.of("status_town_siege_defender", siege.getDefenderNameForDisplay()));
+
+				switch (siegeStatus) {
+					case IN_PROGRESS:
+						// > Balance: 530 | Pending: +130
+						String balanceLine = Translation.of("status_town_siege_status_siege_balance", siege.getSiegeBalance());
+						// If the battle is active with points add the " | Pending: +130"
+						if (battleIsActive(siege)) {
+							int pending = SiegeWarBattleSessionUtil.calculateSiegeBalanceAdjustment(siege);
+							balanceLine += Translation.of("status_town_siege_pending_balance_adjustment", ((pending > 0 ? "+" : "") + pending));
+						}
+						out.add(balanceLine); 
+
+						if(SiegeWarSettings.isBannerXYZTextEnabled()) {
+							// > Banner XYZ: {2223,82,9877}
+							out.add(
+									Translation.of("status_town_siege_status_banner_xyz",
+											siege.getFlagLocation().getBlockX(),
+											siege.getFlagLocation().getBlockY(),
+											siege.getFlagLocation().getBlockZ())
+							);
+						}
+
+						// >  Victory Timer: 5.3 hours
+						String victoryTimer = Translation.of("status_town_siege_victory_timer", siege.getFormattedHoursUntilScheduledCompletion());
+						out.add(victoryTimer);
+
+						// >  War Chest: $12,800
+						if(TownyEconomyHandler.isActive()) {
+							String warChest = TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount());
+							out.add(Translation.of("status_town_siege_status_warchest", warChest));
+						}
+
+						if(battleIsActive(siege)) {
+
+							//Battle:
+							String battle = Translation.of("status_town_siege_battle");
+							out.add(battle);
+
+							// > Banner Control: Attackers [4] Killbot401x, NerfeyMcNerferson, WarCriminal80372
+							if (siege.getBannerControllingSide() == SiegeSide.NOBODY) {
+								out.add(Translation.of("status_town_banner_control_nobody", siege.getBannerControllingSide().getFormattedName()));
+							} else {
+								
+								String[] bannerControllingResidents = TownyFormatter.getFormattedNames(siege.getBannerControllingResidents().toArray(new Resident[0]));
+								if (bannerControllingResidents.length > 34) {
+									String[] entire = bannerControllingResidents;
+									bannerControllingResidents = new String[36];
+									System.arraycopy(entire, 0, bannerControllingResidents, 0, 35);
+									bannerControllingResidents[35] = Translation.of("status_town_reslist_overlength");
+								}
+								out.addAll(ChatTools.listArr(bannerControllingResidents, Translation.of("status_town_banner_control", siege.getBannerControllingSide().getFormattedName(), siege.getBannerControllingResidents().size())));
+							}
+
+							// > Points: +90 / -220
+							out.add(Translation.of("status_town_siege_battle_points", siege.getFormattedAttackerBattlePoints(), siege.getFormattedDefenderBattlePoints()));
+
+							// > Time Remaining: 22 minutes
+							out.add(Translation.of("status_town_siege_battle_time_remaining", BattleSession.getBattleSession().getFormattedTimeRemainingUntilBattleSessionEnds()));
+						}
+	                    break;
+
+	                case ATTACKER_WIN:
+	                case DEFENDER_SURRENDER:
+					case DEFENDER_WIN:
+					case ATTACKER_ABANDON:
+	                    String invadedPlunderedStatus = getInvadedPlunderedStatusLine(siege);
+						if(!invadedPlunderedStatus.isEmpty())
+							out.add(invadedPlunderedStatus);
+
+	                    String siegeImmunityTimer = Translation.of("status_town_siege_immunity_timer", time);
+	                    out.add(siegeImmunityTimer);
+	                    break;
+
+	                case PENDING_DEFENDER_SURRENDER:
+	                case PENDING_ATTACKER_ABANDON:
+					case UNKNOWN:
+						break;
+	            }
+
+				TextComponent hoverText = Component.empty();
+				for (String line : out) {
+					hoverText = hoverText.append(Component.text(line).append(Component.newline()));
+				}
+				event.getStatusScreen().addComponentOf("siegeWar_siegeHover", hoverFormat(Translation.of("status_sieged")), HoverEvent.showText(hoverText));
+
+	        } else {
+	            if(!SiegeController.hasActiveSiege(town)
+	            	&& (System.currentTimeMillis() < immunity)
+					|| immunity == -1l) {
+	                //Siege:
+	                // > Immunity Timer: 40.8 hours
+					String time = immunity == -1l ? Translation.of("msg_permanent") : TimeMgmt.getFormattedTimeValue(immunity- System.currentTimeMillis());
+					TextComponent immunityComp = Component.newline()
+							.append(Component.text(Translation.of("status_town_siege")))
+							.append(Component.newline())
+							.append(Component.text(Translation.of("status_town_siege_immunity_timer", time))); 
+	                event.getStatusScreen().addComponentOf("siegeWar_siegeImmunity", immunityComp);
+	            }
+	        }
+		}
+	}
+
+	private static String getStatusTownSiegeSummary(@NotNull Siege siege) {
+        switch (siege.getStatus()) {
+            case IN_PROGRESS:
+                return Translation.of("status_town_siege_status_in_progress");
+            case ATTACKER_WIN:
+                return Translation.of("status_town_siege_status_attacker_win");
+            case DEFENDER_SURRENDER:
+                return Translation.of("status_town_siege_status_defender_surrender");
+            case DEFENDER_WIN:
+                return Translation.of("status_town_siege_status_defender_win");
+            case ATTACKER_ABANDON:
+                return Translation.of("status_town_siege_status_attacker_abandon");
+            case PENDING_DEFENDER_SURRENDER:
+                return Translation.of("status_town_siege_status_pending_defender_surrender", siege.getTimeRemaining());
+            case PENDING_ATTACKER_ABANDON:
+                return Translation.of("status_town_siege_status_pending_attacker_abandon", siege.getTimeRemaining());
+            default:
+                return "???";
+        }
+    }
+
+    private static String getInvadedPlunderedStatusLine(Siege siege) {
+		switch(siege.getSiegeType()) {
+			case CONQUEST:
+			case LIBERATION:
+				switch (siege.getStatus()) {
+					case ATTACKER_WIN:
+					case DEFENDER_SURRENDER:
+						return getPlunderStatusLine(siege) + getInvadeStatusLine(siege);
+					default:
+						break;
+				}
+				break;
+			case SUPPRESSION:
+				switch (siege.getStatus()) {
+					case ATTACKER_WIN:
+					case DEFENDER_SURRENDER:
+						return getPlunderStatusLine(siege);
+					default:
+						break;
+				}
+				break;
+			case REVOLT:
+				switch (siege.getStatus()) {
+					case DEFENDER_WIN:
+					case ATTACKER_ABANDON:
+						return getPlunderStatusLine(siege);
+					default:
+						break;
+				}
+				break;
+		}
+		return "";
+	}
+
+	private static String getPlunderStatusLine(Siege siege) {
+		String plunderedYesNo = siege.isTownPlundered() ? Translation.of("status_yes") : Translation.of("status_no_green");
+		return Translation.of("status_town_siege_status_plundered", plunderedYesNo);
+	}
+
+	private static String getInvadeStatusLine(Siege siege) {
+		if(siege.getSiegeType() == SiegeType.REVOLT && siege.getSiegeType() == SiegeType.SUPPRESSION) {
+			return "";
+		} else {
+			String invadedYesNo = siege.isTownInvaded() ? Translation.of("status_yes") : Translation.of("status_no_green");
+			return Translation.of("status_town_siege_status_invaded", invadedYesNo);
+		}
+	}
+	
+	private static boolean battleIsActive(Siege siege) {
+		return BattleSession.getBattleSession().isActive()
+				&& (siege.getAttackerBattlePoints() > 0
+				 || siege.getDefenderBattlePoints() > 0
+				 || siege.getBannerControllingSide() != SiegeSide.NOBODY
+				 || siege.getBannerControlSessions().size() > 0);
+	}
+	
+	private String hoverFormat(String hover) {
+		return String.format(hover,
+				com.palmergames.bukkit.towny.object.Translation.of("status_format_hover_bracket_colour"),
+				com.palmergames.bukkit.towny.object.Translation.of("status_format_hover_key"),
+				com.palmergames.bukkit.towny.object.Translation.of("status_format_hover_bracket_colour"));
+	}
+	
+	private String formatKeyValue(String key, String value) {
+		return com.palmergames.bukkit.towny.object.Translation.of("status_format_key_value_key") +
+			key + 
+			com.palmergames.bukkit.towny.object.Translation.of("status_format_key_value_value") +
+			value;
+	}
+	
+	private static String getFormattedTownList(List<Town> towns) {
+		List<String> lines = new ArrayList<>();
+		boolean longname = towns.size() < 20;
+		for (Town town : towns) {
+			lines.add(longname ? town.getFormattedName() : town.getName());
+		}
+		return StringMgmt.join(lines, ", ");
+	}
+
+	private String formatMoney(int refund) {
+		return TownyEconomyHandler.getFormattedBalance(refund);
+	}
+}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -1,39 +1,26 @@
 package com.gmail.goosius.siegewar.listeners;
 
 import java.util.ArrayList;
-import java.util.List;
-
 import com.gmail.goosius.siegewar.TownOccupationController;
-import com.gmail.goosius.siegewar.enums.SiegeType;
-import com.gmail.goosius.siegewar.objects.BattleSession;
-import com.palmergames.bukkit.towny.TownyEconomyHandler;
-import com.palmergames.bukkit.towny.object.Nation;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.jetbrains.annotations.NotNull;
-
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
-import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.settings.Translation;
-import com.gmail.goosius.siegewar.utils.ChatTools;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.PermissionUtil;
-import com.gmail.goosius.siegewar.utils.SiegeWarBattleSessionUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarTownUtil;
-import com.palmergames.bukkit.towny.TownyFormatter;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.event.DeleteTownEvent;
 import com.palmergames.bukkit.towny.event.NewTownEvent;
 import com.palmergames.bukkit.towny.event.TownPreAddResidentEvent;
 import com.palmergames.bukkit.towny.event.TownPreClaimEvent;
-import com.palmergames.bukkit.towny.event.statusscreen.TownStatusScreenEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreMergeEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreUnclaimCmdEvent;
 import com.palmergames.bukkit.towny.event.town.TownRuinedEvent;
@@ -315,210 +302,6 @@ public class SiegeWarTownEventListener implements Listener {
 			SiegeController.removeSiege(SiegeController.getSiegeByTownUUID(event.getTownUUID()), SiegeSide.ATTACKERS);
 	}
 
-	/*
-	 * SiegeWar will add lines to towns which have a siege
-	 */
-	@EventHandler
-	public void onTownStatusScreen(TownStatusScreenEvent event) {
-		if (SiegeWarSettings.getWarSiegeEnabled()) {
-			List<String> out = new ArrayList<>();
-			Town town = event.getTown();
-
-			//Occupying Nation: Empire of the Fluffy Bunnies
-			if(SiegeWarSettings.getWarSiegeInvadeEnabled() && TownOccupationController.isTownOccupied(town)) {
-				Nation townOccupier = TownOccupationController.getTownOccupier(town);
-				out.add(Translation.of("status_town_occupying_nation", townOccupier.getFormattedName()));
-			}
-			
-	        //Revolt Immunity Timer: 71.8 hours
-	        long immunity = TownMetaDataController.getRevoltImmunityEndTime(town);
-	        if (SiegeWarSettings.getRevoltSiegesEnabled() && immunity == -1l || System.currentTimeMillis() < immunity) {
-	            String time = immunity == -1l ? Translation.of("msg_permanent") : TimeMgmt.getFormattedTimeValue(immunity- System.currentTimeMillis());
-	            out.add(Translation.of("status_town_revolt_immunity_timer", time));
-	        }
-
-	        immunity = TownMetaDataController.getSiegeImmunityEndTime(town);
-	        if (SiegeController.hasSiege(town)) {
-				Siege siege = SiegeController.getSiege(town);
-				SiegeStatus siegeStatus= siege.getStatus();
-				String time = immunity == -1l ? Translation.of("msg_permanent") : TimeMgmt.getFormattedTimeValue(immunity- System.currentTimeMillis()); 
-
-				//Siege:
-				out.add(Translation.of("status_town_siege"));
-
-				// > Type: Conquest
-				out.add(Translation.of("status_town_siege_type", siege.getSiegeType().getName()));
-
-				// > Status: In Progress
-				out.add(Translation.of("status_town_siege_status", getStatusTownSiegeSummary(siege)));
-
-				// > Attacker: Darkness
-				out.add(Translation.of("status_town_siege_attacker", siege.getAttackerNameForDisplay()));
-
-				// > Defender: Light
-				out.add(Translation.of("status_town_siege_defender", siege.getDefenderNameForDisplay()));
-
-				switch (siegeStatus) {
-					case IN_PROGRESS:
-						// > Balance: 530 | Pending: +130
-						String balanceLine = Translation.of("status_town_siege_status_siege_balance", siege.getSiegeBalance());
-						// If the battle is active with points add the " | Pending: +130"
-						if (battleIsActive(siege)) {
-							int pending = SiegeWarBattleSessionUtil.calculateSiegeBalanceAdjustment(siege);
-							balanceLine += Translation.of("status_town_siege_pending_balance_adjustment", ((pending > 0 ? "+" : "") + pending));
-						}
-						out.add(balanceLine); 
-
-						if(SiegeWarSettings.isBannerXYZTextEnabled()) {
-							// > Banner XYZ: {2223,82,9877}
-							out.add(
-									Translation.of("status_town_siege_status_banner_xyz",
-											siege.getFlagLocation().getBlockX(),
-											siege.getFlagLocation().getBlockY(),
-											siege.getFlagLocation().getBlockZ())
-							);
-						}
-
-						// >  Victory Timer: 5.3 hours
-						String victoryTimer = Translation.of("status_town_siege_victory_timer", siege.getFormattedHoursUntilScheduledCompletion());
-						out.add(victoryTimer);
-
-						// >  War Chest: $12,800
-						if(TownyEconomyHandler.isActive()) {
-							String warChest = TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount());
-							out.add(Translation.of("status_town_siege_status_warchest", warChest));
-						}
-
-						if(battleIsActive(siege)) {
-
-							//Battle:
-							String battle = Translation.of("status_town_siege_battle");
-							out.add(battle);
-
-							// > Banner Control: Attackers [4] Killbot401x, NerfeyMcNerferson, WarCriminal80372
-							if (siege.getBannerControllingSide() == SiegeSide.NOBODY) {
-								out.add(Translation.of("status_town_banner_control_nobody", siege.getBannerControllingSide().getFormattedName()));
-							} else {
-								
-								String[] bannerControllingResidents = TownyFormatter.getFormattedNames(siege.getBannerControllingResidents().toArray(new Resident[0]));
-								if (bannerControllingResidents.length > 34) {
-									String[] entire = bannerControllingResidents;
-									bannerControllingResidents = new String[36];
-									System.arraycopy(entire, 0, bannerControllingResidents, 0, 35);
-									bannerControllingResidents[35] = Translation.of("status_town_reslist_overlength");
-								}
-								out.addAll(ChatTools.listArr(bannerControllingResidents, Translation.of("status_town_banner_control", siege.getBannerControllingSide().getFormattedName(), siege.getBannerControllingResidents().size())));
-							}
-
-							// > Points: +90 / -220
-							out.add(Translation.of("status_town_siege_battle_points", siege.getFormattedAttackerBattlePoints(), siege.getFormattedDefenderBattlePoints()));
-
-							// > Time Remaining: 22 minutes
-							out.add(Translation.of("status_town_siege_battle_time_remaining", BattleSession.getBattleSession().getFormattedTimeRemainingUntilBattleSessionEnds()));
-						}
-	                    break;
-
-	                case ATTACKER_WIN:
-	                case DEFENDER_SURRENDER:
-					case DEFENDER_WIN:
-					case ATTACKER_ABANDON:
-	                    String invadedPlunderedStatus = getInvadedPlunderedStatusLine(siege);
-						if(!invadedPlunderedStatus.isEmpty())
-							out.add(invadedPlunderedStatus);
-
-	                    String siegeImmunityTimer = Translation.of("status_town_siege_immunity_timer", time);
-	                    out.add(siegeImmunityTimer);
-	                    break;
-
-	                case PENDING_DEFENDER_SURRENDER:
-	                case PENDING_ATTACKER_ABANDON:
-					case UNKNOWN:
-						break;
-	            }
-	        } else {
-	            if(!SiegeController.hasActiveSiege(town)
-	            	&& (System.currentTimeMillis() < immunity)
-					|| immunity == -1l) {
-	                //Siege:
-	                // > Immunity Timer: 40.8 hours
-	                out.add(Translation.of("status_town_siege"));
-					String time = immunity == -1l ? Translation.of("msg_permanent") : TimeMgmt.getFormattedTimeValue(immunity- System.currentTimeMillis());
-	                out.add(Translation.of("status_town_siege_immunity_timer", time));
-	            }
-	        }
-	        event.addLines(out);
-		}
-	}
-
-    private static String getStatusTownSiegeSummary(@NotNull Siege siege) {
-        switch (siege.getStatus()) {
-            case IN_PROGRESS:
-                return Translation.of("status_town_siege_status_in_progress");
-            case ATTACKER_WIN:
-                return Translation.of("status_town_siege_status_attacker_win");
-            case DEFENDER_SURRENDER:
-                return Translation.of("status_town_siege_status_defender_surrender");
-            case DEFENDER_WIN:
-                return Translation.of("status_town_siege_status_defender_win");
-            case ATTACKER_ABANDON:
-                return Translation.of("status_town_siege_status_attacker_abandon");
-            case PENDING_DEFENDER_SURRENDER:
-                return Translation.of("status_town_siege_status_pending_defender_surrender", siege.getTimeRemaining());
-            case PENDING_ATTACKER_ABANDON:
-                return Translation.of("status_town_siege_status_pending_attacker_abandon", siege.getTimeRemaining());
-            default:
-                return "???";
-        }
-    }
-
-    private static String getInvadedPlunderedStatusLine(Siege siege) {
-		switch(siege.getSiegeType()) {
-			case CONQUEST:
-			case LIBERATION:
-				switch (siege.getStatus()) {
-					case ATTACKER_WIN:
-					case DEFENDER_SURRENDER:
-						return getPlunderStatusLine(siege) + getInvadeStatusLine(siege);
-					default:
-						break;
-				}
-				break;
-			case SUPPRESSION:
-				switch (siege.getStatus()) {
-					case ATTACKER_WIN:
-					case DEFENDER_SURRENDER:
-						return getPlunderStatusLine(siege);
-					default:
-						break;
-				}
-				break;
-			case REVOLT:
-				switch (siege.getStatus()) {
-					case DEFENDER_WIN:
-					case ATTACKER_ABANDON:
-						return getPlunderStatusLine(siege);
-					default:
-						break;
-				}
-				break;
-		}
-		return "";
-	}
-
-	private static String getPlunderStatusLine(Siege siege) {
-		String plunderedYesNo = siege.isTownPlundered() ? Translation.of("status_yes") : Translation.of("status_no_green");
-		return Translation.of("status_town_siege_status_plundered", plunderedYesNo);
-	}
-
-	private static String getInvadeStatusLine(Siege siege) {
-		if(siege.getSiegeType() == SiegeType.REVOLT && siege.getSiegeType() == SiegeType.SUPPRESSION) {
-			return "";
-		} else {
-			String invadedYesNo = siege.isTownInvaded() ? Translation.of("status_yes") : Translation.of("status_no_green");
-			return Translation.of("status_town_siege_status_invaded", invadedYesNo);
-		}
-	}
-
     @EventHandler
     public void onTownUnconquer(TownUnconquerEvent event) {
     	if (SiegeWarSettings.getWarSiegeEnabled())
@@ -541,11 +324,4 @@ public class SiegeWarTownEventListener implements Listener {
 		}
 	}
 
-	private static boolean battleIsActive(Siege siege) {
-		return BattleSession.getBattleSession().isActive()
-				&& (siege.getAttackerBattlePoints() > 0
-				 || siege.getDefenderBattlePoints() > 0
-				 || siege.getBannerControllingSide() != SiegeSide.NOBODY
-				 || siege.getBannerControlSessions().size() > 0);
-	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -15,9 +15,9 @@ public class ResidentMetaDataController {
 
 	@SuppressWarnings("unused")
 	private SiegeWar plugin;
-	private static IntegerDataField refundAmount = new IntegerDataField("siegewar_nationrefund", 0, "Nation Refund");
-	private static IntegerDataField plunderAmount = new IntegerDataField("siegewar_plunder", 0, "Plunder");
-	private static IntegerDataField militarySalaryAmount = new IntegerDataField("siegewar_militarysalary", 0, "Military Salary");
+	private static IntegerDataField refundAmount = new IntegerDataField("siegewar_nationrefund", 0);
+	private static IntegerDataField plunderAmount = new IntegerDataField("siegewar_plunder", 0);
+	private static IntegerDataField militarySalaryAmount = new IntegerDataField("siegewar_militarysalary", 0);
 
 	static String beaconsDisabled = "siegewar_beaconsdisabled";
 	static String bossBarsDisabled = "siegewar_bossBarsdisabled";
@@ -52,9 +52,9 @@ public class ResidentMetaDataController {
 			if (resident.hasMeta(idf.getKey())) {
 				int updatedRefundAmount = getNationRefundAmount(resident) + nationRefundAmount;
 				resident.removeMetaData(idf);
-				resident.addMetaData(new IntegerDataField("siegewar_nationrefund", updatedRefundAmount, "Nation Refund"));
+				resident.addMetaData(new IntegerDataField("siegewar_nationrefund", updatedRefundAmount));
 			} else {
-				resident.addMetaData(new IntegerDataField("siegewar_nationrefund", nationRefundAmount, "Nation Refund"));
+				resident.addMetaData(new IntegerDataField("siegewar_nationrefund", nationRefundAmount));
 			}
 		}
 	}
@@ -84,9 +84,9 @@ public class ResidentMetaDataController {
 			if (resident.hasMeta(idf.getKey())) {
 				int updatedAmount = getPlunderAmount(resident) + amountToAdd;
 				resident.removeMetaData(idf);
-				resident.addMetaData(new IntegerDataField("siegewar_plunder", updatedAmount, "Plunder"));
+				resident.addMetaData(new IntegerDataField("siegewar_plunder", updatedAmount));
 			} else {
-				resident.addMetaData(new IntegerDataField("siegewar_plunder", amountToAdd, "Plunder"));
+				resident.addMetaData(new IntegerDataField("siegewar_plunder", amountToAdd));
 			}
 		}
 	}
@@ -116,9 +116,9 @@ public class ResidentMetaDataController {
 			if (resident.hasMeta(idf.getKey())) {
 				int updatedAmount = getMilitarySalaryAmount(resident) + amountToAdd;
 				resident.removeMetaData(idf);
-				resident.addMetaData(new IntegerDataField("siegewar_militarysalary", updatedAmount, "Military Salary"));
+				resident.addMetaData(new IntegerDataField("siegewar_militarysalary", updatedAmount));
 			} else {
-				resident.addMetaData(new IntegerDataField("siegewar_militarysalary", amountToAdd, "Military Salary"));
+				resident.addMetaData(new IntegerDataField("siegewar_militarysalary", amountToAdd));
 			}
 		}
 	}

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -492,3 +492,8 @@ attacker_has_begun_a_siegecamp_session: '%s has begun a SiegeCamp session agains
 msg_bossbar_preference_set: "&bBossBar preference set to %s."
 bossbar_msg_battle_time_remaining: '&2Battle Session Time Remaining: &a%s'
 msg_err_siege_war_revolt_immunity_permanent: "&cYour town has permanent revolt immunity. It cannot revolt."
+status_sieged: "%s[%sSieged%s]"
+status_nation_refund: "Nation Refund: "
+status_plunder: "Plunder: "
+status_military_salary: "Military Salary: "
+hover_message_click_to_claim: "Click to claim money owed to you."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -503,3 +503,8 @@ attacker_has_begun_a_siegecamp_session: '%s has begun a SiegeCamp session agains
 msg_bossbar_preference_set: "&bBossBar preference set to %s."
 bossbar_msg_battle_time_remaining: '&2Battle Session Time Remaining: &a%s'
 msg_err_siege_war_revolt_immunity_permanent: "&cYour town has permanent revolt immunity. It cannot revolt."
+status_sieged: "%s[%sSieged%s]"
+status_nation_refund: "Nation Refund: "
+status_plunder: "Plunder: "
+status_military_salary: "Military Salary: "
+hover_message_click_to_claim: "Click to claim money owed to you."


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- SiegeWar now uses the StatusScreen objects to add details to Towny
status screens.
- Includes:
  - Nation Refund, Plunder, Military Salary details are now
click-to-collect from the Resident Status Screen.
  - Town status screen moves many Siege details to [Sieged] hoverable
component.
  - Nation status screen only shows lists when they are greater than
zero.
    - Made /n screens show only 10 occupied towns per list, with the option to
click the screen to run the above commands and see the full lists.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

/nation siegewar occupiedhometowns {nationname}
/nation siegewar occupiedforeigntowns {nationname}

Shows full lists of occupied towns.
____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #413
____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
