### PR TITLE
Wall Breaching - Remove banner cap requirement for bonus

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -140,5 +140,4 @@ public class ResidentMetaDataController {
 		else
 			resident.addMetaData(new StringDataField("siegewar_recentbattlesessions", value));
 	}
-
 }

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -22,6 +22,7 @@ public class ResidentMetaDataController {
 	private SiegeWar plugin;
 	private static IntegerDataField plunderAmount = new IntegerDataField("siegewar_plunder", 0); //Field no longer in use
 	private static IntegerDataField militarySalaryAmount = new IntegerDataField("siegewar_militarysalary", 0);
+	private static StringDataField wallBreachFatigue = new StringDataField("siegewar_wallbreachfatigue");
 	/*
 	 * A list of battle sessions the player was recently involved in
 	 * Sessions are identified by their start times (in millis)
@@ -140,4 +141,24 @@ public class ResidentMetaDataController {
 		else
 			resident.addMetaData(new StringDataField("siegewar_recentbattlesessions", value));
 	}
+
+	public static boolean hasWallBreachFatigue(Resident resident) {
+		StringDataField sdf = (StringDataField) wallBreachFatigue.clone();
+		return resident.hasMeta(sdf.getKey());
+	}
+
+	public static void removeWallBreachFatigue(Resident resident) {
+		StringDataField sdf = (StringDataField) wallBreachFatigue.clone();
+		if (resident.hasMeta(sdf.getKey())) {
+			resident.removeMetaData(sdf);
+		}		
+	}
+
+	public static void addWallBreachFatigue(Resident resident) {
+		StringDataField sdf = (StringDataField) wallBreachFatigue.clone();
+		if (!resident.hasMeta(sdf.getKey())) {
+			resident.addMetaData(new StringDataField("siegewar_wallbreachfatigue"));
+		}		
+	}
+
 }

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -22,7 +22,6 @@ public class ResidentMetaDataController {
 	private SiegeWar plugin;
 	private static IntegerDataField plunderAmount = new IntegerDataField("siegewar_plunder", 0); //Field no longer in use
 	private static IntegerDataField militarySalaryAmount = new IntegerDataField("siegewar_militarysalary", 0);
-	private static StringDataField wallBreachFatigue = new StringDataField("siegewar_wallbreachfatigue");
 	/*
 	 * A list of battle sessions the player was recently involved in
 	 * Sessions are identified by their start times (in millis)
@@ -140,25 +139,6 @@ public class ResidentMetaDataController {
 			MetaDataUtil.setString(resident, sdf, value, true);
 		else
 			resident.addMetaData(new StringDataField("siegewar_recentbattlesessions", value));
-	}
-
-	public static boolean hasWallBreachFatigue(Resident resident) {
-		StringDataField sdf = (StringDataField) wallBreachFatigue.clone();
-		return resident.hasMeta(sdf.getKey());
-	}
-
-	public static void removeWallBreachFatigue(Resident resident) {
-		StringDataField sdf = (StringDataField) wallBreachFatigue.clone();
-		if (resident.hasMeta(sdf.getKey())) {
-			resident.removeMetaData(sdf);
-		}		
-	}
-
-	public static void addWallBreachFatigue(Resident resident) {
-		StringDataField sdf = (StringDataField) wallBreachFatigue.clone();
-		if (!resident.hasMeta(sdf.getKey())) {
-			resident.addMetaData(new StringDataField("siegewar_wallbreachfatigue"));
-		}		
 	}
 
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -575,7 +575,7 @@ public enum ConfigNodes {
 			"",
 			"# If true, then the wall breaching feature is enabled.",
 			"# If false, then the wall breaching feature is disabled.",
-			"# TIP: This feature is disabled by default, to allow servers owners to carefully review the feature before enabling."),
+			"# TIP: This feature is disabled by default, to allow servers owners to configure the feature carefully before enabling."),
 	WAR_SIEGE_WALL_BREACHING_BREACH_POINT_GENERATION(
 			"war.siege.wall_breaching.breach_point_generation",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWallBreachUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWallBreachUtil.java
@@ -85,10 +85,10 @@ public class SiegeWarWallBreachUtil {
      * Award wall-breach bonuses if conditions are met.
      * 
      * Conditions:
-     * - Town hostile team has Banner Control.
-     * - Player is the BC list.
      * - Player is at the homeblock.
+     * - Player is on the town-hostile side
      * - Player did not already get the award in this Battle Session.
+     * - Player does not have wall-breach fatigue
      *
      * @param siege the siege
      */

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWallBreachUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWallBreachUtil.java
@@ -83,7 +83,6 @@ public class SiegeWarWallBreachUtil {
      * - Player is at the homeblock.
      * - Player is on the town-hostile side
      * - Player did not already get the award in this Battle Session.
-     * - Player does not have wall-breach fatigue
      *
      * @param siege the siege
      */

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWallBreachUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWallBreachUtil.java
@@ -36,12 +36,12 @@ public class SiegeWarWallBreachUtil {
 
         //Cycle all sieges
         for (Siege siege : SiegeController.getSieges()) {
-            if(siege.getStatus() != SiegeStatus.IN_PROGRESS) 
+            if(siege.getStatus() != SiegeStatus.IN_PROGRESS)
                 continue;
             increaseBreachPointsFromBannerControl(siege);
             awardWallBreachBonuses(siege);
             CannonsIntegration.clearRecentTownFriendlycannonFirers(siege);   
-        }        
+        }
     }
 
     /**
@@ -94,27 +94,28 @@ public class SiegeWarWallBreachUtil {
             return;
 
         //Cycle online players
-        Resident resident;
+        Resident candidate;
         Set<Resident> newAwardees = new HashSet<>();
         Set<Resident> previousAwardees = new HashSet<>(siege.getWallBreachBonusAwardees());
         for(Player player: Bukkit.getOnlinePlayers()) {
+            //Candidate must be at the homeblock of the besieged town
             TownBlock townblockWherePlayerIsLocated = TownyAPI.getInstance().getTownBlock(player);
             if(townblockWherePlayerIsLocated == null)
                 continue;
             if(townblockWherePlayerIsLocated != siege.getTown().getHomeBlockOrNull())
                 continue;
-            resident = TownyAPI.getInstance().getResident(player);
-            if(!SiegeWarAllegianceUtil.isPlayerOnTownHostileSide(player, resident, siege))
+            candidate = TownyAPI.getInstance().getResident(player);
+            if(!SiegeWarAllegianceUtil.isPlayerOnTownHostileSide(player, candidate, siege))
                 continue;
 
             //Candidate must not already have award
-            if(previousAwardees.contains(resident)) {
+            if(previousAwardees.contains(candidate)) {
                 Messaging.sendErrorMsg(player, Translatable.of("msg_err_already_received_wall_breach_bonus"));
                 continue;                                       
             }
 
             //Mark candidate to receive bonus
-            newAwardees.add(resident);
+            newAwardees.add(candidate);
 
             //Notify player
             Messaging.sendMsg(player, Translatable.of("msg_wall_breach_bonus_awarded"));
@@ -127,8 +128,8 @@ public class SiegeWarWallBreachUtil {
             if(siege.getSiegeType() == SiegeType.CONQUEST || siege.getSiegeType() == SiegeType.SUPPRESSION) {
                 siege.adjustAttackerBattlePoints(battlePointsBonus);                
             } else {
-                siege.adjustDefenderBattlePoints(battlePointsBonus);            
-            } 
+                siege.adjustDefenderBattlePoints(battlePointsBonus);
+            }
 
             //Register new awardees with Siege
             siege.getWallBreachBonusAwardees().addAll(newAwardees);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWallBreachUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWallBreachUtil.java
@@ -2,11 +2,9 @@ package com.gmail.goosius.siegewar.utils;
 
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
-import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.integration.cannons.CannonsIntegration;
-import com.gmail.goosius.siegewar.metadata.ResidentMetaDataController;
 import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
@@ -218,5 +216,4 @@ public class SiegeWarWallBreachUtil {
 			return true;
 		}
 	}
-
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWallBreachUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWallBreachUtil.java
@@ -34,9 +34,6 @@ public class SiegeWarWallBreachUtil {
         if(!BattleSession.getBattleSession().isActive())
             return;
 
-        //Remove wall breaching fatigue from residents
-        removeWallBreachFatigue();
-
         //Cycle all sieges
         for (Siege siege : SiegeController.getSieges()) {
             if(siege.getStatus() != SiegeStatus.IN_PROGRESS) 
@@ -116,17 +113,8 @@ public class SiegeWarWallBreachUtil {
                 continue;                                       
             }
 
-            //Candidate must not have wall breach fatigue
-            if(ResidentMetaDataController.hasWallBreachFatigue(resident)) {
-                Messaging.sendErrorMsg(player, "Yall has wall breach fatigue");
-                continue;                                                       
-            }
-
             //Mark candidate to receive bonus
             newAwardees.add(resident);
-
-            //Give wall breach fatigue to resident
-            ResidentMetaDataController.addWallBreachFatigue(resident);
 
             //Notify player
             Messaging.sendMsg(player, Translatable.of("msg_wall_breach_bonus_awarded"));
@@ -136,12 +124,12 @@ public class SiegeWarWallBreachUtil {
         if(newAwardees.size() > 0) {         
             //Adjust Battle Points
             int battlePointsBonus = SiegeWarSettings.getWallBreachBonusBattlePoints() * newAwardees.size();
-            if(siege.getBannerControllingSide() == SiegeSide.ATTACKERS) {
+            if(siege.getSiegeType() == SiegeType.CONQUEST || siege.getSiegeType() == SiegeType.SUPPRESSION) {
                 siege.adjustAttackerBattlePoints(battlePointsBonus);                
             } else {
-                siege.adjustDefenderBattlePoints(battlePointsBonus);
-            }
-            
+                siege.adjustDefenderBattlePoints(battlePointsBonus);            
+            } 
+
             //Register new awardees with Siege
             siege.getWallBreachBonusAwardees().addAll(newAwardees);
 
@@ -229,22 +217,5 @@ public class SiegeWarWallBreachUtil {
 			return true;
 		}
 	}
-
-    /**
-     * Remove wall breach fatigue from online residents
-     */	
-    private static void removeWallBreachFatigue() {
-        Resident resident;
-        for(Player player: Bukkit.getOnlinePlayers()) {
-            resident = TownyAPI.getInstance().getResident(player);
-            if(ResidentMetaDataController.hasWallBreachFatigue(resident)) {
-                if(TownyAPI.getInstance().isWilderness(player.getLocation())) {
-                    ResidentMetaDataController.removeWallBreachFatigue(resident);
-                    Messaging.sendMsg(player, "Wall Breach Fatigue removed. You are no longer blocked from getting Wall Breach Bonuses.");    
-                } 
-            }
-        }
-
-    }
 
 }

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.40
+version: 0.39
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -485,7 +485,7 @@ msg_err_breaching_cannot_destroy_this_material: '&cYou cannot destroy this type 
 #Wall-Breach-Bonus
 msg_wall_breach_bonus_awarded_to_attackers: "&bSiege on %s > %d attackers have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
 msg_wall_breach_bonus_awarded_to_defenders: "&bSiege on %s > %d defenders have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
