### PR TITLE
Deal with pvp toggle

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -250,10 +250,6 @@ public class SiegeWarBukkitEventListener implements Listener {
 		if(!(event instanceof Player))
 			return;
 
-		//Return if the event did not occur in a siegezone
-		if(!SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getEntity().getLocation())) 
-			return;
-
 		//Override any previous cancellation attempts
 		Boolean eventIsInActiveSiegeZone = null;
 		if(event.isCancelled()) {


### PR DESCRIPTION
#### Description: 
- Currently SiegeWar cannot work with the (apparently popular) PvpToggle plugin, because that plugin allows players to go immune to damage in Siegezones. 
- This PR resolves the issue, by overriding the damage cancelling that pvptoggle is doing.
- Servers will still have to config the pvpt messages to blank to avoid getting false positive cancellation spam. After that, the integration should be fine.
- Server owner Tree has requested this.

 ____
#### New Nodes/Commands/ConfigOptions: 
Na


____
#### Relevant Issue ticket:
Na


____
- [ Na - I have limited capability to test pvp locally. Double checked code and I think it is ok.

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
