### PR TITLE
Install command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -321,7 +321,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 			file.set("nations.ranks.assistant", groupNodes);
 		}
 		file.save();
-		Messaging.sendMsg(sender, "Townyperms adjusted for recommended SW setup.");
+		Messaging.sendMsg(sender, Translation.of("msg.townyperms.installation.complete"));
 	}
 
 	private void setupTownyConfigFile(CommandSender sender) {
@@ -332,8 +332,8 @@ public class SiegeWarAdminCommand implements TabExecutor {
 		file.set("bankruptcy.nation_tax.do_bankrupt_towns_pay_nation_tax", "true");
 		file.set("town_ruins.enabled", "true");
 		file.set("town_ruins.min_duration_hours", "24");
-		file.save();
-		Messaging.sendMsg(sender, "Towny Config adjusted for recommended SW setup");
+		file.save();		
+		Messaging.sendMsg(sender, Translation.of("msg.townyconfig.installation.complete"));
 	}
 
 	private void showHelp(CommandSender sender) {

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -329,7 +329,6 @@ public class SiegeWarAdminCommand implements TabExecutor {
 		file.set("economy.price_town_neutrality", "0");
 		file.set("economy.price_nation_neutrality", "0");
 		file.set("economy.bankruptcy.enabled", "true");
-		file.set("economy.bankruptcy.nation_tax.do_bankrupt_towns_pay_nation_tax", "true");
 		file.set("town_ruining.town_ruins.enabled", "true");
 		file.set("town_ruining.town_ruins.min_duration_hours", "24");
 		file.save();		

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -326,12 +326,12 @@ public class SiegeWarAdminCommand implements TabExecutor {
 
 	private void setupTownyConfigFile(CommandSender sender) {
 		CommentedConfiguration file = TownySettings.getConfig();
-		file.set("price_town_neutrality", "0");
-		file.set("price_nation_neutrality", "0");
-		file.set("bankruptcy.enabled", "true");
-		file.set("bankruptcy.nation_tax.do_bankrupt_towns_pay_nation_tax", "true");
-		file.set("town_ruins.enabled", "true");
-		file.set("town_ruins.min_duration_hours", "24");
+		file.set("economy.price_town_neutrality", "0");
+		file.set("economy.price_nation_neutrality", "0");
+		file.set("economy.bankruptcy.enabled", "true");
+		file.set("economy.bankruptcy.nation_tax.do_bankrupt_towns_pay_nation_tax", "true");
+		file.set("town_ruining.town_ruins.enabled", "true");
+		file.set("town_ruining.town_ruins.min_duration_hours", "24");
 		file.save();		
 		Messaging.sendMsg(sender, Translation.of("msg.townyconfig.installation.complete"));
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -17,6 +17,7 @@ import com.gmail.goosius.siegewar.timeractions.DefenderTimedWin;
 import com.gmail.goosius.siegewar.utils.SiegeWarBattleSessionUtil;
 import com.palmergames.bukkit.config.CommentedConfiguration;
 import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
@@ -37,7 +38,7 @@ import java.util.List;
 
 public class SiegeWarAdminCommand implements TabExecutor {
 
-	private static final List<String> siegewaradminTabCompletes = Arrays.asList("battlesession","installperms","nation","reload","revoltimmunity","siege","siegeimmunity","town");
+	private static final List<String> siegewaradminTabCompletes = Arrays.asList("battlesession","install","nation","reload","revoltimmunity","siege","siegeimmunity","town");
 	private static final List<String> siegewaradminSiegeImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
 	private static final List<String> siegewaradminRevoltImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
 	private static final List<String> siegewaradminSiegeTabCompletes = Arrays.asList("setbalance","end","setplundered","setinvaded","remove");
@@ -163,8 +164,8 @@ public class SiegeWarAdminCommand implements TabExecutor {
 			case "nation":
 				parseSiegeWarNationCommand(sender, StringMgmt.remFirstArg(args));
 				break;
-			case "installperms":
-				parseInstallPermissionsCommand(sender);
+			case "install":
+				parseInstallCommand(sender);
 				break;
 			case "battlesession":
 				parseSiegeWarBattleSessionCommand(sender, StringMgmt.remFirstArg(args));
@@ -186,7 +187,13 @@ public class SiegeWarAdminCommand implements TabExecutor {
 		}
 	}
 	
-	private void parseInstallPermissionsCommand(CommandSender sender) {
+	private void parseInstallCommand(CommandSender sender) {
+		setupTownyPermsFile(sender);
+		setupTownyConfigFile(sender);
+		Messaging.sendMsg(sender, "Installation Complete");
+	}
+
+	private void setupTownyPermsFile(CommandSender sender) {
 		CommentedConfiguration file = TownyPerms.getTownyPermsFile();
 		List<String> groupNodes = new ArrayList<>();
 		String townpoints = "siegewar.town.siege.battle.points";
@@ -314,7 +321,19 @@ public class SiegeWarAdminCommand implements TabExecutor {
 			file.set("nations.ranks.assistant", groupNodes);
 		}
 		file.save();
-		Messaging.sendMsg(sender, "Permission nodes installed: see wiki for nodes you should give manually: https://git.io/JRSHW");
+		Messaging.sendMsg(sender, "Townyperms adjusted for recommended SW setup.");
+	}
+
+	private void setupTownyConfigFile(CommandSender sender) {
+		CommentedConfiguration file = TownySettings.getConfig();
+		file.set("price_town_neutrality", "0");
+		file.set("price_nation_neutrality", "0");
+		file.set("bankruptcy.enabled", "true");
+		file.set("bankruptcy.nation_tax.do_bankrupt_towns_pay_nation_tax", "true");
+		file.set("town_ruins.enabled", "true");
+		file.set("town_ruins.min_duration_hours", "24");
+		file.save();
+		Messaging.sendMsg(sender, "Towny Config adjusted for recommended SW setup");
 	}
 
 	private void showHelp(CommandSender sender) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -512,7 +512,7 @@ public enum ConfigNodes {
 			"# This setting applies to Monday, Tuesday, Wednesday, Thursday, and Friday.",
 			"# The format is HOUR:MINUTE.",
 			"# The default values are all at ten past the hour, so that the critical point of the battle (the final minutes), will fall on the hour.",
-			"# TIP: Do not use this setting to prevent night capping, as it will hurt cross-timezone players. Instead, use the 'Capping Limiter' for that purpose."),
+			"# TIP: DO NOT CHANGE THIS SETTING, as it does not work cross-timezone. Instead, if you want to restrict player-fighting-times, use the 'Capping Limiter' config for that purpose."),
 	WAR_SIEGE_POINTS_BALANCING_BATTLE_SESSION_TIMINGS_START_TIMES_WEEKEND_DAYS(
 			"war.siege.points_balancing.battle_session_timings.start_times.weekend_days",
 			"00:10,01:10,02:10,03:10,04:10,05:10,06:10,07:10,08:10,09:10,10:10,11:10,12:10,13:10,14:10,15:10,16:10,17:10,18:10,19:10,20:10,21:10,22:10,23:10",
@@ -521,7 +521,7 @@ public enum ConfigNodes {
 			"# This setting applies to Saturday and Sunday.",
 			"# The format is HOUR:MINUTE.",
 			"# The default values are all at ten past the hour, so that the critical point of the battle (the final minutes), will fall on the hour.",
-			"# TIP: Do not use this setting to prevent night capping, as it will hurt cross-timezone players. Instead, use the 'Capping Limiter' for that purpose."),
+			"# TIP: DO NOT CHANGE THIS SETTING, as it does not work cross-timezone. Instead, if you want to restrict player-fighting-times, use the 'Capping Limiter' config for that purpose."),
 	WAR_SIEGE_POINTS_BALANCING_BATTLE_SESSION_TIMINGS_DURATION_MINUTES(
 			"war.siege.points_balancing.battle_session_timings.duration_minutes",
 			"50",

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.35
+version: 0.36
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -504,9 +504,13 @@ msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Br
 #Wall-Breach Cannons Integration
 msg_err_cannot_fire_cannon_without_battle_session: '&cYou cannot fire a cannon in a siegezone unless there is a Battle Session in progress.'
 msg_err_cannot_fire_cannon_without_perms: '&cYou cannot fire this cannon. Check that you are an official participant in the local siege, and that you have a rank which allows cannon-firing.'
-
 #configuration-errors
 msg_error_misconfigured_place_blocks_whitelist: '&cMisconfigured Material on Wall-Breaching-Place-Blocks-Whitelist. Problem Entry: %s.'
 msg_error_misconfigured_destroy_blocks_blacklist: '&cMisconfigured Material on Wall-Breaching-Destroy-Blocks-Blacklist. Problem Entry: %s.'
 #Liberation Siege Restriction
 msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town: '&cYou cannot start a liberation siege at this town, because the nation of the town is not your ally.'
+
+#Added in 0.36
+msg.townyperms.installation.complete: "Townyperms file adjusted for recommended SW setup."
+msg.townyconfig.installation.complete: "Towny config file adjusted for recommended SW setup."
+msg.installation.complete: "Installation Complete."

--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -512,6 +512,6 @@ msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town: '&cYou cannot 
 
 #Added in 0.36
 msg_err_nation_neutrality_not_supported: '&cSiegeWar does not support nation neutrality.'
-msg.townyperms.installation.complete: "Townyperms file adjusted for recommended SW setup."
+msg.townyperms.installation.complete: "Towny perms file adjusted for recommended SW setup."
 msg.townyconfig.installation.complete: "Towny config file adjusted for recommended SW setup."
 msg.installation.complete: "Installation Complete."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -1,5 +1,5 @@
 ﻿name: SiegeWar
-version: 0.35
+version: 0.36
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -515,9 +515,13 @@ msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Br
 #Wall-Breach Cannons Integration
 msg_err_cannot_fire_cannon_without_battle_session: '&cYou cannot fire a cannon in a siegezone unless there is a Battle Session in progress.'
 msg_err_cannot_fire_cannon_without_perms: '&cYou cannot fire this cannon. Check that you are an official participant in the local siege, and that you have a rank which allows cannon-firing.'
-
 #configuration-errors
 msg_error_misconfigured_place_blocks_whitelist: '&cMisconfigured Material on Wall-Breaching-Place-Blocks-Whitelist. Problem Entry: %s.'
 msg_error_misconfigured_destroy_blocks_blacklist: '&cMisconfigured Material on Wall-Breaching-Destroy-Blocks-Blacklist. Problem Entry: %s.'
 #Liberation Siege Restriction
 msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town: '&cYou cannot start a liberation siege at this town, because the nation of the town is not your ally.'
+
+#Added in 0.36
+msg.townyperms.installation.complete: "Townyperms file adjusted for recommended SW setup."
+msg.townyconfig.installation.complete: "Towny config file adjusted for recommended SW setup."
+msg.installation.complete: "Installation Complete."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -523,6 +523,6 @@ msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town: '&cYou cannot 
 
 #Added in 0.36
 msg_err_nation_neutrality_not_supported: '&cSiegeWar does not support nation neutrality.'
-msg.townyperms.installation.complete: "Townyperms file adjusted for recommended SW setup."
+msg.townyperms.installation.complete: "Towny perms file adjusted for recommended SW setup."
 msg.townyconfig.installation.complete: "Towny config file adjusted for recommended SW setup."
 msg.installation.complete: "Installation Complete."


### PR DESCRIPTION
#### Description: 
- Currently the install guide requires manual file changing to set up the Towny configs which are recommended for SW
- To make life easier for installers, the PR replacing the existing `swa installperms` command with `/sw install`, which sets up both the required/recommended configs and perms.

__
#### New Nodes/Commands/ConfigOptions: 
- New command: `/swa install`

____
#### Relevant Issue ticket:
Closes #474 

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
