### PR TITLE
Changed map hiding config default to false

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -757,7 +757,7 @@ public enum ConfigNodes {
 			""),
 	WAR_SIEGE_MAP_HIDING_ENABLED(
 			"war.siege.map_hiding.enabled",
-			"true",
+			"false",
 			"",
 			"# If this setting is true, then the map hiding feature is enabled.",
 			"# This feature allow players to disappear from the dynmap, allowing military tactics.",


### PR DESCRIPTION
#### Description: 
- Most server users today don't seem hardcore enough to remove players from the dynmap for the sake of enabling extra military tactics.
- This PR leaves the map-hiding feature as-is,  but simply sets a more sensible default of enabled=false.
 
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [  N/A  ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
