### PR TITLE
Add Citizens-Repo because it fails to build without it. (tested in 0.7.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
       <id>cannons-repo</id>
       <url>https://github.com/DerPavlov/mvn-repo/raw/master/</url>
     </repository>
+    <repository>
+      <id>citizens-repo</id>
+      <url>https://repo.citizensnpcs.co/</url>
+    </repository>
   </repositories>
   
   <dependencies>


### PR DESCRIPTION
#### Description: 
In https://jitpack.io/com/github/TownyAdvanced/SiegeWar/0.7.0/build.log a Build Failure occurs because of 
`Failed to execute goal on project SiegeWar: Could not resolve dependencies for project com.gmail.goosius:SiegeWar:jar:0.7.0: Could not find artifact net.citizensnpcs:citizensapi:jar:2.0.28-SNAPSHOT in spigot-repo `

Adding this to the pom allows for it to build properly and allows jitpack to build each version so we can utilize it in our repos without errors.

- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
