### PR TITLE
Hotfix for Capping Limiter feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>0.7.5</version>
+  <version>0.7.6</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -507,7 +507,7 @@ public enum ConfigNodes {
 			"war.siege.battle_session.capping_limiter.weekend_days",
 			"5",
 			"",
-			"# This value determines the maximum number of week-day battle sessions for each individual player, in which they can capture the banner.",
+			"# This value determines the maximum number of weekend-day battle sessions for each individual player, in which they can capture the banner.",
 			"# This feature is an important server defence against night-capping, and against players skipping school or work to gain timed points.",
 			"# To disable the feature, set the value to -1."),
 	WAR_SIEGE_BANNER_CONTROL_REVERSAL_BONUS(

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -501,7 +501,6 @@ public enum ConfigNodes {
 			"2",
 			"",
 			"# This value determines the maximum number of week-day battle sessions for each individual player, in which they can capture the banner.",
-            "# ",
 			"# This feature is an important server defence against night-capping, and against players skipping school or work to gain timed points.",
 			"# To disable the feature, set the value to -1."),
 	WAR_SIEGE_BATTLE_SESSION_CAPPING_LIMITER_WEEKEND_DAYS(

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -496,21 +496,21 @@ public enum ConfigNodes {
 			"# This value determines the duration of each battle session.",
 			"# After a battle session ends,",
 			"# the time period until the next battle session starts, is defined as a 'break'"),
-	WAR_SIEGE_BATTLE_SESSION_WEEKDAY_MAX_DAILY_PLAYER_BATTLE_SESSIONS(
-			"war.siege.battle_session.weekday_max_daily_player_battle_sessions",
+	WAR_SIEGE_BATTLE_SESSION_CAPPING_LIMITER_WEEKDAYS(
+			"war.siege.battle_session.capping_limiter.weekdays",
 			"2",
 			"",
-			"# This value determines the maximum number of daily battle sessions allowed per player - on week days.",
-			"# To disable the limit, set the value to -1.",
-			"# This feature mitigates the problem of night-capping, where players stay up all night to gain timed points.",
-			"# This feature also mitigates the problem of players skipping weekday school or work to gain timed points."),
-	WAR_SIEGE_BATTLE_SESSION_WEEKEND_MAX_DAILY_PLAYER_BATTLE_SESSIONS(
-			"war.siege.battle_session.weekend_max_daily_player_battle_sessions",
+			"# This value determines the maximum number of week-day battle sessions for each individual player, in which they can capture the banner.",
+            "# ",
+			"# This feature is an important server defence against night-capping, and against players skipping school or work to gain timed points.",
+			"# To disable the feature, set the value to -1."),
+	WAR_SIEGE_BATTLE_SESSION_CAPPING_LIMITER_WEEKEND_DAYS(
+			"war.siege.battle_session.capping_limiter.weekend_days",
 			"5",
 			"",
-			"# This value determines the maximum number of daily battle sessions allowed per player - on weekend days.",
-			"# To disable the limit, set the value to -1.",
-			"# This feature mitigates the problem of night-capping, where players stay up all night to gain timed points."),
+			"# This value determines the maximum number of week-day battle sessions for each individual player, in which they can capture the banner.",
+			"# This feature is an important server defence against night-capping, and against players skipping school or work to gain timed points.",
+			"# To disable the feature, set the value to -1."),
 	WAR_SIEGE_BANNER_CONTROL_REVERSAL_BONUS(
 			"war.siege.banner_control_reversal_bonus",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -495,23 +495,23 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_SIEGECAMPS_DURATION_IN_MINUTES);
 	}
 
-	public static int getMaxDailyPlayerBattleSessions() {
+	public static int getBattleSessionCappingLimiter() {
 		DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
 		boolean weekend = dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
 
 		if(weekend) {
-			return getWeekendMaxDailyPlayerBattleSessions();
+			return getBattleSessionCappingLimiterWeekendDays();
 		} else {
-			return getWeekdayMaxDailyPlayerBattleSessions();
+			return getBattleSessionCappingLimiterWeekdays();
 		}
 	}
 
-	private static int getWeekdayMaxDailyPlayerBattleSessions() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_BATTLE_SESSION_WEEKDAY_MAX_DAILY_PLAYER_BATTLE_SESSIONS);
+	private static int getBattleSessionCappingLimiterWeekdays() {
+		return Settings.getInt(ConfigNodes.WAR_SIEGE_BATTLE_SESSION_CAPPING_LIMITER_WEEKDAYS);
 	}
 
-	private static int getWeekendMaxDailyPlayerBattleSessions() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_BATTLE_SESSION_WEEKEND_MAX_DAILY_PLAYER_BATTLE_SESSIONS);
+	private static int getBattleSessionCappingLimiterWeekendDays() {
+		return Settings.getInt(ConfigNodes.WAR_SIEGE_BATTLE_SESSION_CAPPING_LIMITER_WEEKEND_DAYS);
 	}
 
 	public static List<DayOfWeek> getSiegeStartDayLimiterAllowedDays() {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -83,12 +83,12 @@ public class SiegeWarBannerControlUtil {
 				if(siege.getBannerControllingResidents().contains(resident))
 					continue;  // Player already on the BC list
 
-				if(SiegeWarBattleSessionUtil.isDailyBattleSessionLimitActiveForResident(resident)) {
+				if(SiegeWarBattleSessionUtil.isBattleSessionCappingLimiterActiveForResident(resident)) {
 					String message = Translation.of("msg_war_siege_max_daily_player_battle_sessions_reached_cannot_get_banner_control",
-													SiegeWarSettings.getMaxDailyPlayerBattleSessions(),
+													SiegeWarSettings.getBattleSessionCappingLimiter(),
 													SiegeWarBattleSessionUtil.getFormattedTimeUntilPlayerBattleSessionLimitExpires(resident));
 					Messaging.sendErrorMsg(player, message);
-					continue;
+					continue;  // Player is being limited by the battle session capping limiter
 				}
 
 				SiegeSide siegeSide = SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, resident.getTown(), siege);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -294,17 +294,17 @@ public class SiegeWarBattleSessionUtil {
 	}
 
 	/**
-	 * Checks if the daily battle session limit is active for the given resident
+	 * Checks if the battle session capping limiter is active for the given resident
 	 * 
-	 * @return true if the limit is active, false if the limit is inactive
+	 * @return true if the limiter is active, false if the limit is inactive
 	 */
-	public static boolean isDailyBattleSessionLimitActiveForResident(Resident resident)  {
-		//Return false if there are no limits
-		int maxDailyPlayerBattleSessions = SiegeWarSettings.getMaxDailyPlayerBattleSessions();
+	public static boolean isBattleSessionCappingLimiterActiveForResident(Resident resident)  {
+		//Return false if the limit is disabled
+		int maxDailyPlayerBattleSessions = SiegeWarSettings.getBattleSessionCappingLimiter();
 		if(maxDailyPlayerBattleSessions == -1)
 			return false;
 
-		//Return true if the limit is 0
+		//Return true if the limit is set to 0
 		if(maxDailyPlayerBattleSessions == 0)
 			return true;
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
@@ -1,6 +1,5 @@
 package com.gmail.goosius.siegewar.utils;
 
-import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.objects.BattleSession;
@@ -8,17 +7,10 @@ import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.settings.Translation;
 import com.palmergames.bukkit.towny.TownyAPI;
-import com.palmergames.bukkit.towny.TownyUniverse;
-import com.palmergames.bukkit.towny.object.Resident;
-import com.palmergames.bukkit.towny.object.Town;
-import com.palmergames.bukkit.towny.object.Nation;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * This class contains utility functions related to battle scoring - i.e. battle points and siege balance
@@ -60,19 +52,6 @@ public class SiegeWarScoringUtil {
 		if(!BattleSession.getBattleSession().isActive())
 			return;
 
-		//No penalty points if killer player is at their daily battle session limit
-		Player killer = getPlayerKiller(player);
-		if(killer != null)  {
-			Resident killerResident = TownyUniverse.getInstance().getResident(killer.getUniqueId());
-			if(killerResident != null && SiegeWarBattleSessionUtil.isDailyBattleSessionLimitActiveForResident(killerResident)) {
-					String message = Translation.of("msg_war_siege_max_daily_player_battle_sessions_reached_cannot_get_kill_points",
-												SiegeWarSettings.getMaxDailyPlayerBattleSessions(),
-												SiegeWarBattleSessionUtil.getFormattedTimeUntilPlayerBattleSessionLimitExpires(killerResident));
-					Messaging.sendErrorMsg(killer, message);
-					return;
-			}
-		}
-
 		//Give battle points to opposing side
 		int battlePoints;
 		if (residentIsAttacker) {
@@ -91,6 +70,7 @@ public class SiegeWarScoringUtil {
 		//Generate message
 		String unformattedErrorMessage;
 		String message;
+		Player killer = getPlayerKiller(player);
 		if(killer != null) {
 			unformattedErrorMessage = residentIsAttacker ? 	Translation.of("msg_siege_war_attacker_killed_by_player") : Translation.of("msg_siege_war_defender_killed_by_player");
 			message = String.format(

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.33
+version: 0.34
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -476,7 +476,6 @@ msg_next_session_cannot_be_determined: "The next Siege Session has not been sche
 
 #Added in 0.32
 msg_war_siege_max_daily_player_battle_sessions_reached_cannot_get_banner_control: "&cBanner capture failed because you have reached your daily battle session limit (%d). Try again in %s."
-msg_war_siege_max_daily_player_battle_sessions_reached_cannot_get_kill_points: "&cBattle points not awarded because you have reached your daily battle session limit (%d). Try again in %s."
 msg_peaceful_town_subverted: "&b%s has been peacefully subverted and occupied by %s."
 msg_peaceful_town_revolted: "&b%s has peacefully revolted against %s, and freed itself from occupation."
 msg_town_became_peaceful: '&b%s has been confirmed as Peaceful. The town is now immune to siege attacks, but vulnerable to getting subverted by nearby nations. Residents cannot enter siege-zones or gain nation-military ranks.'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,5 +1,5 @@
 ﻿name: SiegeWar
-version: 0.33
+version: 0.34
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -487,7 +487,6 @@ msg_next_session_cannot_be_determined: "The next Siege Session has not been sche
 
 #Added in 0.32
 msg_war_siege_max_daily_player_battle_sessions_reached_cannot_get_banner_control: "&cBanner capture failed because you have reached your daily battle session limit (%d). Try again in %s."
-msg_war_siege_max_daily_player_battle_sessions_reached_cannot_get_kill_points: "&cBattle points not awarded because you have reached your daily battle session limit (%d). Try again in %s."
 msg_peaceful_town_subverted: "&b%s has been peacefully subverted and occupied by %s."
 msg_peaceful_town_revolted: "&b%s has peacefully revolted against %s, and freed itself from occupation."
 msg_town_became_peaceful: '&b%s has been confirmed as Peaceful. The town is now immune to siege attacks, but vulnerable to getting subverted by nearby nations. Residents cannot enter siege-zones or gain nation-military ranks.'


### PR DESCRIPTION
#### Description: 
- The recently release *Capping Limiter* feature, added a method to prevent extensive night capping. The feature contains a timed-point-limit, as designed. 
- However the current version of the feature also contains a kill-points-limit, which is not necessary to fulfill the ticketed requirement of anti-night-capping.
- I am concerned that the unnecessary kill-point-limit might be vulnerable to cheesing/exploiting (*although there have been no reports yet containing specific exploit steps*).
- Out of caution, this PR removes the unnecessary kill-point-limit, refactoring the feature into a purely "Capping Limiter".
- I hope to release this change as a Hotfix release.

#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