-msg_wall_breach_bonus_awarded: "&bYou have been awarded a wall breach bonus!. If you wish to gain the bonus in future battle sessions, make sure to leave the town first before returning to the homeblock."
+msg_wall_breach_bonus_awarded: "&bYou have been awarded a wall breach bonus!"
 msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Breach-Bonus for this Battle Session.'
 #Wall-Breach Cannons Integration
 msg_err_cannot_fire_cannon_without_battle_session: '&cYou cannot fire a cannon in a siegezone unless there is a Battle Session in progress.'

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.39
+version: 0.40
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -485,7 +485,7 @@ msg_err_breaching_cannot_destroy_this_material: '&cYou cannot destroy this type 
 #Wall-Breach-Bonus
 msg_wall_breach_bonus_awarded_to_attackers: "&bSiege on %s > %d attackers have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
 msg_wall_breach_bonus_awarded_to_defenders: "&bSiege on %s > %d defenders have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
-msg_wall_breach_bonus_awarded: "&bYou have been awarded a wall breach bonus."
+msg_wall_breach_bonus_awarded: "&bYou have been awarded a wall breach bonus!. If you wish to gain the bonus in future battle sessions, make sure to leave the town first before returning to the homeblock."
 msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Breach-Bonus for this Battle Session.'
 #Wall-Breach Cannons Integration
 msg_err_cannot_fire_cannon_without_battle_session: '&cYou cannot fire a cannon in a siegezone unless there is a Battle Session in progress.'

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.39
+version: 0.40
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -485,8 +485,8 @@ msg_err_breaching_cannot_destroy_this_material: '&cYou cannot destroy this type 
 #Wall-Breach-Bonus
 msg_wall_breach_bonus_awarded_to_attackers: "&bSiege on %s > %d attackers have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
 msg_wall_breach_bonus_awarded_to_defenders: "&bSiege on %s > %d defenders have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
