### PR TITLE
Change Battle Session Scheduler config to use LOCAL instead of UTC times

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -473,19 +473,19 @@ public enum ConfigNodes {
 			"# +------------------------------------------------------+ #",
 			"############################################################",
 			""),
-	WAR_SIEGE_BATTLE_SESSION_WEEKDAY_START_TIMES_UTC(
-			"war.siege.battle_session.weekday_start_times_utc",
-			"12:10,14:10,16:10,18:10,20:10",
+	WAR_SIEGE_BATTLE_SESSION_WEEKDAY_START_TIMES(
+			"war.siege.battle_session.weekday_start_times",
+			"00:10,01:10,02:10,03:10,04:10,05:10,06:10,07:10,08:10,09:10,10:10,11:10,12:10,13:10,14:10,15:10,16:10,17:10,18:10,19:10,20:10,21:10,22:10,23:10",
 			"",
-			"# This value determines the UTC weekday times when each battle session will start.",
+			"# This value determines the weekday times (in Server timezone) when each battle session will start.",
 			"# This setting applies to Monday, Tuesday, Wednesday, Thursday, and Friday.",
 			"# The format is HOUR:MINUTE.",
 			"# The default values are all at ten past the hour, so that the critical point of the battle (the final minutes), will fall on the hour."),
-	WAR_SIEGE_BATTLE_SESSION_WEEKEND_START_TIMES_UTC(
-			"war.siege.battle_session.weekend_start_times_utc",
-			"12:10,14:10,16:10,18:10,20:10",
+	WAR_SIEGE_BATTLE_SESSION_WEEKEND_START_TIMES(
+			"war.siege.battle_session.weekend_start_times",
+			"00:10,01:10,02:10,03:10,04:10,05:10,06:10,07:10,08:10,09:10,10:10,11:10,12:10,13:10,14:10,15:10,16:10,17:10,18:10,19:10,20:10,21:10,22:10,23:10",
 			"",
-			"# This value determines the UTC weekend times when each battle session will start.",
+			"# This value determines the weekend times (in Server timezone) when each battle session will start.",
 			"# This setting applies to Saturday and Sunday.",
 			"# The format is HOUR:MINUTE.",
 			"# The default values are all at ten past the hour, so that the critical point of the battle (the final minutes), will fall on the hour."),

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -278,15 +278,14 @@ public class SiegeWarSettings {
 		return Settings.getDouble(ConfigNodes.WAR_SIEGE_COUNTERATTACK_BOOSTER_EXTRA_DEATH_POINTS_PER_PLAYER_PERCENTAGE);
 	}
 
-	public static List<LocalDateTime> getAllBattleSessionStartTimesForTodayUtc() {
-		LocalDate today = OffsetDateTime.now(ZoneOffset.UTC).toLocalDate();
-		return getAllBattleSessionStartTimesForDayUtc(today);
+	public static List<LocalDateTime> getAllBattleSessionStartTimesForToday() {
+		return getAllBattleSessionStartTimesForDay(LocalDate.now());
 	}
 	
 	@Nullable
 	public static LocalDateTime getFirstBattleSessionStartTimeForTomorrowUtc() {
-		LocalDate tomorrow = OffsetDateTime.now(ZoneOffset.UTC).plusDays(1).toLocalDate();
-		List<LocalDateTime> allBattleSessionStartTimesForTomorrow = getAllBattleSessionStartTimesForDayUtc(tomorrow); 
+		LocalDate tomorrow = LocalDate.now().plusDays(1);
+		List<LocalDateTime> allBattleSessionStartTimesForTomorrow = getAllBattleSessionStartTimesForDay(tomorrow); 
 		if(allBattleSessionStartTimesForTomorrow.size() != 0) {
 			return allBattleSessionStartTimesForTomorrow.get(0);
 		} else {
@@ -294,14 +293,14 @@ public class SiegeWarSettings {
 		}
 	}
 	
-	private static List<LocalDateTime> getAllBattleSessionStartTimesForDayUtc(LocalDate day) {
+	private static List<LocalDateTime> getAllBattleSessionStartTimesForDay(LocalDate day) {
 		//Determine if the given day is on the weekend
 		boolean isWeekend = day.getDayOfWeek() == DayOfWeek.SATURDAY || day.getDayOfWeek() == DayOfWeek.SUNDAY;
 
 		//Get the start times from the config file, in the form of a single string.
 		String startTimesAsString = isWeekend ? 
-			getWarSiegeBattleSessionWeekendStartTimesUtc() :
-			getWarSiegeBattleSessionWeekdayStartTimesUtc();
+			getWarSiegeBattleSessionWeekendStartTimes() :
+			getWarSiegeBattleSessionWeekdayStartTimes();
 
 		//Transform the config file strings into a list of LocalDateTime objects
 		List<LocalDateTime> startTimesAsList = new ArrayList<>();	
@@ -321,12 +320,12 @@ public class SiegeWarSettings {
 		return startTimesAsList;
 	}
 
-	public static String getWarSiegeBattleSessionWeekdayStartTimesUtc() {
-		return Settings.getString(ConfigNodes.WAR_SIEGE_BATTLE_SESSION_WEEKDAY_START_TIMES_UTC);
+	public static String getWarSiegeBattleSessionWeekdayStartTimes() {
+		return Settings.getString(ConfigNodes.WAR_SIEGE_BATTLE_SESSION_WEEKDAY_START_TIMES);
 	}
 
-	public static String getWarSiegeBattleSessionWeekendStartTimesUtc() {
-		return Settings.getString(ConfigNodes.WAR_SIEGE_BATTLE_SESSION_WEEKEND_START_TIMES_UTC);
+	public static String getWarSiegeBattleSessionWeekendStartTimes() {
+		return Settings.getString(ConfigNodes.WAR_SIEGE_BATTLE_SESSION_WEEKEND_START_TIMES);
 	}
 
 	public static int getWarSiegeBattleSessionDurationMinutes() {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -266,13 +266,13 @@ public class SiegeWarBattleSessionUtil {
 	 * @return configured start time, in millis.
 	 */
 	private static Long getConfiguredStartTimeOfNextBattleSession() {
-		LocalDateTime currentTime = LocalDateTime.now(Clock.systemUTC());
+		LocalDateTime currentTime = LocalDateTime.now();
 		LocalDateTime nextStartDateTime = null;
 
 		//Look for next configured-start-time for today
-		for (LocalDateTime candidateStartTimeUtc : SiegeWarSettings.getAllBattleSessionStartTimesForTodayUtc()) {
-			if(candidateStartTimeUtc.isAfter(currentTime)) {
-				nextStartDateTime = candidateStartTimeUtc;
+		for (LocalDateTime candidateStartTime : SiegeWarSettings.getAllBattleSessionStartTimesForToday()) {
+			if(candidateStartTime.isAfter(currentTime)) {
+				nextStartDateTime = candidateStartTime;
 				break;
 			}
 		}
@@ -282,10 +282,12 @@ public class SiegeWarBattleSessionUtil {
 			nextStartDateTime = SiegeWarSettings.getFirstBattleSessionStartTimeForTomorrowUtc();
 		}
 		
-		//If nextStartTime is still null, return null, else transform it to millis and return
+		//If nextStartTime is still null, return null, else return the UTC time of the given value.
 		if(nextStartDateTime != null) {
-			ZonedDateTime zdt = ZonedDateTime.of(nextStartDateTime, ZoneOffset.UTC);
-			return zdt.toInstant().toEpochMilli();
+			ZonedDateTime nextStartTimeInServerTimeZone = ZonedDateTime.of(nextStartDateTime, ZoneId.systemDefault());
+			ZonedDateTime nextStartTimeInUtcTimeZone = nextStartTimeInServerTimeZone.withZoneSameInstant(ZoneId.of("UTC"));
+			long nextStartTimeAsUtcMillis = nextStartTimeInUtcTimeZone.toInstant().toEpochMilli();
+			return nextStartTimeAsUtcMillis;
 		} else {
 			return null;
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -282,7 +282,7 @@ public class SiegeWarBattleSessionUtil {
 			nextStartDateTime = SiegeWarSettings.getFirstBattleSessionStartTimeForTomorrowUtc();
 		}
 		
-		//If nextStartTime is still null, return null, else return the UTC time of the given value.
+		//If nextStartTime is still null, return null, else return the UTC time in millis of the given value.
 		if(nextStartDateTime != null) {
 			ZonedDateTime nextStartTimeInServerTimeZone = ZonedDateTime.of(nextStartDateTime, ZoneId.systemDefault());
 			ZonedDateTime nextStartTimeInUtcTimeZone = nextStartTimeInServerTimeZone.withZoneSameInstant(ZoneId.of("UTC"));


### PR DESCRIPTION
#### Description: 
- With current code, the battle session scheduler config requires UTC times to be specified. This is not convenient.
- This PR improves the config, by allowing LOCAL times to be specified (i.e. using the timezone at the server location).
- This PR also changes the default configured battles times to 1/hour, which is a more sensible default than the current one.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
