### PR TITLE
Chest Placement Improvement

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -27,6 +27,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * This class is fired from the SiegeWarActionListener's TownyBuildEvent listener.
@@ -317,25 +318,17 @@ public class PlaceBlock {
 		if(!TownyEconomyHandler.isActive())
 			throw new TownyException(Translation.of("msg_err_siege_war_cannot_plunder_without_economy"));
 		
-		//Ensure there is at least 1 adjacent town
-		List<TownBlock> allAdjacentTownBlocks = SiegeWarBlockUtil.getAllAdjacentTownBlocks(block);
-		if(allAdjacentTownBlocks.size() == 0)
+		//If there are no sieges nearby, do normal block placement
+		Set<Siege> adjacentSieges = SiegeWarBlockUtil.getAllAdjacentSieges(block);
+		if(adjacentSieges.size() == 0)
 			return;
 
-		//Ensure there is only one adjacent town
-		Town town = allAdjacentTownBlocks.get(0).getTownOrNull();
-		for(int i = 1; i < allAdjacentTownBlocks.size(); i++) {
-			if(allAdjacentTownBlocks.get(i).getTown() != town) {
-				throw new TownyException(Translation.of("msg_err_siege_war_too_many_adjacent_towns"));
-			}
-		}
-
-		//If there is no siege, do normal block placement
-		if(!SiegeController.hasSiege(town))
-			return;
+		//Ensure there is only one adjacent siege
+		if(adjacentSieges.size() > 1)
+			throw new TownyException(Translation.of("msg_err_siege_war_too_many_adjacent_towns"));
 
 		//Attempt plunder.
-		PlunderTown.processPlunderTownRequest(player, town);
+		PlunderTown.processPlunderTownRequest(player, adjacentSieges.iterator().next().getTown());
 	}
 	
 	private static boolean isWhiteBanner(Block block) {

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -318,21 +318,17 @@ public class PlaceBlock {
 			throw new TownyException(Translation.of("msg_err_siege_war_cannot_plunder_without_economy"));
 		
 		//Ensure there is at least 1 adjacent town
-		List<TownBlock> adjacentCardinalTownBlocks = SiegeWarBlockUtil.getCardinalAdjacentTownBlocks(block);
-		List<TownBlock> adjacentNonCardinalTownBlocks = SiegeWarBlockUtil.getNonCardinalAdjacentTownBlocks(block);
-		if(adjacentCardinalTownBlocks.size() == 0 && adjacentNonCardinalTownBlocks.size() == 0)
+		List<TownBlock> allAdjacentTownBlocks = SiegeWarBlockUtil.getAllAdjacentTownBlocks(block);
+		if(allAdjacentTownBlocks.size() == 0)
 			return;
 
-		//Ensure there is just one cardinal town block
-		if (adjacentCardinalTownBlocks.size() > 1)
-			throw new TownyException(Translation.of("msg_err_siege_war_too_many_adjacent_towns"));
-
-		//Get 1st nearby town
-		Town town;
-		if(adjacentCardinalTownBlocks.size() > 0)
-			town = adjacentCardinalTownBlocks.get(0).getTownOrNull();
-		else
-			town = adjacentNonCardinalTownBlocks.get(0).getTownOrNull();
+		//Ensure there is only one adjacent town
+		Town town = allAdjacentTownBlocks.get(0).getTownOrNull();
+		for(int i = 1; i < allAdjacentTownBlocks.size(); i++) {
+			if(allAdjacentTownBlocks.get(i).getTown() != town) {
+				throw new TownyException(Translation.of("msg_err_siege_war_too_many_adjacent_towns"));
+			}
+		}
 
 		//If there is no siege, do normal block placement
 		if(!SiegeController.hasSiege(town))

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBlockUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBlockUtil.java
@@ -27,6 +27,19 @@ import java.util.List;
 public class SiegeWarBlockUtil {
 
 	/**
+	 * This method gets a list of all adjacent townblocks.
+	 *
+	 * @param block the block to start from
+	 * @return list of all adjacent townblocks
+	 */
+	public static List<TownBlock> getAllAdjacentTownBlocks(Block block) {
+		List<TownBlock> result = new ArrayList<>();
+		result.addAll(getCardinalAdjacentTownBlocks(block));
+		result.addAll(getNonCardinalAdjacentTownBlocks(block));
+		return result;
+	}
+
+	/**
 	 * This method gets a list of adjacent cardinal townblocks, either N, S, E or W.
 	 * 
 	 * @param block the block to start from

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBlockUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBlockUtil.java
@@ -51,7 +51,7 @@ public class SiegeWarBlockUtil {
 		Set<Siege> result = new HashSet<>();
 		for(TownBlock townBlock: getAllAdjacentTownBlocks(block)) {
 			if(townBlock.hasTown() & SiegeController.hasSiege(townBlock.getTownOrNull())) {
-				result.add(SiegeController.getSiege(townBlock.getTownOrNull()));	
+				result.add(SiegeController.getSiege(townBlock.getTownOrNull()));
 			}
 		}
 		return result;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBlockUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBlockUtil.java
@@ -16,7 +16,9 @@ import org.bukkit.block.Banner;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This class contains utility functions related to blocks 
@@ -36,6 +38,22 @@ public class SiegeWarBlockUtil {
 		List<TownBlock> result = new ArrayList<>();
 		result.addAll(getCardinalAdjacentTownBlocks(block));
 		result.addAll(getNonCardinalAdjacentTownBlocks(block));
+		return result;
+	}
+
+	/**
+	 * This method gets a list of all adjacent sieges.
+	 *
+	 * @param block the block to start from
+	 * @return list of all adjacent sieges (active or not)
+	 */
+	public static Set<Siege> getAllAdjacentSieges(Block block) {
+		Set<Siege> result = new HashSet<>();
+		for(TownBlock townBlock: getAllAdjacentTownBlocks(block)) {
+			if(townBlock.hasTown() & SiegeController.hasSiege(townBlock.getTownOrNull())) {
+				result.add(SiegeController.getSiege(townBlock.getTownOrNull()));	
+			}
+		}
 		return result;
 	}
 


### PR DESCRIPTION
#### Description: 
- As discussed in the ticket, this PR improves chest placement so that players will get the "too many facing chunks" error less often.
- Now they will only get it if the chunk faces two different besieged towns.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
Closes #455 

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