-msg_wall_breach_bonus_awarded: "&bYou have been awarded a wall breach bonus!"
-msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Breach-Bonus for this Battle Session.'
+msg_wall_breach_bonus_awarded: "&bYou have been awarded a Wall Breach Bonus!"
+msg_err_already_received_wall_breach_bonus: '&cYou already received a Wall Breach Bonus for this Battle Session.'
 #Wall-Breach Cannons Integration
 msg_err_cannot_fire_cannon_without_battle_session: '&cYou cannot fire a cannon in a siegezone unless there is a Battle Session in progress.'
 msg_err_cannot_fire_cannon_without_perms: '&cYou cannot fire this cannon. Check that you are an official participant in the local siege, and that you have a rank which allows cannon-firing.'

--- a/src/main/resources/lang/fr-FR.yml
+++ b/src/main/resources/lang/fr-FR.yml
@@ -1,5 +1,5 @@
 ﻿name: SiegeWar
-version: 0.39
+version: 0.40
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -495,7 +495,7 @@ msg_err_breaching_cannot_destroy_this_material: '&cYou cannot destroy this type 
 #Wall-Breach-Bonus
 msg_wall_breach_bonus_awarded_to_attackers: "&bSiege on %s > %d attackers have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
 msg_wall_breach_bonus_awarded_to_defenders: "&bSiege on %s > %d defenders have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
