### PR TITLE
Glowing Refactor for performance improvement

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -369,7 +369,7 @@ public class SiegeWarBannerControlUtil {
 			BannerControlSession glowingSession = null;
 			for(BannerControlSession bannerControlSession: sessions) {
 				if(glowingSession == null
-					|| bannerControlSession.getSessionEndTime() > glowingSession.getSessionEndTime()) {
+					|| bannerControlSession.getSessionEndTime() < glowingSession.getSessionEndTime()) {
 					glowingSession = bannerControlSession;
 				}
 			}


### PR DESCRIPTION
#### Description: 
- With current code, glowing can still make things laggy..... because although most times nobody glows, when it does activate, a lot of people in a small area can glow at the same time!
- This PR improves the pattern, by refactoring to this:
  - Of the capping attackers, only the one with the shortest timer glows.
  - Of the capping defenders, only the one with the shortest timer glows.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A


____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
