### PR TITLE
Cannons Integration - added new rule to improve gameplay

### DIFF
--- a/src/main/resources/english.yml
+++ b/src/main/resources/english.yml
@@ -515,3 +515,4 @@ msg.installation.complete: "Installation Complete."
 
 #Added in 0.37
 msg_siege_zone_proximity_warning_text: "&cWARNING: You are in a SiegeZone!. If you are not prepared for combat, get to a safe location immediately before you get murdered."
+msg_err_cannon_must_be_in_wilderness_or_besieged_town: "&cWithin SiegeZones, cannons can only be fired if they are in the wilderness or the besieged town."

--- a/src/main/resources/french.yml
+++ b/src/main/resources/french.yml
@@ -526,3 +526,4 @@ msg.installation.complete: "Installation Complete."
 
 #Added in 0.37
 msg_siege_zone_proximity_warning_text: "&cWARNING: You are in a SiegeZone!. If you are not prepared for combat, get to a safe location immediately before you get murdered."
+msg_err_cannon_must_be_in_wilderness_or_besieged_town: "&cWithin SiegeZones, cannons can only be fired if they are in the wilderness or the besieged town."


### PR DESCRIPTION
#### Description: 
- With current code, cannons can be fired, without reply, from towns which are not the sieged town
- This does not seem good
- In this PR I fix the issue by forcing siegezone cannons to be fired from either the besieged town or the wilderness
 
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [ N/A ] I have tested this pull request for defects on a server. 
(I viewed the previous PR on cannons refactor and confirmed that the cannons method used here is correct)

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