-msg_wall_breach_bonus_awarded: "&bYou have been awarded a wall breach bonus."
+msg_wall_breach_bonus_awarded: "&bYou have been awarded a wall breach bonus!. If you wish to gain the bonus in future battle sessions, make sure to leave the town first before returning to the homeblock."
 msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Breach-Bonus for this Battle Session.'
 #Wall-Breach Cannons Integration
 msg_err_cannot_fire_cannon_without_battle_session: '&cYou cannot fire a cannon in a siegezone unless there is a Battle Session in progress.'

--- a/src/main/resources/lang/fr-FR.yml
+++ b/src/main/resources/lang/fr-FR.yml
@@ -1,5 +1,5 @@
 ﻿name: SiegeWar
-version: 0.39
+version: 0.40
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -495,8 +495,8 @@ msg_err_breaching_cannot_destroy_this_material: '&cYou cannot destroy this type 
 #Wall-Breach-Bonus
 msg_wall_breach_bonus_awarded_to_attackers: "&bSiege on %s > %d attackers have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
 msg_wall_breach_bonus_awarded_to_defenders: "&bSiege on %s > %d defenders have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
-msg_wall_breach_bonus_awarded: "&bYou have been awarded a wall breach bonus!"
-msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Breach-Bonus for this Battle Session.'
+msg_wall_breach_bonus_awarded: "&bYou have been awarded a Wall Breach Bonus!"
+msg_err_already_received_wall_breach_bonus: '&cYou already received a Wall Breach Bonus for this Battle Session.'
 #Wall-Breach Cannons Integration
 msg_err_cannot_fire_cannon_without_battle_session: '&cYou cannot fire a cannon in a siegezone unless there is a Battle Session in progress.'
 msg_err_cannot_fire_cannon_without_perms: '&cYou cannot fire this cannon. Check that you are an official participant in the local siege, and that you have a rank which allows cannon-firing.'

--- a/src/main/resources/lang/fr-FR.yml
+++ b/src/main/resources/lang/fr-FR.yml
@@ -1,5 +1,5 @@
 ﻿name: SiegeWar
-version: 0.40
+version: 0.39
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -495,7 +495,7 @@ msg_err_breaching_cannot_destroy_this_material: '&cYou cannot destroy this type 
 #Wall-Breach-Bonus
 msg_wall_breach_bonus_awarded_to_attackers: "&bSiege on %s > %d attackers have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
 msg_wall_breach_bonus_awarded_to_defenders: "&bSiege on %s > %d defenders have reached the homeblock. Wall Breach Bonus: +%d Battle Points."
-msg_wall_breach_bonus_awarded: "&bYou have been awarded a wall breach bonus!. If you wish to gain the bonus in future battle sessions, make sure to leave the town first before returning to the homeblock."
+msg_wall_breach_bonus_awarded: "&bYou have been awarded a wall breach bonus!"
 msg_err_already_received_wall_breach_bonus: '&cYou already received your Wall-Breach-Bonus for this Battle Session.'
 #Wall-Breach Cannons Integration
 msg_err_cannot_fire_cannon_without_battle_session: '&cYou cannot fire a cannon in a siegezone unless there is a Battle Session in progress.'


### PR DESCRIPTION
#### Description: 
- With current code, a town hostile side has to cap the banner to get the WB bonus
- This is to stop them logging off/on at homeblock to get ez bonus
- This is messy, bcs first they probably need defender to cap (to breach walls), then get in, secure path, then cap, then go to homeblock.
- I have come up with a better way to patch exploit (will follow in a separate pr)
- In this pr I remove the remove the banner cap requirement for bonus

____
#### New Nodes/Commands/ConfigOptions: 
na

____
#### Relevant Issue ticket:
na

____
- [ x ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
