### PR TITLE
Persistent Battle Points

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -91,6 +91,8 @@ public class SiegeController {
 		SiegeMetaDataController.setSiegeType(town, siege.getSiegeType().toString());
 		SiegeMetaDataController.setSiegeStatus(town, siege.getStatus().toString());
 		SiegeMetaDataController.setSiegeBalance(town, siege.getSiegeBalance());
+		SiegeMetaDataController.setAttackerBattlePoints(town, siege.getAttackerBattlePoints());
+		SiegeMetaDataController.setDefenderBattlePoints(town, siege.getDefenderBattlePoints());
 		SiegeMetaDataController.setWarChestAmount(town, siege.getWarChestAmount());
 		SiegeMetaDataController.setTownPlundered(town, siege.getTownPlundered());
 		SiegeMetaDataController.setTownInvaded(town, siege.getTownInvaded());
@@ -223,6 +225,8 @@ public class SiegeController {
 		siege.setFlagLocation(loc);
 
 		siege.setSiegeBalance(SiegeMetaDataController.getSiegeBalance(town));
+		siege.setAttackerBattlePoints(SiegeMetaDataController.getAttackerBattlePoints(town));
+		siege.setDefenderBattlePoints(SiegeMetaDataController.getDefenderBattlePoints(town));
 		siege.setWarChestAmount(SiegeMetaDataController.getWarChestAmount(town));
 		siege.setTownPlundered(SiegeMetaDataController.townPlundered(town));
 		siege.setTownInvaded(SiegeMetaDataController.townInvaded(town));

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -198,7 +198,7 @@ public class SiegeWar extends JavaPlugin {
 			}
 			//Resolve battles
 			if(siegesWithUnresolvedBattles.size() > 0) {
-				info(Translation.of("siegewar.battle.session.cleanup.starting"));
+				info(Translation.of("msg.battle.session.cleanup.starting"));
 				int numBattlesUpdated = 0;
 				for(Siege siege: siegesWithUnresolvedBattles) {
 					siege.setSiegeBalance(siege.getSiegeBalance() + siege.getAttackerBattlePoints() - siege.getDefenderBattlePoints());
@@ -208,7 +208,7 @@ public class SiegeWar extends JavaPlugin {
 					numBattlesUpdated++;
 				}
 				
-				info(Translation.of("siegewar.battle.session.cleanup.complete", numBattlesUpdated));
+				info(Translation.of("msg.battle.session.cleanup.complete", numBattlesUpdated));
 			}
 		}
 	

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -201,7 +201,7 @@ public class SiegeWar extends JavaPlugin {
 				info(Translation.of("siegewar.battle.session.cleanup.starting"));
 				int numBattlesUpdated = 0;
 				for(Siege siege: siegesWithUnresolvedBattles) {
-					siege.setSiegeBalance(siege.getSiegeBalance() + siege.getAttackerBattlePoints() + siege.getDefenderBattlePoints());
+					siege.setSiegeBalance(siege.getSiegeBalance() + siege.getAttackerBattlePoints() - siege.getDefenderBattlePoints());
 					siege.setAttackerBattlePoints(0);
 					siege.setDefenderBattlePoints(0);
 					SiegeController.saveSiege(siege);

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -1,6 +1,9 @@
 package com.gmail.goosius.siegewar;
 
+import com.gmail.goosius.siegewar.enums.SiegeStatus;
+import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.gmail.goosius.siegewar.settings.Translation;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -25,6 +28,8 @@ import com.gmail.goosius.siegewar.listeners.SiegeWarTownEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarTownyEventListener;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SiegeWar extends JavaPlugin {
 	
@@ -65,6 +70,7 @@ public class SiegeWar extends JavaPlugin {
 	        siegeWarPluginError = true;
         }
 
+		cleanupBattleSession();
 		registerCommands();
 		registerListeners();
 		checkIntegrations();
@@ -173,5 +179,38 @@ public class SiegeWar extends JavaPlugin {
 	
 	public static void severe(String msg) {
 		plugin.getLogger().severe(msg);
+	}
+
+	/**
+	 * Cleans up the battle session, if it did not exit properly when the plugin shut down.
+ 	 */	
+	private void cleanupBattleSession() {
+		if(siegeWarPluginError) {
+			severe("SiegeWar is in safe mode. Battle Session Cleanup not attempted.");
+		} else {
+			//Find any sieges with unresolved battles
+			List<Siege> siegesWithUnresolvedBattles = new ArrayList<>();
+			for(Siege siege: SiegeController.getSieges()) {
+				if(siege.getStatus() == SiegeStatus.IN_PROGRESS
+					&& (siege.getAttackerBattlePoints() > 0 || siege.getDefenderBattlePoints() > 0)) {
+					siegesWithUnresolvedBattles.add(siege);					
+				}
+			}
+			//Resolve battles
+			if(siegesWithUnresolvedBattles.size() > 0) {
+				info(Translation.of("siegewar.battle.session.cleanup.starting"));
+				int numBattlesUpdated = 0;
+				for(Siege siege: siegesWithUnresolvedBattles) {
+					siege.setSiegeBalance(siege.getSiegeBalance() + siege.getAttackerBattlePoints() + siege.getDefenderBattlePoints());
+					siege.setAttackerBattlePoints(0);
+					siege.setDefenderBattlePoints(0);
+					SiegeController.saveSiege(siege);
+					numBattlesUpdated++;
+				}
+				
+				info(Translation.of("siegewar.battle.session.cleanup.complete", numBattlesUpdated));
+			}
+		}
+	
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -48,7 +48,7 @@ public class SiegeMetaDataController {
 	//In metadata, siegeBalance still uses the old name of points
 	private static IntegerDataField siegeBalance = new IntegerDataField("siegewar_points", 0);
 	private static IntegerDataField attackerBattlePoints = new IntegerDataField("siegewar_attackerBattlePoints", 0);
-	private static IntegerDataField defenderBattlePoints = new IntegerDataField("siegewar_defenderBattlePoits", 0);
+	private static IntegerDataField defenderBattlePoints = new IntegerDataField("siegewar_defenderBattlePoints", 0);
 	
 	private static DecimalDataField siegeWarChestAmount = new DecimalDataField("siegewar_warChestAmount", 0.0);
 	private static BooleanDataField townPlundered = new BooleanDataField("siegewar_townPlundered", false);

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -47,6 +47,9 @@ public class SiegeMetaDataController {
 	private static StringDataField siegeType = new StringDataField("siegewar_type", "");
 	//In metadata, siegeBalance still uses the old name of points
 	private static IntegerDataField siegeBalance = new IntegerDataField("siegewar_points", 0);
+	private static IntegerDataField attackerBattlePoints = new IntegerDataField("siegewar_attackerBattlePoints", 0);
+	private static IntegerDataField defenderBattlePoints = new IntegerDataField("siegewar_defenderBattlePoits", 0);
+	
 	private static DecimalDataField siegeWarChestAmount = new DecimalDataField("siegewar_warChestAmount", 0.0);
 	private static BooleanDataField townPlundered = new BooleanDataField("siegewar_townPlundered", false);
 	private static BooleanDataField townInvaded = new BooleanDataField("siegewar_townInvaded", false);
@@ -218,7 +221,21 @@ public class SiegeMetaDataController {
 			return MetaDataUtil.getInt(town, idf);
 		return 0;
 	}
-	
+
+	public static int getAttackerBattlePoints(Town town) {
+		IntegerDataField idf = (IntegerDataField) attackerBattlePoints.clone();
+		if (town.hasMeta(idf.getKey()))
+			return MetaDataUtil.getInt(town, idf);
+		return 0;		
+	}
+
+	public static int getDefenderBattlePoints(Town town) {
+		IntegerDataField idf = (IntegerDataField) defenderBattlePoints.clone();
+		if (town.hasMeta(idf.getKey()))
+			return MetaDataUtil.getInt(town, idf);
+		return 0;		
+	}
+
 	public static void setSiegeBalance(Town town, int num) {
 		IntegerDataField idf = (IntegerDataField) siegeBalance.clone();
 		if (town.hasMeta(idf.getKey()))
@@ -226,7 +243,23 @@ public class SiegeMetaDataController {
 		else
 			town.addMetaData(new IntegerDataField("siegewar_points", num));
 	}
-	
+
+	public static void setAttackerBattlePoints(Town town, int num) {
+		IntegerDataField idf = (IntegerDataField) attackerBattlePoints.clone();
+		if (town.hasMeta(idf.getKey()))
+			MetaDataUtil.setInt(town, idf, num, true);
+		else
+			town.addMetaData(new IntegerDataField("siegewar_attackerBattlePoints", num));
+	}
+
+	public static void setDefenderBattlePoints(Town town, int num) {
+		IntegerDataField idf = (IntegerDataField) defenderBattlePoints.clone();
+		if (town.hasMeta(idf.getKey()))
+			MetaDataUtil.setInt(town, idf, num, true);
+		else
+			town.addMetaData(new IntegerDataField("siegewar_defenderBattlePoints", num));
+	}
+
 	public static double getWarChestAmount(Town town) {
 		DecimalDataField ddf = (DecimalDataField) siegeWarChestAmount.clone();
 		if (town.hasMeta(ddf.getKey()))
@@ -360,7 +393,13 @@ public class SiegeMetaDataController {
 		IntegerDataField idf = (IntegerDataField) siegeBalance.clone();
 		if (town.hasMeta(idf.getKey()))
 			town.removeMetaData(idf);
-		
+		idf = (IntegerDataField) attackerBattlePoints.clone();
+		if (town.hasMeta(idf.getKey()))
+			town.removeMetaData(idf);
+		idf = (IntegerDataField) defenderBattlePoints.clone();
+		if (town.hasMeta(idf.getKey()))
+			town.removeMetaData(idf);
+
 		DecimalDataField ddf = (DecimalDataField) siegeWarChestAmount.clone();
 		if (town.hasMeta(ddf.getKey()))
 			town.removeMetaData(ddf);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -1,6 +1,7 @@
 package com.gmail.goosius.siegewar.utils;
 
 import com.gmail.goosius.siegewar.Messaging;
+import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
@@ -324,6 +325,9 @@ public class SiegeWarBannerControlUtil {
 			break;
 			default:
 		}
+
+		//Save siege to db
+		SiegeController.saveSiege(siege);
 
 		//Record gained battle points for use by the 'Banner Control Reversal Bonus' feature
 		siege.adjustBattlePointsEarnedFromCurrentBannerControl(battlePoints);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -100,9 +100,6 @@ public class SiegeWarBattleSessionUtil {
 
 					//Prepare result for messaging
 					battleResults.put(siege, siegeBalanceAdjustment);
-
-					//Save siege
-					SiegeController.saveSiege(siege);
 				}
 
 				//Remove glowing effects from players in bc sessions
@@ -124,6 +121,9 @@ public class SiegeWarBattleSessionUtil {
 				siege.setAttackerBattlePoints(0);
 				siege.setDefenderBattlePoints(0);
 				siege.clearSuccessfulBattleContributors();
+
+				//Save siege to database
+				SiegeController.saveSiege(siege);
 			}
 		} catch (Throwable t) {
 			try {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
@@ -87,6 +87,9 @@ public class SiegeWarScoringUtil {
 			siege.adjustAttackerBattlePoints(battlePoints);
 		}
 
+		//Save siege to db
+		SiegeController.saveSiege(siege);
+
 		//Generate message
 		String unformattedErrorMessage;
 		String message;

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -497,5 +497,5 @@ msg_err_cannot_peacefully_revolt_because_unoccupied: "&cThere is no need to peac
 msg_err_cannot_peacefully_revolt_because_occupier_has_influence: "&cYour town cannot peacefully revolt, because its occupier, %s, still has some Towny-Influence in the local area (%d)."
 
 #Added in 0.33
-msg.battle.session.cleanup.starting: "&bThe previous Battle Session did not complete. Initiating Battle Session Cleanup. Each battle will be resolved as a draw, with both attacker and defender battle points being applied to the siege balance."
-msg.battle.session.cleanup.complete: "&bBattle Session Cleanup complete. %d battles were resolved."
+msg.battle.session.cleanup.starting: "The previous Battle Session did not complete. Initiating Battle Session Cleanup. Each battle will be resolved as a draw, with both attacker and defender battle points being applied to the siege balance."
+msg.battle.session.cleanup.complete: "Battle Session Cleanup complete. %d battles were resolved."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.32
+version: 0.33
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -495,3 +495,7 @@ msg_err_cannot_subvert_town_insufficient_influence: "&cYou cannot subvert this t
 msg_err_cannot_invite_peaceful_town_occupation: "&cYou cannot invite occupation if your town is peaceful."
 msg_err_cannot_peacefully_revolt_because_unoccupied: "&cThere is no need to peacefully revolt, because your town is not occupied."
 msg_err_cannot_peacefully_revolt_because_occupier_has_influence: "&cYour town cannot peacefully revolt, because its occupier, %s, still has some Towny-Influence in the local area (%d)."
+
+#Added in 0.33
+msg.battle.session.cleanup.starting: "&bThe previous Battle Session did not complete. Initiating Battle Session Cleanup. Each battle will be resolved as a draw, with both attacker and defender battle points being applied to the siege balance."
+msg.battle.session.cleanup.complete: "&bBattle Session Cleanup complete. %d battles were resolved."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.32
+version: 0.33
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -506,3 +506,7 @@ msg_err_cannot_subvert_town_insufficient_influence: "&cYou cannot subvert this t
 msg_err_cannot_invite_peaceful_town_occupation: "&cYou cannot invite occupation if your town is peaceful."
 msg_err_cannot_peacefully_revolt_because_unoccupied: "&cThere is no need to peacefully revolt, because your town is not occupied."
 msg_err_cannot_peacefully_revolt_because_occupier_has_influence: "&cYour town cannot peacefully revolt, because its occupier, %s, still has some Towny-Influence in the local area (%d)."
+
+#Added in 0.33
+msg.battle.session.cleanup.starting: "&bThe previous Battle Session did not complete. Initiating Battle Session Cleanup. Each battle will be resolved as a draw, with both attacker and defender battle points being applied to the siege balance."
+msg.battle.session.cleanup.complete: "&bBattle Session Cleanup complete. %d battles were resolved."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,4 +1,4 @@
-name: SiegeWar
+﻿name: SiegeWar
 version: 0.33
 language: french
 author: PainOchoco
@@ -508,5 +508,5 @@ msg_err_cannot_peacefully_revolt_because_unoccupied: "&cThere is no need to peac
 msg_err_cannot_peacefully_revolt_because_occupier_has_influence: "&cYour town cannot peacefully revolt, because its occupier, %s, still has some Towny-Influence in the local area (%d)."
 
 #Added in 0.33
-msg.battle.session.cleanup.starting: "&bThe previous Battle Session did not complete. Initiating Battle Session Cleanup. Each battle will be resolved as a draw, with both attacker and defender battle points being applied to the siege balance."
-msg.battle.session.cleanup.complete: "&bBattle Session Cleanup complete. %d battles were resolved."
+msg.battle.session.cleanup.starting: "The previous Battle Session did not complete. Initiating Battle Session Cleanup. Each battle will be resolved as a draw, with both attacker and defender battle points being applied to the siege balance."
+msg.battle.session.cleanup.complete: "Battle Session Cleanup complete. %d battles were resolved."


### PR DESCRIPTION
#### Description: 
- With current code, if a server shuts down while a battle is in progress, all battle points are lost.
- This PR addresses the issue as follows:
  - Battle points now persist to the DB whenever they are gained. 
  - If the server shuts down during a battle session, then on the restart of the plugin, the plugin immediately resolves all battles as a "draw", applying both attacker & defender battle points to the siege balance.
  - If this occurs, a message is shown in the console during server restart.
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
Closes #264 

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
