### PR TITLE
nationzone fix

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -65,7 +65,7 @@ public class PlaceBlock {
 			//If the event is in a town and was cancelled by towny, SW might un-cancel the event via wall breaching
 			if(event.isCancelled()
 				&& SiegeWarSettings.isWallBreachingEnabled()
-				&& TownyAPI.getInstance().isWilderness(block)) {
+				&& !TownyAPI.getInstance().isWilderness(block)) {
 
 				Town town = TownyAPI.getInstance().getTown(block.getLocation());
 				if(!SiegeController.hasActiveSiege(town))

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -17,6 +17,7 @@ import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarWallBreachUtil;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
+import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.event.actions.TownyBuildEvent;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
@@ -61,10 +62,10 @@ public class PlaceBlock {
 			if (!TownyAPI.getInstance().getTownyWorld(block.getWorld()).isWarAllowed())
 				return;
 
-			//Unless in nationzone-wilderness, SW might uncancel a cancellation, via wall breaching
+			//If the block is in a town, SW might uncancel a cancellation, via wall breaching
 			if(event.isCancelled()
 				&& SiegeWarSettings.isWallBreachingEnabled()
-				&& !TownyAPI.getInstance().isNationZone(block.getLocation())) {
+				&& TownyAPI.getInstance().isWilderness(block)) {
 
 				Town town = TownyAPI.getInstance().getTown(block.getLocation());
 				if(town == null)

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -62,14 +62,12 @@ public class PlaceBlock {
 			if (!TownyAPI.getInstance().getTownyWorld(block.getWorld()).isWarAllowed())
 				return;
 
-			//If the block is in a town, SW might uncancel a cancellation, via wall breaching
+			//If the event is in a town and was cancelled by towny, SW might un-cancel the event via wall breaching
 			if(event.isCancelled()
 				&& SiegeWarSettings.isWallBreachingEnabled()
 				&& TownyAPI.getInstance().isWilderness(block)) {
 
 				Town town = TownyAPI.getInstance().getTown(block.getLocation());
-				if(town == null)
-					return; //SW currently doesn't un-cancel events in non-nationzone-wilderness
 				if(!SiegeController.hasActiveSiege(town))
 					return; //SW doesn't un-cancel events in unsieged towns
 				//Ensure player has permission

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -61,13 +61,14 @@ public class PlaceBlock {
 			if (!TownyAPI.getInstance().getTownyWorld(block.getWorld()).isWarAllowed())
 				return;
 
-			//If the event has already been cancelled by Towny...
-			if(event.isCancelled()) {
-				if(!SiegeWarSettings.isWallBreachingEnabled())
-					return; //Without wall breaching, SW doesn't un-cancel events
+			//Unless in nationzone-wilderness, SW might uncancel a cancellation, via wall breaching
+			if(event.isCancelled()
+				&& SiegeWarSettings.isWallBreachingEnabled()
+				&& !TownyAPI.getInstance().isNationZone(block.getLocation())) {
+
 				Town town = TownyAPI.getInstance().getTown(block.getLocation());
 				if(town == null)
-					return; //SW currently doesn't un-cancel wilderness events
+					return; //SW currently doesn't un-cancel events in non-nationzone-wilderness
 				if(!SiegeController.hasActiveSiege(town))
 					return; //SW doesn't un-cancel events in unsieged towns
 				//Ensure player has permission


### PR DESCRIPTION
#### Description: 
Fixes placement in nationzone issue

____
#### New Nodes/Commands/ConfigOptions: 
NA

____
#### Relevant Issue ticket:
NA

____
- [x] I have tested this pull request for defects on a server. 
  - Tested fix in world-protected wilderness
  - Could place banner and start siege as in 0.7.6
  - Although I didn't test a nationzone as such, I'm confident this fix will work, as the code which allows placing in siegezones has not changed and can be expected to kick in immediately after the siege start (see method "onNationZoneStatus")

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
