### PR TITLE
Siege Start Day Limiter

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -26,6 +26,8 @@ import org.bukkit.block.Banner;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -271,6 +273,9 @@ public class PlaceBlock {
 
 		if(SiegeWarBlockUtil.isSupportBlockUnstable(bannerBlock))
 			throw new TownyException(Translation.of("msg_err_siege_war_banner_support_block_not_stable"));
+
+        if(!SiegeWarSettings.getSiegeStartDayLimiterAllowedDays().contains(LocalDate.now().getDayOfWeek()))
+			throw new TownyException(Translation.of("msg_err_cannot_start_sieges_today"));
 
 		if (residentsTown == nearbyTown) {
 			//Revolt siege

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -967,11 +967,11 @@ public enum ConfigNodes {
 			"# you could limit siege-starts to just Thursday.           #",
 			"############################################################",
 			""),
-	SIEGE_START_DAY_LIMITER_DAYS(
-			"siege_start_day_limiter.days",
+	SIEGE_START_DAY_LIMITER_ALLOWED_DAYS(
+			"siege_start_day_limiter.allowed_days",
 			"monday, tuesday, wednesday, thursday, friday, saturday, sunday",
 			"",
-			"# This setting determines the days when players can start sieges.",
+			"# This setting determines the days (in server timezone) when players can start sieges.",
 			"# Multiple entries should be separated by a comma.",
 			"# Permitted values: monday, tuesday, wednesday, thursday, friday, saturday, sunday.");
 

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -949,7 +949,31 @@ public enum ConfigNodes {
 			"yellow",
 			"",
 			"# This setting determines the color of the boss bar message,",
-			"# which players see while they are capturing the banner.");
+			"# which players see while they are capturing the banner."),
+	SIEGE_START_DAY_LIMITER(
+		"siege_start_day_limiter",
+			"",
+			"",
+			"",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |              SIEGE START DAY LIMITER                 | #",
+			"# +------------------------------------------------------+ #",
+			"#                                                          #",
+			"# The feature allows a server to limit the days when       #",
+			"# players can start sieges.                                #",
+			"# 						                                    #",
+			"# Example: If you wanted fighting mostly on the weekends   #",
+			"# you could limit siege-starts to just Thursday.           #",
+			"############################################################",
+			""),
+	SIEGE_START_DAY_LIMITER_DAYS(
+			"siege_start_day_limiter.days",
+			"monday, tuesday, wednesday, thursday, friday, saturday, sunday",
+			"",
+			"# This setting determines the days when players can start sieges.",
+			"# Multiple entries should be separated by a comma.",
+			"# Permitted values: monday, tuesday, wednesday, thursday, friday, saturday, sunday.");
 
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -514,4 +514,17 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_BATTLE_SESSION_WEEKEND_MAX_DAILY_PLAYER_BATTLE_SESSIONS);
 	}
 
+	public static List<DayOfWeek> getSiegeStartDayLimiterAllowedDays() {
+		List<DayOfWeek> allowedDaysList = new ArrayList<>();
+		String[] allowedDaysStringArray = Settings.getString(ConfigNodes.SIEGE_START_DAY_LIMITER_ALLOWED_DAYS).toUpperCase().replaceAll(" ", "").split(",");
+
+			DayOfWeek allowedDay;
+			for(String allowedDayString: allowedDaysStringArray) {
+				allowedDay = DayOfWeek.valueOf(allowedDayString);
+				allowedDaysList.add(allowedDay);
+			}
+
+		return  allowedDaysList;
+	}
+
 }

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -495,3 +495,4 @@ nation_help_11 : 'Collect any income due to you from: plunder or military salary
 msg_err_siege_war_collect_unavailable: "There is nothing for you to collect."
 msg.battle.session.cleanup.starting: "The previous Battle Session did not complete. Initiating Battle Session Cleanup. Each battle will be resolved as a draw, with both attacker and defender battle points being applied to the siege balance."
 msg.battle.session.cleanup.complete: "Battle Session Cleanup complete. %d battles were resolved."
+msg_err_cannot_start_sieges_today: "&cYour server has limited the days-of-the-week when sieges can be started. Players cannot start sieges today."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -495,4 +495,4 @@ nation_help_11 : 'Collect any income due to you from: plunder or military salary
 msg_err_siege_war_collect_unavailable: "There is nothing for you to collect."
 msg.battle.session.cleanup.starting: "The previous Battle Session did not complete. Initiating Battle Session Cleanup. Each battle will be resolved as a draw, with both attacker and defender battle points being applied to the siege balance."
 msg.battle.session.cleanup.complete: "Battle Session Cleanup complete. %d battles were resolved."
-msg_err_cannot_start_sieges_today: "&cYour server has limited the days-of-the-week when sieges can be started. Players cannot start sieges today."
+msg_err_cannot_start_sieges_today: "&cYour server has limited the days-of-the-week when sieges can be started. Sieges cannot be started today."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -506,3 +506,4 @@ nation_help_11 : 'Collect any income due to you from: plunder or military salary
 msg_err_siege_war_collect_unavailable: "There is nothing for you to collect."
 msg.battle.session.cleanup.starting: "The previous Battle Session did not complete. Initiating Battle Session Cleanup. Each battle will be resolved as a draw, with both attacker and defender battle points being applied to the siege balance."
 msg.battle.session.cleanup.complete: "Battle Session Cleanup complete. %d battles were resolved."
+msg_err_cannot_start_sieges_today: "&cYour server has limited the days-of-the-week when sieges can be started. Players cannot start sieges today."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -506,4 +506,4 @@ nation_help_11 : 'Collect any income due to you from: plunder or military salary
 msg_err_siege_war_collect_unavailable: "There is nothing for you to collect."
 msg.battle.session.cleanup.starting: "The previous Battle Session did not complete. Initiating Battle Session Cleanup. Each battle will be resolved as a draw, with both attacker and defender battle points being applied to the siege balance."
 msg.battle.session.cleanup.complete: "Battle Session Cleanup complete. %d battles were resolved."
-msg_err_cannot_start_sieges_today: "&cYour server has limited the days-of-the-week when sieges can be started. Players cannot start sieges today."
+msg_err_cannot_start_sieges_today: "&cYour server has limited the days-of-the-week when sieges can be started. Sieges cannot be started today."


### PR DESCRIPTION

#### Description: 
- As per ticket, adds a config to allow siege-starting only on certain days of the week.

____
#### New Nodes/Commands/ConfigOptions: 
```
- New Config Nodes:

############################################################
# +------------------------------------------------------+ #
# |              SIEGE START DAY LIMITER                 | #
# +------------------------------------------------------+ #
#                                                          #
# The feature allows a server to limit the days when       #
# players can start sieges.                                #
# 						                                    #
# Example: If you wanted fighting mostly on the weekends   #
# you could limit siege-starts to just Thursday.           #
############################################################
 
siege_start_day_limiter:
 
  # This setting determines the days (in server timezone) when players can start sieges.
  # Multiple entries should be separated by a comma.
  # Permitted values: monday, tuesday, wednesday, thursday, friday, saturday, sunday.
  allowed_days:  monday, tuesday, wednesday, thursday, friday, saturday, sunday
```
____
#### Relevant Issue ticket:
Closes #451 

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
