### PR TITLE
Fxed banner cap boss bars not disappearing

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/BossBarUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/BossBarUtil.java
@@ -33,7 +33,7 @@ public class BossBarUtil {
 		}
 		bossBarBattleSessionMap.clear();
 	}
-	
+
 	public static void updateBattleSessionBossBar() {
 		BattleSession session = BattleSession.getBattleSession();
 		TextComponent comp = Component.text(Translation.of("bossbar_msg_battle_time_remaining", session.getFormattedTimeRemainingUntilBattleSessionEnds()));

--- a/src/main/java/com/gmail/goosius/siegewar/utils/BossBarUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/BossBarUtil.java
@@ -33,7 +33,7 @@ public class BossBarUtil {
 		}
 		bossBarBattleSessionMap.clear();
 	}
-
+	
 	public static void updateBattleSessionBossBar() {
 		BattleSession session = BattleSession.getBattleSession();
 		TextComponent comp = Component.text(Translation.of("bossbar_msg_battle_time_remaining", session.getFormattedTimeRemainingUntilBattleSessionEnds()));

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -76,7 +76,7 @@ public class SiegeWarBattleSessionUtil {
 		//Send message
 		sendBattleSessionEndedMessage(battleResults);
 		
-		//Remove BossBar
+		//Remove Battle Session Boss-Bars
 		BossBarUtil.removeBattleSessionBossBars();
 	}
 
@@ -109,6 +109,11 @@ public class SiegeWarBattleSessionUtil {
 							}
 						});
 					}
+				}
+
+				//Remove banner cap boss bars
+				for(Player player: siege.getBannerControlSessions().keySet()) {
+					BossBarUtil.removeBannerCapBossBar(player);
 				}
 
 				//Clear battle related stats from the siege


### PR DESCRIPTION
#### Description: 
- Currently, at the end of a battle session or siege, the banner cap boss bars do not get removed.
- This PR fixes the issue by removing them in those scenarios

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [  N/A  ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
