### PR TITLE
Automatic config field migration

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -5,6 +5,7 @@ import com.gmail.goosius.siegewar.metadata.ResidentMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.settings.Translation;
+import com.gmail.goosius.siegewar.utils.MigrationUtil;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Resident;
 import org.bukkit.Bukkit;
@@ -68,7 +69,7 @@ public class SiegeWar extends JavaPlugin {
         } else {
             info("Towny version " + getTownyVersion() + " found.");
         }
-        
+
         if (!loadAll()) {
 	        siegeWarPluginError = true;
         }
@@ -93,7 +94,9 @@ public class SiegeWar extends JavaPlugin {
     
     private boolean loadAll() {
     	return !Towny.getPlugin().isError()
+				&& MigrationUtil.readInConfigFileMigrationFields()
 				&& Settings.loadSettingsAndLang()
+				&& MigrationUtil.migrateConfigFileFields()
 				&& SiegeController.loadAll()
 				&& TownOccupationController.loadAll();
     }

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -69,7 +69,7 @@ public class SiegeWar extends JavaPlugin {
         } else {
             info("Towny version " + getTownyVersion() + " found.");
         }
-
+        
         if (!loadAll()) {
 	        siegeWarPluginError = true;
         }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -398,8 +398,7 @@ public enum ConfigNodes {
 			"war.siege.points_balancing.base_points.banner_control.defender",
 			"10",
 			"",
-			"# This value determines the number of battle points awarded every SiegeWar-tick (20 seconds) to a defender with banner-control.",
-			"# TIP: Always keep this value at 10, for easier comparison with other server configurations."),
+			"# This value determines the number of battle points awarded every SiegeWar-tick (20 seconds) to a defender with banner-control."),
     WAR_SIEGE_POINTS_BALANCING_BASE_POINTS_DEATHS(
 			"war.siege.points_balancing.base_points.deaths",
 			"",
@@ -433,7 +432,6 @@ public enum ConfigNodes {
 			"# If the wall breaching feature is enabled (in the 'Wall Breaching' config section), this value determines the number of Battle Points awarded by the Wall Breach Bonus.",
 			"# To get the bonus, hostile-to-town players must capture the banner first, then get to the homeblock.",
 			"# TIP: Players are required to cap first, because otherwise they could log off at the homeblock after getting the bonus, and then in the next session, simply log back in to get the bonus again."),
-
 	WAR_SIEGE_POINTS_BALANCING_BANNER_CONTROL_REVERSAL_BONUS(
 			"war.siege.points_balancing.banner_control_reversal_bonus",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/Settings.java
@@ -181,4 +181,8 @@ public class Settings {
 	public static File getBattleIconFile() {
 		return battleIconFile;
 	}
+
+	public static CommentedConfiguration getConfig() {
+		return config;
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/MigrationUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/MigrationUtil.java
@@ -1,0 +1,103 @@
+package com.gmail.goosius.siegewar.utils;
+
+import com.gmail.goosius.siegewar.SiegeWar;
+import com.gmail.goosius.siegewar.settings.Settings;
+import com.palmergames.bukkit.config.CommentedConfiguration;
+import com.palmergames.bukkit.towny.exceptions.TownyException;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This util is for assisting with migrating configs, perms, metadata etc.
+ */
+public class MigrationUtil {
+
+    private static Set<ConfigFileMigrationField> migrationFields = new HashSet<>();
+    static {
+        //Points balancing migration
+        migrationFields.add(new ConfigFileMigrationField("war.siege.scoring.points_for_attacker_occupation","war.siege.points_balancing.base_points.banner_control.attacker"));
+        migrationFields.add(new ConfigFileMigrationField("war.siege.scoring.points_for_defender_occupation","war.siege.points_balancing.base_points.banner_control.defender"));
+        migrationFields.add(new ConfigFileMigrationField("war.siege.scoring.points_for_attacker_death","war.siege.points_balancing.base_points.deaths.attacker"));
+        migrationFields.add(new ConfigFileMigrationField("war.siege.scoring.points_for_defender_death","war.siege.points_balancing.base_points.deaths.defender"));
+        migrationFields.add(new ConfigFileMigrationField("war.siege.scoring.winner_takes_all_points","war.siege.points_balancing.end_of_battle_points_distribution.winner_takes_all"));
+        migrationFields.add(new ConfigFileMigrationField("war.siege.switches.counterattack_booster_enabled","war.siege.points_balancing.counterattack_booster.enabled"));
+        migrationFields.add(new ConfigFileMigrationField("war.siege.scoring.counterattack_booster_extra_death_points_per_player_percentage","war.siege.points_balancing.counterattack_booster.extra_death_points_per_player_percentage"));
+        migrationFields.add(new ConfigFileMigrationField("war.siege.banner_control_reversal_bonus.enabled","war.siege.points_balancing.banner_control_reversal_bonus.enabled"));
+        migrationFields.add(new ConfigFileMigrationField("war.siege.banner_control_reversal_bonus.multiplier","war.siege.points_balancing.banner_control_reversal_bonus.multiplier"));
+        migrationFields.add(new ConfigFileMigrationField("war.siege.battle_session.duration_minutes","war.siege.points_balancing.battle_session_timings.duration_minutes"));
+        migrationFields.add(new ConfigFileMigrationField("war.siege.battle_session.capping_limiter.weekdays","war.siege.points_balancing.capping_limiter.weekdays"));
+        migrationFields.add(new ConfigFileMigrationField("war.siege.battle_session.capping_limiter.weekend_days","war.siege.points_balancing.capping_limiter.weekend_days"));
+        //Peaceful towns migration
+        migrationFields.add(new ConfigFileMigrationField("peaceful_towns.enabled","neutral_towns.enabled"));
+        migrationFields.add(new ConfigFileMigrationField("peaceful_towns.confirmation_requirement_days","neutral_towns.confirmation_requirement_days"));
+        migrationFields.add(new ConfigFileMigrationField("peaceful_towns.new_town_confirmation_requirement_days","neutral_towns.new_town_confirmation_requirement_days"));
+        migrationFields.add(new ConfigFileMigrationField("peaceful_towns.subvert_enabled","neutral_towns.subvert_enabled"));
+        migrationFields.add(new ConfigFileMigrationField("peaceful_towns.revolt_enabled","neutral_towns.revolt_enabled"));
+        migrationFields.add(new ConfigFileMigrationField("peaceful_towns.towny_influence_radius","neutral_towns.towny_influence_radius")); 
+    }
+
+    /**
+     * Read in the config fields to migrate
+     */
+    public static boolean readInConfigFileMigrationFields() {
+        try {
+            String configFilePath = SiegeWar.getSiegeWar().getDataFolder().getPath() + File.separator + "config.yml";
+            if (FileMgmt.checkOrCreateFile(configFilePath)) {
+                File file = new File(configFilePath);
+                // read the config.yml into memory
+                CommentedConfiguration config = new CommentedConfiguration(file.toPath());
+                if (!config.load()) {
+                    throw new TownyException("Failed to load config");
+                }
+                //Read in migration fields
+                for(ConfigFileMigrationField migrationField: migrationFields) {
+                    migrationField.value = config.get(migrationField.oldKey);
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            SiegeWar.severe(e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Migrate config fields
+     */
+    public static boolean migrateConfigFileFields() {
+        try {
+            CommentedConfiguration config = Settings.getConfig();
+            //migrate fields
+            for(ConfigFileMigrationField migrationField: migrationFields) {
+                if(migrationField.value != null) {
+                    config.set(migrationField.newKey, migrationField.value);
+                }
+            }
+            //Save to disk
+            config.save();
+            return true;
+        } catch (Exception e) {
+            SiegeWar.severe(e.getMessage());
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Inner class representing a field to migrate
+     */
+    private static class ConfigFileMigrationField {
+        final String oldKey;
+        final String newKey;
+        Object value;
+
+        private ConfigFileMigrationField(String oldKey, String newKey) {
+            this.oldKey = oldKey;
+            this.newKey = newKey;
+            value = null;
+        }
+    }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/MigrationUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/MigrationUtil.java
@@ -49,13 +49,14 @@ public class MigrationUtil {
                 // read the config.yml into memory
                 CommentedConfiguration config = new CommentedConfiguration(file.toPath());
                 if (!config.load()) {
-                    throw new TownyException("Failed to load config");
+                    throw new TownyException("Failed to load existing config file.");
                 }
                 //Read in migration fields
                 for(ConfigFileMigrationField migrationField: migrationFields) {
                     migrationField.value = config.get(migrationField.oldKey);
                 }
             }
+            SiegeWar.info("Successfully read existing config file.");
             return true;
         } catch (Exception e) {
             SiegeWar.severe(e.getMessage());
@@ -69,15 +70,20 @@ public class MigrationUtil {
      */
     public static boolean migrateConfigFileFields() {
         try {
+            int numMigratedFields = 0;
             CommentedConfiguration config = Settings.getConfig();
             //migrate fields
             for(ConfigFileMigrationField migrationField: migrationFields) {
                 if(migrationField.value != null) {
                     config.set(migrationField.newKey, migrationField.value);
+                    numMigratedFields++;
                 }
             }
-            //Save to disk
-            config.save();
+            if(numMigratedFields > 0) {
+                //Save to disk
+                config.save();
+                SiegeWar.info("Successfully migrated " + numMigratedFields + " fields.");
+            }
             return true;
         } catch (Exception e) {
             SiegeWar.severe(e.getMessage());

--- a/src/main/java/com/gmail/goosius/siegewar/utils/MigrationUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/MigrationUtil.java
@@ -53,7 +53,10 @@ public class MigrationUtil {
                 }
                 //Read in migration fields
                 for(ConfigFileMigrationField migrationField: migrationFields) {
-                    migrationField.value = config.get(migrationField.oldKey);
+                    //Read if old field exists AND is not dummy
+                    if(config.contains(migrationField.oldKey) && config.getComments(migrationField.oldKey).size() >0 ) {
+                        migrationField.value = config.get(migrationField.oldKey);
+                    }
                 }
             }
             SiegeWar.info("Successfully read existing config file.");


### PR DESCRIPTION
#### Description: 
- Since 0.7.0, there are now 18 config field which need migration.
- This PR automates that task, by doing it automatically when, after dropping in the new jar, the server is restarted.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
