### PR TITLE
Fix for wall breaching in liberation sieges

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/StartLiberationSiege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/StartLiberationSiege.java
@@ -58,9 +58,13 @@ public class StartLiberationSiege {
         if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.getPermissionNodeToStartSiege(SiegeType.LIBERATION)))
             throw new TownyException(Translation.of("msg_err_action_disable"));
 
-        Nation occupierNation = TownOccupationController.getTownOccupier(targetTown);
-        if (!nationOfSiegeStarter.hasEnemy(occupierNation))
+        Nation occupierNationOfTown = TownOccupationController.getTownOccupier(targetTown);
+        if (!nationOfSiegeStarter.hasEnemy(occupierNationOfTown))
             throw new TownyException(Translation.of("msg_err_siege_war_cannot_attack_occupied_town_non_enemy_nation"));
+
+        Nation naturalNationOfTown = targetTown.getNationOrNull();
+        if(!naturalNationOfTown.hasMutualAlly(nationOfSiegeStarter))
+            throw new TownyException(Translation.of("msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town"));
 
         if (TownySettings.getNationRequiresProximity() > 0) {
             Coord capitalCoord = nationOfSiegeStarter.getCapital().getHomeBlock().getCoord();
@@ -75,7 +79,7 @@ public class StartLiberationSiege {
             }
         }
 
-		SiegeCamp camp = new SiegeCamp(player, bannerBlock, SiegeType.LIBERATION, targetTown, nationOfSiegeStarter, occupierNation, townOfSiegeStarter, townBlock);
+		SiegeCamp camp = new SiegeCamp(player, bannerBlock, SiegeType.LIBERATION, targetTown, nationOfSiegeStarter, occupierNationOfTown, townOfSiegeStarter, townBlock);
 
 		PreSiegeCampEvent event = new PreSiegeCampEvent(camp);
 		Bukkit.getPluginManager().callEvent(event);

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/StartLiberationSiege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/StartLiberationSiege.java
@@ -58,12 +58,12 @@ public class StartLiberationSiege {
         if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.getPermissionNodeToStartSiege(SiegeType.LIBERATION)))
             throw new TownyException(Translation.of("msg_err_action_disable"));
 
-        Nation occupierNationOfTown = TownOccupationController.getTownOccupier(targetTown);
-        if (!nationOfSiegeStarter.hasEnemy(occupierNationOfTown))
+        Nation occupierNation = TownOccupationController.getTownOccupier(targetTown);
+        if (!nationOfSiegeStarter.hasEnemy(occupierNation))
             throw new TownyException(Translation.of("msg_err_siege_war_cannot_attack_occupied_town_non_enemy_nation"));
 
         Nation naturalNationOfTown = targetTown.getNationOrNull();
-        if(!naturalNationOfTown.hasMutualAlly(nationOfSiegeStarter))
+        if(naturalNationOfTown != null && !naturalNationOfTown.hasMutualAlly(nationOfSiegeStarter))
             throw new TownyException(Translation.of("msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town"));
 
         if (TownySettings.getNationRequiresProximity() > 0) {
@@ -79,7 +79,7 @@ public class StartLiberationSiege {
             }
         }
 
-		SiegeCamp camp = new SiegeCamp(player, bannerBlock, SiegeType.LIBERATION, targetTown, nationOfSiegeStarter, occupierNationOfTown, townOfSiegeStarter, townBlock);
+		SiegeCamp camp = new SiegeCamp(player, bannerBlock, SiegeType.LIBERATION, targetTown, nationOfSiegeStarter, occupierNation, townOfSiegeStarter, townBlock);
 
 		PreSiegeCampEvent event = new PreSiegeCampEvent(camp);
 		Bukkit.getPluginManager().callEvent(event);

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -512,4 +512,4 @@ msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Br
 msg_error_misconfigured_place_blocks_whitelist: '&cMisconfigured Material on Wall-Breaching-Place-Blocks-Whitelist. Problem Entry: %s'
 msg_error_misconfigured_destroy_blocks_blacklist: '&cMisconfigured Material on Wall-Breaching-Destroy-Blocks-Blacklist. Problem Entry: %s'
 #Liberation Siege Restriction
-msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town: '&cYou cannot start a liberation siege unless the natural nation of the target town is your ally.'
+msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town: '&cYou cannot start a liberation siege at this town, because the nation of the town is not your ally.'

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -511,3 +511,5 @@ msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Br
 #configuration-errors
 msg_error_misconfigured_place_blocks_whitelist: '&cMisconfigured Material on Wall-Breaching-Place-Blocks-Whitelist. Problem Entry: %s'
 msg_error_misconfigured_destroy_blocks_blacklist: '&cMisconfigured Material on Wall-Breaching-Destroy-Blocks-Blacklist. Problem Entry: %s'
+#Liberation Siege Restriction
+msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town: '&cYou cannot start a liberation siege unless the natural nation of the target town is your ally.'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -522,3 +522,5 @@ msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Br
 #configuration-errors
 msg_error_misconfigured_place_blocks_whitelist: '&cMisconfigured Material on Wall-Breaching-Place-Blocks-Whitelist. Problem Entry: %s'
 msg_error_misconfigured_destroy_blocks_blacklist: '&cMisconfigured Material on Wall-Breaching-Destroy-Blocks-Blacklist. Problem Entry: %s'
+#Liberation Siege Restriction
+msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town: '&cYou cannot start a liberation siege unless the natural nation of the target town is your ally.'

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -523,4 +523,4 @@ msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Br
 msg_error_misconfigured_place_blocks_whitelist: '&cMisconfigured Material on Wall-Breaching-Place-Blocks-Whitelist. Problem Entry: %s'
 msg_error_misconfigured_destroy_blocks_blacklist: '&cMisconfigured Material on Wall-Breaching-Destroy-Blocks-Blacklist. Problem Entry: %s'
 #Liberation Siege Restriction
-msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town: '&cYou cannot start a liberation siege unless the natural nation of the target town is your ally.'
+msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town: '&cYou cannot start a liberation siege at this town, because the nation of the town is not your ally.'


### PR DESCRIPTION
#### Description: 
- Wall breaching has an unexpectedly nasty implication at liberation sieges: Because the town owner doesn't get to choose the liberator who will generate breach points, an unpleasant liberator could grief the town excessively, by racking up breach points and letting the occupier team (who is also hostile to the town) do a lot of damage.
- In this PR I fix the problem as follows:
  - Liberation sieges at nation towns now require that the liberator and natural nation be allies.
  - Liberation sieges at nationless towns can proceed as before.
    - The Liberator will be the one who can rack up breach points.
    - It is possible that the Liberator is careless or unpleasant.
    - However the town has multiple options to solve this: In the short term it can surrender, and in the medium term it has the simple option of joining or creating a nation.
- Much thanks to @galacticwarrior9 for largely coming up with this solution.
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [ N/A ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
