### PR TITLE
Siege Balance Cap

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -200,7 +200,7 @@ public class SiegeWar extends JavaPlugin {
 				info(Translation.of("msg.battle.session.cleanup.starting"));
 				int numBattlesUpdated = 0;
 				for(Siege siege: siegesWithUnresolvedBattles) {
-					siege.setSiegeBalance(siege.getSiegeBalance() + siege.getAttackerBattlePoints() - siege.getDefenderBattlePoints());
+					siege.adjustSiegeBalance(siege.getAttackerBattlePoints() - siege.getDefenderBattlePoints());
 					siege.setAttackerBattlePoints(0);
 					siege.setDefenderBattlePoints(0);
 					SiegeController.saveSiege(siege);

--- a/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
@@ -252,7 +252,13 @@ public class Siege {
 	}
 
 	public void adjustSiegeBalance(int adjustment) {
-		siegeBalance += adjustment;
+		if(SiegeWarSettings.getSiegeBalanceCapValue() != -1) {
+			siegeBalance = Math.min(
+							siegeBalance + adjustment,
+							SiegeWarSettings.getSiegeBalanceCapValue());
+		} else {
+			siegeBalance += adjustment;
+		}
 	}
 
 	public double getWarChestAmount() {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -542,7 +542,7 @@ public enum ConfigNodes {
 			"20000",
 			"",
 			"# This value determines the siege balance cap.",
-			"# Set to -1 to disable the cap",
+			"# Set to -1 to disable the cap.",
 			"# The value applies to both positive and negative balances e.g. 20000 means a lower limit of -20000 and an upper limit of 20000.",
 			"# TIP: Set this value HIGH to give advantage to big nations, and LOW to give advantage to small nations."),
 	WAR_SIEGE_POINTS_BALANCING_CAPPING_LIMITER(

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -528,6 +528,23 @@ public enum ConfigNodes {
 			"",
 			"# This value determines the duration of each battle session.",
 			"# TIP: The default value of 50 is deliberately designed to give players a 10 minute break after each battle session, for reasons of health and safety."),
+	WAR_SIEGE_POINTS_SIEGE_BALANCE_CAP(
+			"war.siege.points_balancing.siege_balance_cap",
+			"",
+			"",
+			"",
+			"# +------------------------------------------------------+ #",
+			"# |                  Siege Balance Cap                     | #",
+			"# +------------------------------------------------------+ #",
+			""),
+	WAR_SIEGE_POINTS_SIEGE_BALANCE_CAP_VALUE(
+			"war.siege.points_balancing.siege_balance_cap.value",
+			"20000",
+			"",
+			"# This value determines the siege balance cap.",
+			"# Set to -1 to disable the cap",
+			"# The value applies to both positive and negative balances e.g. 20000 means a lower limit of -20000 and an upper limit of 20000.",
+			"# TIP: Set this value HIGH to give advantage to big nations, and LOW to give advantage to small nations."),
 	WAR_SIEGE_POINTS_BALANCING_CAPPING_LIMITER(
 			"war.siege.points_balancing.capping_limiter",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -617,4 +617,8 @@ public class SiegeWarSettings {
 	public static int getWallBreachingCannonExplosionCostPerBlock() {
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_CANNONS_INTEGRATION_EXPLODING_BLOCKS_COST_PER_BLOCK);
 	}
+
+	public static int getSiegeBalanceCapValue() {
+		return Settings.getInt(ConfigNodes.WAR_SIEGE_POINTS_SIEGE_BALANCE_CAP_VALUE);
+	}
 }


### PR DESCRIPTION
#### Description: 
- As per #462 , a siege balance cap may be a useful option for servers, to even the balance between large and small nations
- This PR adds it.

____
#### New Nodes/Commands/ConfigOptions: 
```
      # +------------------------------------------------------+ #
      # |                  Siege Balance Cap                     | #
      # +------------------------------------------------------+ #

      siege_balance_cap:
        # This value determines the siege balance cap.
        # Set to -1 to disable the cap
        # The value applies to both positive and negative balances e.g. 20000 means a lower limit of -20000 and an upper limit of 20000.
        # TIP: Set this value HIGH to give advantage to big nations, and LOW to give advantage to small nations.
        value: '20000'
```

____
#### Relevant Issue ticket:
Closes #462 

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
