### PR TITLE
Refactor: Capping Limiter -> Siege Attendance Limiter

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -319,16 +319,35 @@ public class SiegeController {
 		return null;
 	}
 
+	/**
+	 * Get the active siege at the given location
+	 * If more than one active siege is found, return the closest one
+	 * If no active sieges are found, return null
+	 *
+	 * @param loc Given location
+	 * @return active siege at given location
+	 */
 	@Nullable
-	public static Siege getSiegeAtLocation(Location loc) {
-		for (Siege siege : getSieges()) {
-			if (siege.getStatus().isActive() 
-				&& SiegeWarDistanceUtil.isInSiegeZone(loc, siege))
-				return siege;
+	public static Siege getActiveSiegeAtLocation(Location loc) {
+		Siege resultSiege = null;
+		int distanceToResultSiege = 0;
+		int distanceToCandidateSiege = 0;
+		for (Siege candidateSiege : getSieges()) {
+			if (candidateSiege.getStatus().isActive()) {
+				if(resultSiege == null) {
+					resultSiege = candidateSiege;
+				} else {
+					distanceToCandidateSiege = SiegeWarDistanceUtil.getDistanceToSiege(loc, candidateSiege);
+					if(distanceToCandidateSiege < distanceToResultSiege) {
+						resultSiege = candidateSiege;
+						distanceToResultSiege = distanceToCandidateSiege;
+					}
+				}
+			}
 		}
-		return null;
+		return resultSiege;
 	}
-	
+
 	public static void setSiege(Town town, boolean bool) {
 		SiegeMetaDataController.setSiege(town, bool);
 	}
@@ -339,16 +358,6 @@ public class SiegeController {
 			result.addAll(siege.getBannerControlSessions().keySet());
 		}
 		return result;
-	}
-
-	public static List<Siege> getActiveSiegesAt(Location location) {
-		List<Siege> siegesAtLocation = new ArrayList<>();
-		for (Siege siege : townSiegeMap.values()) {
-			if (SiegeWarDistanceUtil.isInSiegeZone(location, siege) && siege.getStatus().isActive()) {
-				siegesAtLocation.add(siege);
-			}
-		}
-		return siegesAtLocation;
 	}
 
 	/**

--- a/src/main/java/com/gmail/goosius/siegewar/integration/cannons/CannonsListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/integration/cannons/CannonsListener.java
@@ -52,7 +52,7 @@ public class CannonsListener implements Listener {
 			}
 
 			//Ensure cannon is fully in the wilderness OR the besieged town
-			Siege siege = SiegeController.getSiegeAtLocation(event.getCannon().getLocation());
+			Siege siege = SiegeController.getActiveSiegeAtLocation(event.getCannon().getLocation());
 			for(Location cannonBlockLocation: event.getCannon().getCannonDesign().getAllCannonBlocks(event.getCannon())) {
 				if(!TownyAPI.getInstance().isWilderness(cannonBlockLocation)
 					&& !TownyAPI.getInstance().getTown(cannonBlockLocation).equals(siege.getTown())) {

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -269,7 +269,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 		}
 
 		//Return if the entity being damaged is not a player
-		if(!(event instanceof Player))
+		if(!(event.getEntity() instanceof Player))
 			return;
 
 		//Return if event is not in a SiegeZone
@@ -298,7 +298,9 @@ public class SiegeWarBukkitEventListener implements Listener {
 			//Register the damager as having participated in the battle session
 			Resident resident = TownyAPI.getInstance().getResident((Player)event.getDamager());
 			SiegeWarBattleSessionUtil.markResidentAsHavingAttendedCurrentBattleSession(resident);
-
+			//Register the damagee as having participated in the battle session
+			resident = TownyAPI.getInstance().getResident((Player)event.getEntity());
+			SiegeWarBattleSessionUtil.markResidentAsHavingAttendedCurrentBattleSession(resident);
 		} else {
 
 			//Stop TNT/Minecarts from damaging players in SiegeZone wilderness

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -4,7 +4,11 @@ import java.util.List;
 
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 
-import com.gmail.goosius.siegewar.utils.*;
+import com.gmail.goosius.siegewar.utils.SiegeWarBlockUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarAllegianceUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarNotificationUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarBattleSessionUtil;
 import com.palmergames.bukkit.towny.object.Translation;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -293,7 +297,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 
 			//Register the damager as having participated in the battle session
 			Resident resident = TownyAPI.getInstance().getResident((Player)event.getDamager());
-			SiegeWarBattleSessionUtil.markResidentAsHavingAttendedCurrentBattleSession(resident);			
+			SiegeWarBattleSessionUtil.markResidentAsHavingAttendedCurrentBattleSession(resident);
 
 		} else {
 
@@ -303,7 +307,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 				event.setCancelled(true);
 				return;
 			}
-		}	
+		}
 	}
 
 	//Stops battlefield observers from taking damage in siegezones

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -4,11 +4,8 @@ import java.util.List;
 
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 
-import com.gmail.goosius.siegewar.utils.SiegeWarBlockUtil;
-import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarAllegianceUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarNotificationUtil;
-import com.gmail.goosius.siegewar.utils.SiegeWarBattleSessionUtil;
 import com.palmergames.bukkit.towny.object.Translation;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -39,6 +36,9 @@ import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.playeractions.PlayerDeath;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.gmail.goosius.siegewar.utils.SiegeWarBlockUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarBattleSessionUtil;
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -106,12 +106,11 @@ public class SiegeWarTownyEventListener implements Listener {
         if (SiegeWarSettings.getWarSiegeEnabled()) {
             SiegeWarTimerTaskController.punishPeacefulPlayersInActiveSiegeZones();
             SiegeWarTimerTaskController.evaluateBattleSessions();
-            SiegeWarTimerTaskController.punishPlayersInSiegeZonesOverSiegeAttendanceLimit();
+            SiegeWarTimerTaskController.evaluateWarSickness();
             SiegeWarTimerTaskController.evaluateBannerControl();
             SiegeWarTimerTaskController.evaluateWallBreaching();         
             SiegeWarTimerTaskController.evaluateMapHiding();
             SiegeWarTimerTaskController.evaluateTimedSiegeOutcomes();
-            SiegeWarTimerTaskController.punishNonSiegeParticipantsInSiegeZones();
             SiegeHUDManager.updateHUDs();
             SiegeWarTimerTaskController.evaluateBeacons();
             SiegeWarTimerTaskController.evaluateBattlefieldReporters();

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -106,6 +106,7 @@ public class SiegeWarTownyEventListener implements Listener {
         if (SiegeWarSettings.getWarSiegeEnabled()) {
             SiegeWarTimerTaskController.punishPeacefulPlayersInActiveSiegeZones();
             SiegeWarTimerTaskController.evaluateBattleSessions();
+            SiegeWarTimerTaskController.punishPlayersInSiegeZonesOverSiegeAttendanceLimit();
             SiegeWarTimerTaskController.evaluateBannerControl();
             SiegeWarTimerTaskController.evaluateWallBreaching();         
             SiegeWarTimerTaskController.evaluateMapHiding();

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -131,7 +131,7 @@ public class ResidentMetaDataController {
 			return Arrays.asList(recentBattleSessionsArray);
 		}
 	}
-		
+
 	@Nullable
 	private static String getRecentBattleSessions(Resident resident) {
 		StringDataField sdf = (StringDataField) recentBattleSessions.clone();

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -9,6 +9,8 @@ import com.palmergames.bukkit.towny.object.metadata.StringDataField;
 import com.palmergames.bukkit.towny.utils.MetaDataUtil;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -120,8 +122,18 @@ public class ResidentMetaDataController {
 		return getBoolean(resident, bossBarsDisabled);
 	}
 
+	public static List<String> getRecentBattleSessionsAsList(Resident resident) {
+		String recentBattleSessionsString = getRecentBattleSessions(resident);
+		if(recentBattleSessionsString == null || recentBattleSessionsString.length() == 0) {
+			return new ArrayList<>();		
+		} else {
+			String[] recentBattleSessionsArray = recentBattleSessionsString.replaceAll(" ","").split(",");
+			return Arrays.asList(recentBattleSessionsArray);
+		}
+	}
+		
 	@Nullable
-	public static String getRecentBattleSessions(Resident resident) {
+	private static String getRecentBattleSessions(Resident resident) {
 		StringDataField sdf = (StringDataField) recentBattleSessions.clone();
 		if (resident.hasMeta(sdf.getKey()))
 			return MetaDataUtil.getString(resident, sdf);

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -128,7 +128,7 @@ public class ResidentMetaDataController {
 			return new ArrayList<>();
 		} else {
 			String[] recentBattleSessionsArray = recentBattleSessionsString.replaceAll(" ","").split(",");
-			return Arrays.asList(recentBattleSessionsArray);
+			return new ArrayList<>(Arrays.asList(recentBattleSessionsArray));
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/ResidentMetaDataController.java
@@ -125,7 +125,7 @@ public class ResidentMetaDataController {
 	public static List<String> getRecentBattleSessionsAsList(Resident resident) {
 		String recentBattleSessionsString = getRecentBattleSessions(resident);
 		if(recentBattleSessionsString == null || recentBattleSessionsString.length() == 0) {
-			return new ArrayList<>();		
+			return new ArrayList<>();
 		} else {
 			String[] recentBattleSessionsArray = recentBattleSessionsString.replaceAll(" ","").split(",");
 			return Arrays.asList(recentBattleSessionsArray);

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -526,29 +526,31 @@ public enum ConfigNodes {
 			"# Set to -1 to disable the cap.",
 			"# The value applies to both positive and negative balances e.g. 20000 means a lower limit of -20000 and an upper limit of 20000.",
 			"# TIP: Set this value HIGH to give advantage to big nations, and LOW to give advantage to small nations."),
-	WAR_SIEGE_POINTS_BALANCING_CAPPING_LIMITER(
-			"war.siege.points_balancing.capping_limiter",
+	WAR_SIEGE_ATTENDANCE_LIMITER(
+			"war.siege.attendance_limiter",
 			"",
 			"",
 			"",
+			"############################################################",
 			"# +------------------------------------------------------+ #",
-			"# |                   Capping Limiter                    | #",
+			"# |                 Attendance Limiter                     #",
 			"# +------------------------------------------------------+ #",
+			"############################################################",
 			""),
-	WAR_SIEGE_POINTS_BALANCING_CAPPING_LIMITER_WEEKDAYS(
-			"war.siege.points_balancing.capping_limiter.weekdays",
+	WAR_SIEGE_ATTENDANCE_LIMITER_WEEKDAY_BATTLE_SESSIONS(
+			"war.siege.attendance_limiter.weekday_battle_sessions",
 			"2",
 			"",
-			"# This value determines the maximum number of week-day battle sessions for each individual player, in which they can capture the banner.",
+			"# This value determines the maximum number of week-day battle sessions which each player can attend.",
 			"# To disable the feature, set the value to -1.",
-			"# TIP: This feature is an important server defence against night-capping, and against players skipping school or work to gain timed points."),
-	WAR_SIEGE_POINTS_BALANCING_CAPPING_LIMITER_WEEKEND_DAYS(
-			"war.siege.points_balancing.capping_limiter.weekend_days",
+			"# TIP: This feature is critical to prevent teams trying to win sieges via excessive-online-time, including skipping school or work."),
+	WAR_SIEGE_ATTENDANCE_LIMITER_WEEKEND_DAY_BATTLE_SESSIONS(
+			"war.siege.attendance_limiter.weekend_day_battle_sessions",
 			"5",
 			"",
-			"# This value determines the maximum number of weekend-day battle sessions for each individual player, in which they can capture the banner.",
+			"# This value determines the maximum number of weekend-day battle sessions which each player can attend.",
 			"# To disable the feature, set the value to -1.",
-			"# TIP: This feature is an important server defence against night-capping, and against players skipping school or work to gain timed points."),
+			"# TIP: This feature is critical to prevent teams trying to win sieges via excessive-online-time, including skipping school or work."),
     WAR_SIEGE_POINTS_BALANCING_END_OF_BATTLE_POINTS_DISTRIBUTION(
 			"war.siege.points_balancing.end_of_battle_points_distribution",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -526,36 +526,6 @@ public enum ConfigNodes {
 			"# Set to -1 to disable the cap.",
 			"# The value applies to both positive and negative balances e.g. 20000 means a lower limit of -20000 and an upper limit of 20000.",
 			"# TIP: Set this value HIGH to give advantage to big nations, and LOW to give advantage to small nations."),
-	WAR_SIEGE_ATTENDANCE_LIMITER(
-			"war.siege.attendance_limiter",
-			"",
-			"",
-			"",
-			"############################################################",
-			"# +------------------------------------------------------+ #",
-			"# |                 Attendance Limiter                     #",
-			"# +------------------------------------------------------+ #",
-			"############################################################",
-			""),
-	WAR_SIEGE_ATTENDANCE_LIMITER_WEEKDAY_BATTLE_SESSIONS(
-			"war.siege.attendance_limiter.weekday_battle_sessions",
-			"3",
-			"",
-			"# This value determines the maximum number of week-day battle sessions which each player can attend.",
-			"# To disable the feature, set the value to -1.",
-			"# TIP: This feature is critical to prevent teams trying to win sieges via excessive-online-time, including skipping school or work."),
-	WAR_SIEGE_ATTENDANCE_LIMITER_WEEKEND_DAY_BATTLE_SESSIONS(
-			"war.siege.attendance_limiter.weekend_day_battle_sessions",
-			"6",
-			"",
-			"# This value determines the maximum number of weekend-day battle sessions which each player can attend.",
-			"# To disable the feature, set the value to -1.",
-			"# TIP: This feature is critical to prevent teams trying to win sieges via excessive-online-time, including skipping school or work."),
-	WAR_SIEGE_ATTENDANCE_LIMITER_SICKNESS_WARNING_DURATION_SECONDS(
-			"war.siege.attendance_limiter.sickness_warning_duration_seconds",
-			"20",
-			"",
-			"# This value determines the number of warning seconds before sickness applies."),
     WAR_SIEGE_POINTS_BALANCING_END_OF_BATTLE_POINTS_DISTRIBUTION(
 			"war.siege.points_balancing.end_of_battle_points_distribution",
 			"",
@@ -1134,7 +1104,37 @@ public enum ConfigNodes {
 			"500",
 			"",
 			"# This value determines the delay before teleport.",
-			"# TIP: If you set this value very low, you might get lag.");
+			"# TIP: If you set this value very low, you might get lag."),
+	SIEGE_ATTENDANCE_LIMITER(
+			"siege_attendance_limiter",
+			"",
+			"",
+			"",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |              Siege Attendance Limiter                  #",
+			"# +------------------------------------------------------+ #",
+			"############################################################",
+			""),
+	SIEGE_ATTENDANCE_LIMITER_WEEKDAY_BATTLE_SESSIONS(
+			"siege_attendance_limiter.weekday_battle_sessions",
+			"3",
+			"",
+			"# This value determines the maximum number of week-day battle sessions which each player can attend.",
+			"# To disable the feature, set the value to -1.",
+			"# TIP: This feature is critical to prevent teams trying to win sieges via excessive-online-time, including skipping school or work."),
+	SIEGE_ATTENDANCE_LIMITER_WEEKEND_DAY_BATTLE_SESSIONS(
+			"siege_attendance_limiter.weekend_day_battle_sessions",
+			"6",
+			"",
+			"# This value determines the maximum number of weekend-day battle sessions which each player can attend.",
+			"# To disable the feature, set the value to -1.",
+			"# TIP: This feature is critical to prevent teams trying to win sieges via excessive-online-time, including skipping school or work."),
+	SIEGE_ATTENDANCE_LIMITER_SICKNESS_WARNING_DURATION_SECONDS(
+			"siege_attendance_limiter.sickness_warning_duration_seconds",
+			"20",
+			"",
+			"# This value determines the number of warning seconds before sickness applies.");
 
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -539,18 +539,23 @@ public enum ConfigNodes {
 			""),
 	WAR_SIEGE_ATTENDANCE_LIMITER_WEEKDAY_BATTLE_SESSIONS(
 			"war.siege.attendance_limiter.weekday_battle_sessions",
-			"2",
+			"3",
 			"",
 			"# This value determines the maximum number of week-day battle sessions which each player can attend.",
 			"# To disable the feature, set the value to -1.",
 			"# TIP: This feature is critical to prevent teams trying to win sieges via excessive-online-time, including skipping school or work."),
 	WAR_SIEGE_ATTENDANCE_LIMITER_WEEKEND_DAY_BATTLE_SESSIONS(
 			"war.siege.attendance_limiter.weekend_day_battle_sessions",
-			"5",
+			"6",
 			"",
 			"# This value determines the maximum number of weekend-day battle sessions which each player can attend.",
 			"# To disable the feature, set the value to -1.",
 			"# TIP: This feature is critical to prevent teams trying to win sieges via excessive-online-time, including skipping school or work."),
+	WAR_SIEGE_ATTENDANCE_LIMITER_SICKNESS_WARNING_DURATION_SECONDS(
+			"war.siege.attendance_limiter.sickness_warning_duration_seconds",
+			"5",
+			"",
+			"# This value determines the number of warning seconds before sickness applies."),
     WAR_SIEGE_POINTS_BALANCING_END_OF_BATTLE_POINTS_DISTRIBUTION(
 			"war.siege.points_balancing.end_of_battle_points_distribution",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -553,7 +553,7 @@ public enum ConfigNodes {
 			"# TIP: This feature is critical to prevent teams trying to win sieges via excessive-online-time, including skipping school or work."),
 	WAR_SIEGE_ATTENDANCE_LIMITER_SICKNESS_WARNING_DURATION_SECONDS(
 			"war.siege.attendance_limiter.sickness_warning_duration_seconds",
-			"5",
+			"20",
 			"",
 			"# This value determines the number of warning seconds before sickness applies."),
     WAR_SIEGE_POINTS_BALANCING_END_OF_BATTLE_POINTS_DISTRIBUTION(

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -469,6 +469,10 @@ public class SiegeWarSettings {
 		return  allowedDaysList;
 	}
 
+	public static int getSiegeAttendanceLimiterSicknessWarningDurationTicks() {
+		return Settings.getInt(ConfigNodes.WAR_SIEGE_ATTENDANCE_LIMITER_SICKNESS_WARNING_DURATION_SECONDS) * 20;
+	}
+
 	public static boolean isWallBreachingEnabled() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_WALL_BREACHING_ENABLED);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -449,11 +449,11 @@ public class SiegeWarSettings {
 	}
 
 	private static int getSiegeAttendanceLimiterWeekdayBattleSessions() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_ATTENDANCE_LIMITER_WEEKDAY_BATTLE_SESSIONS);
+		return Settings.getInt(ConfigNodes.SIEGE_ATTENDANCE_LIMITER_WEEKDAY_BATTLE_SESSIONS);
 	}
 
 	private static int getSiegeAttendanceLimiterWeekendDayBattleSessions() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_ATTENDANCE_LIMITER_WEEKEND_DAY_BATTLE_SESSIONS);
+		return Settings.getInt(ConfigNodes.SIEGE_ATTENDANCE_LIMITER_WEEKEND_DAY_BATTLE_SESSIONS);
 	}
 
 	public static List<DayOfWeek> getSiegeStartDayLimiterAllowedDays() {
@@ -470,7 +470,7 @@ public class SiegeWarSettings {
 	}
 
 	public static int getSiegeAttendanceLimiterSicknessWarningDurationSeconds() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_ATTENDANCE_LIMITER_SICKNESS_WARNING_DURATION_SECONDS);
+		return Settings.getInt(ConfigNodes.SIEGE_ATTENDANCE_LIMITER_SICKNESS_WARNING_DURATION_SECONDS);
 	}
 
 	public static boolean isWallBreachingEnabled() {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -437,23 +437,23 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_SIEGECAMPS_DURATION_IN_MINUTES);
 	}
 
-	public static int getBattleSessionCappingLimiter() {
+	public static int getSiegeAttendanceLimiterBattleSessions() {
 		DayOfWeek dayOfWeek = LocalDate.now().getDayOfWeek();
 		boolean weekend = dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
 
 		if(weekend) {
-			return getBattleSessionCappingLimiterWeekendDays();
+			return getSiegeAttendanceLimiterWeekdayBattleSessions();
 		} else {
-			return getBattleSessionCappingLimiterWeekdays();
+			return getSiegeAttendanceLimiterWeekendDayBattleSessions();
 		}
 	}
 
-	private static int getBattleSessionCappingLimiterWeekdays() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_POINTS_BALANCING_CAPPING_LIMITER_WEEKDAYS);
+	private static int getSiegeAttendanceLimiterWeekdayBattleSessions() {
+		return Settings.getInt(ConfigNodes.WAR_SIEGE_ATTENDANCE_LIMITER_WEEKDAY_BATTLE_SESSIONS);
 	}
 
-	private static int getBattleSessionCappingLimiterWeekendDays() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_POINTS_BALANCING_CAPPING_LIMITER_WEEKEND_DAYS);
+	private static int getSiegeAttendanceLimiterWeekendDayBattleSessions() {
+		return Settings.getInt(ConfigNodes.WAR_SIEGE_ATTENDANCE_LIMITER_WEEKEND_DAY_BATTLE_SESSIONS);
 	}
 
 	public static List<DayOfWeek> getSiegeStartDayLimiterAllowedDays() {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -353,8 +353,8 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.ENABLE_SICKNESS);
 	}
 
-	public static int getSicknessWarningTimeInTicks() {
-		return Settings.getInt(ConfigNodes.SECONDS_BEFORE_SICKNESS) * 20;
+	public static int getNonResidentSicknessWarningTimeSeconds() {
+		return Settings.getInt(ConfigNodes.SECONDS_BEFORE_SICKNESS);
 	}
 
 	public static double getWarSiegeCapitalCostIncreasePercentage() {
@@ -442,9 +442,9 @@ public class SiegeWarSettings {
 		boolean weekend = dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
 
 		if(weekend) {
-			return getSiegeAttendanceLimiterWeekdayBattleSessions();
-		} else {
 			return getSiegeAttendanceLimiterWeekendDayBattleSessions();
+		} else {
+			return getSiegeAttendanceLimiterWeekdayBattleSessions();
 		}
 	}
 
@@ -469,8 +469,8 @@ public class SiegeWarSettings {
 		return  allowedDaysList;
 	}
 
-	public static int getSiegeAttendanceLimiterSicknessWarningDurationTicks() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_ATTENDANCE_LIMITER_SICKNESS_WARNING_DURATION_SECONDS) * 20;
+	public static int getSiegeAttendanceLimiterSicknessWarningDurationSeconds() {
+		return Settings.getInt(ConfigNodes.WAR_SIEGE_ATTENDANCE_LIMITER_SICKNESS_WARNING_DURATION_SECONDS);
 	}
 
 	public static boolean isWallBreachingEnabled() {

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
@@ -100,16 +100,8 @@ public class SiegeWarTimerTaskController {
 		}
 	}
 
-	public static void punishNonSiegeParticipantsInSiegeZones() {
-		if (SiegeWarSettings.getPunishingNonSiegeParticipantsInSiegeZone()) {
-			SiegeWarSicknessUtil.punishNonSiegeParticipantsInSiegeZones();
-		}
-	}
-
-	public static void punishPlayersInSiegeZonesOverSiegeAttendanceLimit() {
-		if(SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions() != -1) {
-			SiegeWarSicknessUtil.punishPlayersInSiegeZonesOverSiegeAttendanceLimit();
-		}
+	public static void evaluateWarSickness() {
+		SiegeWarSicknessUtil.evaluateWarSickness();
 	}
 
 	public static void evaluateBeacons() {

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
@@ -102,7 +102,13 @@ public class SiegeWarTimerTaskController {
 
 	public static void punishNonSiegeParticipantsInSiegeZones() {
 		if (SiegeWarSettings.getPunishingNonSiegeParticipantsInSiegeZone()) {
-			SiegeWarSicknessUtil.punishNonSiegeParticipantsInSiegeZone();
+			SiegeWarSicknessUtil.punishNonSiegeParticipantsInSiegeZones();
+		}
+	}
+
+	public static void punishPlayersInSiegeZonesOverSiegeAttendanceLimit() {
+		if(SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions() != -1) {
+			SiegeWarSicknessUtil.punishPlayersInSiegeZonesOverSiegeAttendanceLimit();
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -289,6 +289,7 @@ public class SiegeWarBannerControlUtil {
 					}
 				}
 			} catch (Exception e) {
+				e.printStackTrace();
 				SiegeWar.severe("Problem evaluating banner control session for player " + bannerControlSession.getPlayer().getName());
 			}
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -6,6 +6,7 @@ import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
+import com.gmail.goosius.siegewar.metadata.ResidentMetaDataController;
 import com.gmail.goosius.siegewar.objects.BannerControlSession;
 import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
@@ -70,9 +71,6 @@ public class SiegeWarBannerControlUtil {
 				if(!doesPlayerMeetBasicSessionRequirements(siege, player, resident))
 					continue;
 
-				if(!player.isOp() && player.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_SIEGEZONE_CANNOT_GET_BANNER_CONTROL.getNode()))
-					continue;
-
 				if(!BattleSession.getBattleSession().isActive()) {
 					Translatable message = Translatable.of("msg_war_siege_battle_session_break_cannot_get_banner_control",
 													SiegeWarBattleSessionUtil.getFormattedTimeUntilNextBattleSessionStarts());
@@ -86,13 +84,8 @@ public class SiegeWarBannerControlUtil {
 				if(siege.getBannerControllingResidents().contains(resident))
 					continue;  // Player already on the BC list
 
-				if(SiegeWarBattleSessionUtil.isBattleSessionCappingLimiterActiveForResident(resident)) {
-					Translatable message = Translatable.of("msg_war_siege_max_daily_player_battle_sessions_reached_cannot_get_banner_control",
-													SiegeWarSettings.getBattleSessionCappingLimiter(),
-													SiegeWarBattleSessionUtil.getFormattedTimeUntilPlayerBattleSessionLimitExpires(resident));
-					Messaging.sendErrorMsg(player, message);
-					continue;  // Player is being limited by the battle session capping limiter
-				}
+				if(SiegeWarBattleSessionUtil.isSiegeAttendanceLimiterActiveForResident(resident)) 
+					continue; // Max daily battle sessions reached
 
 				SiegeSide siegeSide = SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, resident.getTown(), siege);
 
@@ -173,12 +166,18 @@ public class SiegeWarBannerControlUtil {
 		if (!resident.hasTown())
 			return false; //Player is a nomad
 
+		if(resident.getTownOrNull().isNeutral())
+			return false; //Player if from a neutral town
+
 		if(player.isFlying() || player.isGliding())
 			return false;   // Player is flying
 
 		if (player.getGameMode() == GameMode.SPECTATOR)
 			return false; // Player is spectating
 
+		if(!player.isOp() && player.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_SIEGEZONE_CANNOT_GET_BANNER_CONTROL.getNode()))
+			return false;  //Player is SiegeZone observer
+					
 		if(!SiegeWarScoringUtil.isPlayerInTimedPointZone(player, siege))
 			return false; //player is not in the timed point zone
 
@@ -241,6 +240,9 @@ public class SiegeWarBannerControlUtil {
 							}
 						});
 					}
+					//Count this sessions towards the player's daily bs attendance limit
+					SiegeWarBattleSessionUtil.markPlayerAsHavingAttendedCurrentBattleSession(siege);
+					
 					//Update siege
 					if(bannerControlSession.getSiegeSide() == siege.getBannerControllingSide()) {
 						//Player contributes to ongoing banner control

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -83,7 +83,7 @@ public class SiegeWarBannerControlUtil {
 				if(siege.getBannerControllingResidents().contains(resident))
 					continue;  // Player already on the BC list
 
-				if(SiegeWarBattleSessionUtil.hasResidentExceededTheirSiegeAttendanceLimit(resident)) 
+				if(SiegeWarBattleSessionUtil.hasResidentExceededTheirSiegeAttendanceLimit(resident))
 					continue; // Max daily battle sessions reached
 
 				SiegeSide siegeSide = SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, resident.getTown(), siege);
@@ -176,7 +176,7 @@ public class SiegeWarBannerControlUtil {
 
 		if(!player.isOp() && player.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_SIEGEZONE_CANNOT_GET_BANNER_CONTROL.getNode()))
 			return false;  //Player is SiegeZone observer
-					
+
 		if(!SiegeWarScoringUtil.isPlayerInTimedPointZone(player, siege))
 			return false; //player is not in the timed point zone
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -6,7 +6,6 @@ import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
-import com.gmail.goosius.siegewar.metadata.ResidentMetaDataController;
 import com.gmail.goosius.siegewar.objects.BannerControlSession;
 import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
@@ -84,7 +83,7 @@ public class SiegeWarBannerControlUtil {
 				if(siege.getBannerControllingResidents().contains(resident))
 					continue;  // Player already on the BC list
 
-				if(SiegeWarBattleSessionUtil.isSiegeAttendanceLimiterActiveForResident(resident)) 
+				if(SiegeWarBattleSessionUtil.hasResidentExceededTheirSiegeAttendanceLimit(resident)) 
 					continue; // Max daily battle sessions reached
 
 				SiegeSide siegeSide = SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, resident.getTown(), siege);
@@ -240,9 +239,10 @@ public class SiegeWarBannerControlUtil {
 							}
 						});
 					}
-					//Count this sessions towards the player's daily bs attendance limit
-					SiegeWarBattleSessionUtil.markPlayerAsHavingAttendedCurrentBattleSession(siege);
-					
+
+					//Mark the player as having attended the current battle session
+					SiegeWarBattleSessionUtil.markResidentAsHavingAttendedCurrentBattleSession(bannerControlSession.getResident());
+
 					//Update siege
 					if(bannerControlSession.getSiegeSide() == siege.getBannerControllingSide()) {
 						//Player contributes to ongoing banner control

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -304,7 +304,7 @@ public class SiegeWarBattleSessionUtil {
 		} else {
 			//Player is not at the limit
 			return false;
-		}		
+		}
 	}
 
 	/**
@@ -336,7 +336,7 @@ public class SiegeWarBattleSessionUtil {
 			if(recentBattleSessionsList.size() != recalculatedRecentBattleSessionsList.size()) {
 				ResidentMetaDataController.setRecentBattleSessions(resident, recalculatedRecentBattleSessionsList);
 				resident.save();
-			}			
+			}
 		}
 	}
 
@@ -375,7 +375,7 @@ public class SiegeWarBattleSessionUtil {
 		String startTimeOfCurrentBattleSessionAsString = BattleSession.getBattleSession().getStartTime().toString();
 		if(recentBattleSessionsList.contains(startTimeOfCurrentBattleSessionAsString)) 
 			return;
-			
+
 		//Add the current battle session to the player's list
 		recentBattleSessionsList.add(BattleSession.getBattleSession().getStartTime().toString());
 		ResidentMetaDataController.setRecentBattleSessions(resident, recentBattleSessionsList);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -12,6 +12,8 @@ import com.gmail.goosius.siegewar.metadata.ResidentMetaDataController;
 import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.gmail.goosius.siegewar.tasks.SiegeWarTimerTaskController;
+import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translation;
@@ -65,6 +67,10 @@ public class SiegeWarBattleSessionUtil {
 		battleSession.setScheduledStartTime(null);
 		//Send up the Bukkit event for other plugins to listen for.
 		Bukkit.getPluginManager().callEvent(new BattleSessionStartedEvent());	
+		//Recalculate recent battle sessions of players
+		try { Thread.sleep(5000); //Sleep to ensure recalculation is good
+		} catch (InterruptedException e) { e.printStackTrace();}
+		SiegeWarBattleSessionUtil.recalculateRecentBattleSessionsLists();
 		//Send global message to let the server know that the battle session started
 		Messaging.sendGlobalMessage(Translatable.of("msg_war_siege_battle_session_started"));
 		//Start the bossbar for the Battle Session
@@ -275,12 +281,12 @@ public class SiegeWarBattleSessionUtil {
 	}
 
 	/**
-	 * Checks if the siege attendance limiter is active for the given resident
+	 * Checks if the given resident has exceeded their siege attendance limit
 	 * 
-	 * @return true if the limiter is active, false if the limit is inactive
+	 * @return true if resident has exceeded their siege attendance limit
 	 */
-	public static boolean isSiegeAttendanceLimiterActiveForResident(Resident resident)  {
-		//Return false if the Siege Attendance Limit is disabled or 0
+	public static boolean hasResidentExceededTheirSiegeAttendanceLimit(Resident resident)  {
+		//Return false if the Siege Attendance Limit is -1 (disabled).
 		int maxDailyPlayerBattleSessions = SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions();
 		if(maxDailyPlayerBattleSessions == -1)
 			return false;
@@ -299,26 +305,39 @@ public class SiegeWarBattleSessionUtil {
 			//Player is not at the limit
 			return false;
 		}		
-		
+	}
 
+	/**
+	 * Recalculate the recent battle sessions list of each player
+	 *
+	 * After this method runs, some players may be able to attend sieges again.
+	 */
+	public static void recalculateRecentBattleSessionsLists() {
+		//Return if the Siege Attendance Limit is -1 (disabled).
+		if(SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions() == -1)
+			return;
 
+		Resident resident;
+		List<String> recentBattleSessionsList;
+		List<String> recalculatedRecentBattleSessionsList;
+		for(Player player: Bukkit.getOnlinePlayers()) {
+			resident = TownyAPI.getInstance().getResident(player);
 
-		//TODO - MOVE ME
-		//Recalculate recent-sessions list, keeping only entries which are newer then 24 hours old
-		List<String> recalculatedRecentBattleSessionsList = new ArrayList<>();
-		for(String battleSessionStartTime: recentBattleSessionsList) {
-			if(System.currentTimeMillis() - Long.parseLong(battleSessionStartTime) < ONE_DAY_IN_MILLIS) {
-				recalculatedRecentBattleSessionsList.add(battleSessionStartTime);
+			//Recalculate recent-sessions list, keeping only entries which are newer then 24 hours old
+			recentBattleSessionsList = ResidentMetaDataController.getRecentBattleSessionsAsList(resident);
+			recalculatedRecentBattleSessionsList = new ArrayList<>();
+			for(String battleSessionStartTime: recentBattleSessionsList) {
+				if(System.currentTimeMillis() - Long.parseLong(battleSessionStartTime) < ONE_DAY_IN_MILLIS) {
+					recalculatedRecentBattleSessionsList.add(battleSessionStartTime);
+				}
 			}
-		}
-		//TODO - MOVE ME
-		//Save recent-session list if it has changed (will happen if one or more entries have dropped off)
-		if(recentBattleSessionsList.size() != recalculatedRecentBattleSessionsList.size()) {
-			ResidentMetaDataController.setRecentBattleSessions(resident, recalculatedRecentBattleSessionsList);
-			resident.save();
-		}
 
-
+			//Save recent-session list if it has changed (will happen if one or more entries have dropped off)
+			if(recentBattleSessionsList.size() != recalculatedRecentBattleSessionsList.size()) {
+				ResidentMetaDataController.setRecentBattleSessions(resident, recalculatedRecentBattleSessionsList);
+				resident.save();
+			}			
+		}
 	}
 
 	/**
@@ -328,61 +347,35 @@ public class SiegeWarBattleSessionUtil {
 	 * @return formatted time e.g.  11.2 minutes, 12.8 hours,
 	 */
 	public static String getFormattedTimeUntilPlayerBattleSessionLimitExpires(Resident resident) {
-		//Get list of recent sessions
-		String recentBattleSessionsString = ResidentMetaDataController.getRecentBattleSessions(resident);
-
-		//If player's recent-sessions list is null, initialize it
-		if(recentBattleSessionsString == null) {
-			ResidentMetaDataController.setRecentBattleSessions(resident,"");
-			resident.save();
-			recentBattleSessionsString = "";
-		}
-
 		/*
-		 * If the list is blank at this point, it means that the server has limited player sessions to 0
-		 * This should be ideally be done via the scheduler
-		 * But in any case, lets return something
-		*/
-		if(recentBattleSessionsString.length()== 0)
+		 * The 1st entry on the player's list will be the oldest session.
+		 * Find out when it will drop off the list
+		 */
+		List<String> recentBattleSessions = ResidentMetaDataController.getRecentBattleSessionsAsList(resident);
+		if(recentBattleSessions.size()== 0)
 			return "?";
-
-		//The 1st entry will be the oldest one. Find out when it will drop off the list
-		String stringStartTimeOfOldestSession = recentBattleSessionsString.replace(" ", "").split(",")[0];
+		String stringStartTimeOfOldestSession = recentBattleSessions.get(0);
 		long longStartTimeOfOldestSession = Long.parseLong(stringStartTimeOfOldestSession);
 		long millisSinceOldestSessionStarted = System.currentTimeMillis() - longStartTimeOfOldestSession; //will be less than 24 hrs
 		long millisUntilOldestSessionDropsOffList = ONE_DAY_IN_MILLIS - millisSinceOldestSessionStarted;
-
 		return TimeMgmt.getFormattedTimeValue(millisUntilOldestSessionDropsOffList);
 	}
 
+	/**
+	 * Mark the player as having attended the current battle session
+	 * @param resident the resident
+	 */
 	public static void markResidentAsHavingAttendedCurrentBattleSession(Resident resident) {
-		//Return false if the Siege Attendance Limit is disabled or 0
-		int maxDailyPlayerBattleSessions = SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions();
-		if(maxDailyPlayerBattleSessions == -1 || maxDailyPlayerBattleSessions == 0)
+		//Return false if the Siege Attendance Limit is -1 (disabled)
+		if(SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions() == -1)
 			return;
 
-		//If player's recent-sessions list is null, initialize it
-		String recentBattleSessionsString = ResidentMetaDataController.getRecentBattleSessions(resident);
-		if(recentBattleSessionsString == null) {
-			ResidentMetaDataController.setRecentBattleSessions(resident,"");
-			resident.save();
-			recentBattleSessionsString = "";
-		}
-
-		//Transform recent-sessions string into List
-		List<String> recentBattleSessionsList;
-		if(recentBattleSessionsString.length() == 0) {
-			recentBattleSessionsList = new ArrayList<>();		
-		} else {
-			String[] recentBattleSessionsArray = recentBattleSessionsString.replaceAll(" ","").split(",");
-			recentBattleSessionsList = Arrays.asList(recentBattleSessionsArray);
-		}
-
-		//Return if current session is already in the player's recent-sessions list
+		//If current session is already on players's recent-sessions-list, return.
+		List<String> recentBattleSessionsList = ResidentMetaDataController.getRecentBattleSessionsAsList(resident);
 		String startTimeOfCurrentBattleSessionAsString = BattleSession.getBattleSession().getStartTime().toString();
 		if(recentBattleSessionsList.contains(startTimeOfCurrentBattleSessionAsString)) 
-			return;			
-
+			return;
+			
 		//Add the current battle session to the player's list
 		recentBattleSessionsList.add(BattleSession.getBattleSession().getStartTime().toString());
 		ResidentMetaDataController.setRecentBattleSessions(resident, recentBattleSessionsList);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -285,32 +285,25 @@ public class SiegeWarBattleSessionUtil {
 		if(maxDailyPlayerBattleSessions == -1)
 			return false;
 
-		//Return true if the Siege Attendance Limit is set to 0
-		if(maxDailyPlayerBattleSessions == 0)
-			return true;
-
-		//If player's recent-sessions list is null, initialize it
-		String recentBattleSessionsString = ResidentMetaDataController.getRecentBattleSessions(resident);
-		if(recentBattleSessionsString == null) {
-			ResidentMetaDataController.setRecentBattleSessions(resident,"");
-			resident.save();
-			recentBattleSessionsString = "";
-		}
-		
-		//Transform recent-sessions string into List
-		List<String> recentBattleSessionsList;
-		if(recentBattleSessionsString.length() == 0) {
-			recentBattleSessionsList = new ArrayList<>();		
-		} else {
-			String[] recentBattleSessionsArray = recentBattleSessionsString.replaceAll(" ","").split(",");
-			recentBattleSessionsList = Arrays.asList(recentBattleSessionsArray);
-		}
-		
-		//Return false if current session is in the player's recent-sessions list
+		//If current session is on players's recent-sessions-list, that means they can attend it, so return false.
+		List<String> recentBattleSessionsList = ResidentMetaDataController.getRecentBattleSessionsAsList(resident);
 		String startTimeOfCurrentBattleSessionAsString = BattleSession.getBattleSession().getStartTime().toString();
 		if(recentBattleSessionsList.contains(startTimeOfCurrentBattleSessionAsString)) 
 			return false;			
 
+		//Check if player is at their daily limit
+		if(recentBattleSessionsList.size() >= maxDailyPlayerBattleSessions) {
+			//Player at or over the limit. Return true
+			return true;
+		} else {
+			//Player is not at the limit
+			return false;
+		}		
+		
+
+
+
+		//TODO - MOVE ME
 		//Recalculate recent-sessions list, keeping only entries which are newer then 24 hours old
 		List<String> recalculatedRecentBattleSessionsList = new ArrayList<>();
 		for(String battleSessionStartTime: recentBattleSessionsList) {
@@ -318,21 +311,14 @@ public class SiegeWarBattleSessionUtil {
 				recalculatedRecentBattleSessionsList.add(battleSessionStartTime);
 			}
 		}
-		
+		//TODO - MOVE ME
 		//Save recent-session list if it has changed (will happen if one or more entries have dropped off)
 		if(recentBattleSessionsList.size() != recalculatedRecentBattleSessionsList.size()) {
 			ResidentMetaDataController.setRecentBattleSessions(resident, recalculatedRecentBattleSessionsList);
 			resident.save();
 		}
 
-		//Check if player is at their daily limit
-		if(recalculatedRecentBattleSessionsList.size() >= maxDailyPlayerBattleSessions) {
-			//Player at or over the limit. Return true
-			return true;
-		} else {
-			//Player is not at the limit
-			return false;
-		}		
+
 	}
 
 	/**

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -175,4 +175,15 @@ public class SiegeWarDistanceUtil {
 	public static boolean isInSiegeCampZone(Location location, SiegeCamp camp) {
 		return areLocationsClose(location, camp.getBannerBlock().getLocation(), TownySettings.getTownBlockSize());
 	}
+
+	/**
+	 * Get distance between given location and given siege
+	 * @param location1 given location
+	 * @param siege given siege
+	 * @return distance
+	 */
+	public static int getDistanceToSiege(Location location1, Siege siege) {
+		Location location2 = siege.getFlagLocation();
+		return (int)MathUtil.distance(location1.getX(), location2.getX(), location1.getZ(), location2.getZ());
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
@@ -94,7 +94,7 @@ public class SiegeWarNotificationUtil {
 			return;
 
 		//Send warning if player is in SiegeZone (& didn't already get the warning)
-		Siege siege = SiegeController.getSiegeAtLocation(player.getLocation());
+		Siege siege = SiegeController.getActiveSiegeAtLocation(player.getLocation());
 		if(siege != null
 			&& siege.getStatus().isActive()
 			&& !siege.getPlayersWhoWereInTheSiegeZone().contains(player)

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
@@ -6,7 +6,6 @@ import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.TownyAPI;
-import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translation;
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
@@ -6,6 +6,7 @@ import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translation;
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
@@ -62,12 +62,12 @@ public class SiegeWarSicknessUtil {
 			    if (isInOwnClaims(resident)) {
 			        givePlayerSpecialWarSicknessNow(player);
 			    } else {
-			        int warningDurationInTicks = SiegeWarSettings.getSicknessWarningTimeInTicks();
+			        int warningDurationInSeconds = SiegeWarSettings.getNonResidentSicknessWarningTimeSeconds();
 			        givePlayerFullWarSicknessWithWarning(
 			            player,
 			            resident,
-			            warningDurationInTicks,
-			            Translatable.of("msg_you_will_get_sickness", warningDurationInTicks / 20),
+			            warningDurationInSeconds,
+			            Translatable.of("msg_you_will_get_sickness", warningDurationInSeconds),
 			            Translatable.of("msg_you_received_war_sickness"));
 			    }
 			}
@@ -88,7 +88,7 @@ public class SiegeWarSicknessUtil {
 
             //Continue if not in a siege zone
             Location location = player.getLocation();
-            if (SiegeWarDistanceUtil.isLocationInActiveSiegeZone(location))
+            if (!SiegeWarDistanceUtil.isLocationInActiveSiegeZone(location))
                 continue;
 
             //Continue if player is still within their attendance limit
@@ -100,16 +100,16 @@ public class SiegeWarSicknessUtil {
             if (isInOwnClaims(resident)) {
                 givePlayerSpecialWarSicknessNow(player);
             } else {
-                int warningDurationInTicks = SiegeWarSettings.getSicknessWarningTimeInTicks();
+                int warningDurationSeconds = SiegeWarSettings.getSiegeAttendanceLimiterSicknessWarningDurationSeconds();
                 givePlayerFullWarSicknessWithWarning(
                     player,
                     resident,
-                    SiegeWarSettings.getSiegeAttendanceLimiterSicknessWarningDurationTicks(),
+                    warningDurationSeconds,
                     Translatable.of(
                         "msg_battle_session_attendance_limit_exceeded_warning",
                         SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions(),
                         SiegeWarBattleSessionUtil.getFormattedTimeUntilPlayerBattleSessionLimitExpires(resident), 
-                        warningDurationInTicks),
+                        warningDurationSeconds),
                     Translatable.of(
                         "msg_battle_session_attendance_limit_exceeded_punish",
                         SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions(),
@@ -123,18 +123,18 @@ public class SiegeWarSicknessUtil {
      *
      * @param player player
      * @param resident resident
-     * @param warningDurationInTicks warning duration in ticks
+     * @param warningDurationInSeconds warning duration in ticks
      * @param warningTranslatable warning message
      * @param punishmentTranslatable punishment message
      */
     private static void givePlayerFullWarSicknessWithWarning(
             Player player,
             Resident resident,
-            int warningDurationInTicks,
+            int warningDurationInSeconds,
             Translatable warningTranslatable,
             Translatable punishmentTranslatable) {
 
-        if (warningDurationInTicks / 20 >= 1) {
+        if (warningDurationInSeconds >= 1) {
             Messaging.sendMsg(player, warningTranslatable);
         }
         Towny.getPlugin().getServer().getScheduler().runTaskLater(Towny.getPlugin(), () -> {
@@ -148,7 +148,7 @@ public class SiegeWarSicknessUtil {
                     givePlayerFullWarSicknessNow(player);
                 }
             }
-        }, warningDurationInTicks);
+        }, warningDurationInSeconds * 20);
     }
 
     /**

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
@@ -54,39 +54,43 @@ public class SiegeWarSicknessUtil {
             if (resident == null)
                 continue;
 
-            if (isInOwnClaims(resident)) {
-                givePlayerSpecialWarSicknessNow(player);
-                continue;
-            }
-
             if(attendanceLimiterEnabled && SiegeWarBattleSessionUtil.hasResidentExceededTheirSiegeAttendanceLimit(resident)) {
 
                 //Give war sickness to players who have exceeded attendance limit
-                givePlayerFullWarSicknessWithWarning(
-                    player,
-                    resident,
-                    siege,
-                    SiegeWarSettings.getSiegeAttendanceLimiterSicknessWarningDurationSeconds(),
-                    Translatable.of(
-                        "msg_battle_session_attendance_limit_exceeded_warning",
-                        SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions(),
-                        SiegeWarBattleSessionUtil.getFormattedTimeUntilPlayerBattleSessionLimitExpires(resident)),
-                    Translatable.of(
-                        "msg_battle_session_attendance_limit_exceeded_punish",
-                        SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions(),
-                        SiegeWarBattleSessionUtil.getFormattedTimeUntilPlayerBattleSessionLimitExpires(resident)));
+                if (isInOwnClaims(resident)) {
+                    givePlayerSpecialWarSicknessNow(player);
+                } else {
+                    givePlayerFullWarSicknessWithWarning(
+                        player,
+                        resident,
+                        siege,
+                        SiegeWarSettings.getSiegeAttendanceLimiterSicknessWarningDurationSeconds(),
+                        Translatable.of(
+                            "msg_battle_session_attendance_limit_exceeded_warning",
+                            SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions(),
+                            SiegeWarBattleSessionUtil.getFormattedTimeUntilPlayerBattleSessionLimitExpires(resident)),
+                        Translatable.of(
+                            "msg_battle_session_attendance_limit_exceeded_punish",
+                            SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions(),
+                            SiegeWarBattleSessionUtil.getFormattedTimeUntilPlayerBattleSessionLimitExpires(resident)));
+                }
+
 
             } else if (nonOfficialLimiterEnabled && isSiegeParticipant(player, resident, siege)) {
 
                 //Give war sickness to players who are not official participants in the SiegeZone
-                int warningDurationInSeconds = SiegeWarSettings.getNonResidentSicknessWarningTimeSeconds();
-                givePlayerFullWarSicknessWithWarning(
-                    player,
-                    resident,
-                    siege,
-                    warningDurationInSeconds,
-                    Translatable.of("msg_you_will_get_sickness", warningDurationInSeconds),
-                    Translatable.of("msg_you_received_war_sickness"));
+                if (isInOwnClaims(resident)) {
+                    givePlayerSpecialWarSicknessNow(player);
+                } else {
+                    int warningDurationInSeconds = SiegeWarSettings.getNonResidentSicknessWarningTimeSeconds();
+                    givePlayerFullWarSicknessWithWarning(
+                        player,
+                        resident,
+                        siege,
+                        warningDurationInSeconds,
+                        Translatable.of("msg_you_will_get_sickness", warningDurationInSeconds),
+                        Translatable.of("msg_you_received_war_sickness"));
+                }
             }
         }
     }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
@@ -25,8 +25,13 @@ import java.util.List;
 
 public class SiegeWarSicknessUtil {
 
-    public static void punishNonSiegeParticipantsInSiegeZone() {
-
+    /**
+     * Punish any players who are inside siegezones, but not official participants
+     * 
+     * Special war sickness if they are in their own town
+     * Full war sickness otherwise
+     */
+    public static void punishNonSiegeParticipantsInSiegeZones() {
         for (Player player : Bukkit.getOnlinePlayers()) {
             Location location = player.getLocation();
 
@@ -55,55 +60,123 @@ public class SiegeWarSicknessUtil {
 
 			if (!allowedInAnyOverlappingSiege) {
 			    if (isInOwnClaims(resident)) {
-			        punishWithSpecialWarSickness(player);
+			        givePlayerSpecialWarSicknessNow(player);
 			    } else {
-			        punishWithFullWarSickness(player);
+			        int warningDurationInTicks = SiegeWarSettings.getSicknessWarningTimeInTicks();
+			        givePlayerFullWarSicknessWithWarning(
+			            player,
+			            resident,
+			            warningDurationInTicks,
+			            Translatable.of("msg_you_will_get_sickness", warningDurationInTicks / 20),
+			            Translatable.of("msg_you_received_war_sickness"));
 			    }
-
 			}
-
         }
-
     }
 
-    public static void punishWithFullWarSickness(Player player) {
-        final int effectDurationTicks = (int)(TimeTools.convertToTicks(TownySettings.getShortInterval() + 5));
-        if (SiegeWarSettings.getSicknessWarningTimeInTicks() / 20 >= 1) {
-            Messaging.sendMsg(player, Translatable.of("msg_you_will_get_sickness",
-                    SiegeWarSettings.getSicknessWarningTimeInTicks() / 20));
+    /**
+     * Punish any players who are inside siegezones, but over their siege attendance limit for the day
+     * 
+     * Special war sickness if they are in their own town
+     * Full war sickness otherwise
+     */
+    public static void punishPlayersInSiegeZonesOverSiegeAttendanceLimit() {
+        for(Player player: Bukkit.getOnlinePlayers()) {
+            // Players immune to war nausea won't be punished
+            if (player.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_IMMUNE_TO_WAR_NAUSEA.getNode()))
+                continue;
+
+            //Continue if not in a siege zone
+            Location location = player.getLocation();
+            if (SiegeWarDistanceUtil.isLocationInActiveSiegeZone(location))
+                continue;
+
+            //Continue if player is still within their attendance limit
+            Resident resident = TownyAPI.getInstance().getResident(player);
+            if(!SiegeWarBattleSessionUtil.hasResidentExceededTheirSiegeAttendanceLimit(resident))
+                continue;
+
+            //Give player war sickness
+            if (isInOwnClaims(resident)) {
+                givePlayerSpecialWarSicknessNow(player);
+            } else {
+                int warningDurationInTicks = SiegeWarSettings.getSicknessWarningTimeInTicks();
+                givePlayerFullWarSicknessWithWarning(
+                    player,
+                    resident,
+                    SiegeWarSettings.getSiegeAttendanceLimiterSicknessWarningDurationTicks(),
+                    Translatable.of(
+                        "msg_battle_session_attendance_limit_exceeded_warning",
+                        SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions(),
+                        SiegeWarBattleSessionUtil.getFormattedTimeUntilPlayerBattleSessionLimitExpires(resident), 
+                        warningDurationInTicks),
+                    Translatable.of(
+                        "msg_battle_session_attendance_limit_exceeded_punish",
+                        SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions(),
+                        SiegeWarBattleSessionUtil.getFormattedTimeUntilPlayerBattleSessionLimitExpires(resident))); 
+            }                        
+        }
+    }
+
+    /**
+     * Give player full war sickness, with a warning beforehand
+     * 
+     * @param player player
+     * @param resident resident
+     * @param warningDurationInTicks warning duration in ticks
+     * @param warningTranslatable warning message
+     * @param punishmentTranslatable punishment message
+     */
+    private static void givePlayerFullWarSicknessWithWarning(
+            Player player,
+            Resident resident,
+            int warningDurationInTicks,
+            Translatable warningTranslatable,
+            Translatable punishmentTranslatable) {
+
+        if (warningDurationInTicks / 20 >= 1) {
+            Messaging.sendMsg(player, warningTranslatable);
         }
         Towny.getPlugin().getServer().getScheduler().runTaskLater(Towny.getPlugin(), () -> {
-            Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
-			List<Siege> sieges = SiegeController.getActiveSiegesAt(player.getLocation());
-			boolean allowedInAnyOverlappingSiege = false;
-			for (Siege siege : sieges) {
-			    if (isSiegeParticipant(player, resident, siege)) {
-			        allowedInAnyOverlappingSiege = true;
-			        break;
-			    }
-			}
-
-			if (!allowedInAnyOverlappingSiege && SiegeWarDistanceUtil.isLocationInActiveSiegeZone(player.getLocation())) {
-			    // still in siege zone
-			    List<PotionEffect> potionEffects = new ArrayList<>();
-			    potionEffects.add(new PotionEffect(PotionEffectType.CONFUSION, effectDurationTicks, 4));
-			    potionEffects.add(new PotionEffect(PotionEffectType.POISON, effectDurationTicks, 4));
-			    potionEffects.add(new PotionEffect(PotionEffectType.WEAKNESS, effectDurationTicks, 4));
-			    potionEffects.add(new PotionEffect(PotionEffectType.SLOW, effectDurationTicks, 2));
-			    potionEffects.add(new PotionEffect(PotionEffectType.SLOW_DIGGING, effectDurationTicks, 2));
-			    player.addPotionEffects(potionEffects);
-			    Messaging.sendMsg(player, Translatable.of("msg_you_received_war_sickness"));
-			}
-        }, SiegeWarSettings.getSicknessWarningTimeInTicks());
+			if (SiegeWarDistanceUtil.isLocationInActiveSiegeZone(player.getLocation())) {
+        	    if (isInOwnClaims(resident)) {
+                    //In own claims
+                    givePlayerSpecialWarSicknessNow(player);
+                } else {
+			        //Still in forbidden siege zone area
+                    Messaging.sendMsg(player, punishmentTranslatable);
+                    givePlayerFullWarSicknessNow(player);			        
+                }
+            }
+        }, warningDurationInTicks);
     }
 
-    public static void punishWithSpecialWarSickness(Player player) {
+    /**
+     * Give player full war sickness effects now
+     * @param player the player
+     */
+    private static void givePlayerFullWarSicknessNow(Player player) {
+        int effectDurationTicks = (int)(TimeTools.convertToTicks(TownySettings.getShortInterval() + 5));
+        List<PotionEffect> potionEffects = new ArrayList<>();
+        potionEffects.add(new PotionEffect(PotionEffectType.CONFUSION, effectDurationTicks, 4));
+        potionEffects.add(new PotionEffect(PotionEffectType.POISON, effectDurationTicks, 4));
+        potionEffects.add(new PotionEffect(PotionEffectType.WEAKNESS, effectDurationTicks, 4));
+        potionEffects.add(new PotionEffect(PotionEffectType.SLOW, effectDurationTicks, 2));
+        potionEffects.add(new PotionEffect(PotionEffectType.SLOW_DIGGING, effectDurationTicks, 2));
+        player.addPotionEffects(potionEffects);
+    }
+
+    /**
+     * Give player special war sickness effects now
+     * @param player the player
+     */
+    private static void givePlayerSpecialWarSicknessNow(Player player) {
         final int effectDurationTicks = (int)(TimeTools.convertToTicks(TownySettings.getShortInterval() + 5));
         Towny.getPlugin().getServer().getScheduler().runTask(Towny.getPlugin(), new Runnable() {
             public void run() {
                 player.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, effectDurationTicks, 4));
             }
-        });
+        });        
     }
 
     public static boolean isSiegeParticipant(Player player, Resident resident, Siege siege) {
@@ -125,5 +198,4 @@ public class SiegeWarSicknessUtil {
 
         return TownyAPI.getInstance().getTown(location).equals(TownyAPI.getInstance().getResidentTownOrNull(resident));
     }
-
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 public class SiegeWarSicknessUtil {
 
-    public static Set<Player> playersWithWarSickness = new HashSet<>();
+    public static Set<Player> playersWithFullWarSickness = new HashSet<>();
 
     /**
      * Evaluate all war sickness:
@@ -113,25 +113,26 @@ public class SiegeWarSicknessUtil {
             Translatable warningTranslatable,
             Translatable punishmentTranslatable) {
 
-        if(!playersWithWarSickness.contains(player)) {
+        if(!playersWithFullWarSickness.contains(player)) {
             //Send warning
             if (warningDurationInSeconds >= 1)
                 Messaging.sendMsg(player, warningTranslatable);
-            //Mark player as having sickness
-            playersWithWarSickness.add(player);
+            //Mark player as having full war sickness
+            playersWithFullWarSickness.add(player);
         }
         Towny.getPlugin().getServer().getScheduler().runTaskLater(Towny.getPlugin(), () -> {
             if (SiegeWarDistanceUtil.isInSiegeZone(player, siege)) {
                 if (isInOwnClaims(resident)) {
                     //In own claims
                     givePlayerSpecialWarSicknessNow(player);
+                    playersWithFullWarSickness.remove(player);
                 } else {
 			        //Still in forbidden siege zone area
                     Messaging.sendMsg(player, punishmentTranslatable);
                     givePlayerFullWarSicknessNow(player);
                 }
             } else {
-                playersWithWarSickness.remove(player);
+                playersWithFullWarSickness.remove(player);
             }
         }, warningDurationInSeconds * 20);
     }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
@@ -164,6 +164,7 @@ public class SiegeWarSicknessUtil {
         potionEffects.add(new PotionEffect(PotionEffectType.SLOW, effectDurationTicks, 2));
         potionEffects.add(new PotionEffect(PotionEffectType.SLOW_DIGGING, effectDurationTicks, 2));
         player.addPotionEffects(potionEffects);
+        player.setHealth(1);
     }
 
     /**

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
@@ -27,7 +27,7 @@ public class SiegeWarSicknessUtil {
 
     /**
      * Punish any players who are inside siegezones, but not official participants
-     * 
+     *
      * Special war sickness if they are in their own town
      * Full war sickness otherwise
      */
@@ -76,7 +76,7 @@ public class SiegeWarSicknessUtil {
 
     /**
      * Punish any players who are inside siegezones, but over their siege attendance limit for the day
-     * 
+     *
      * Special war sickness if they are in their own town
      * Full war sickness otherwise
      */
@@ -114,13 +114,13 @@ public class SiegeWarSicknessUtil {
                         "msg_battle_session_attendance_limit_exceeded_punish",
                         SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions(),
                         SiegeWarBattleSessionUtil.getFormattedTimeUntilPlayerBattleSessionLimitExpires(resident))); 
-            }                        
+            }
         }
     }
 
     /**
      * Give player full war sickness, with a warning beforehand
-     * 
+     *
      * @param player player
      * @param resident resident
      * @param warningDurationInTicks warning duration in ticks
@@ -138,14 +138,14 @@ public class SiegeWarSicknessUtil {
             Messaging.sendMsg(player, warningTranslatable);
         }
         Towny.getPlugin().getServer().getScheduler().runTaskLater(Towny.getPlugin(), () -> {
-			if (SiegeWarDistanceUtil.isLocationInActiveSiegeZone(player.getLocation())) {
-        	    if (isInOwnClaims(resident)) {
+            if (SiegeWarDistanceUtil.isLocationInActiveSiegeZone(player.getLocation())) {
+                if (isInOwnClaims(resident)) {
                     //In own claims
                     givePlayerSpecialWarSicknessNow(player);
                 } else {
 			        //Still in forbidden siege zone area
                     Messaging.sendMsg(player, punishmentTranslatable);
-                    givePlayerFullWarSicknessNow(player);			        
+                    givePlayerFullWarSicknessNow(player);
                 }
             }
         }, warningDurationInTicks);
@@ -176,7 +176,7 @@ public class SiegeWarSicknessUtil {
             public void run() {
                 player.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, effectDurationTicks, 4));
             }
-        });        
+        });
     }
 
     public static boolean isSiegeParticipant(Player player, Resident resident, Siege siege) {

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -510,4 +510,5 @@ msg_besieged_town_proximity_warning_text: "&cWARNING: You are in a besieged town
 msg_player_killed_from_logging_out_in_besieged_town: "%s was killed because they logged out while in a besieged town."
 
 #Added in 0.40
-msg_max_daily_player_battle_session_attendance_limit_reached: "&cYou have reached your daily Battle Session Attendance Limit (%d). War Sickness active. You can attend another battle session in %s."
+msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another battle session in %s. War sickness will activate in %d seconds."
+msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another battle session in %s. War Sickness Activated."

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.40
+version: 0.41
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -451,7 +451,6 @@ hover_message_click_to_claim: "Click to claim money owed to you."
 msg_next_session_cannot_be_determined: "The next Siege Session has not been scheduled. Try again later."
 
 #Added in 0.32
-msg_war_siege_max_daily_player_battle_sessions_reached_cannot_get_banner_control: "&cBanner capture failed because you have reached your daily battle session limit (%d). Try again in %s."
 msg_peaceful_town_subverted: "&b%s has been peacefully subverted and occupied by %s."
 msg_peaceful_town_revolted: "&b%s has peacefully revolted against %s, and freed itself from occupation."
 msg_town_became_peaceful: '&b%s has been confirmed as Neutral. The town is now immune to siege attacks, but vulnerable to getting subverted by nearby nations. Residents cannot enter siege-zones or gain nation-military ranks.'
@@ -509,3 +508,6 @@ msg_err_cannon_must_be_in_wilderness_or_besieged_town: "&cWithin SiegeZones, can
 #Added in 0.40
 msg_besieged_town_proximity_warning_text: "&cWARNING: You are in a besieged town!. If you log out here while not a military-ranked member of the town-friendly side, you will be killed."
 msg_player_killed_from_logging_out_in_besieged_town: "%s was killed because they logged out while in a besieged town."
+
+#Added in 0.40
+msg_max_daily_player_battle_session_attendance_limit_reached: "&cYou have reached your daily Battle Session Attendance Limit (%d). War Sickness active. You can attend another battle session in %s."

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -510,5 +510,5 @@ msg_besieged_town_proximity_warning_text: "&cWARNING: You are in a besieged town
 msg_player_killed_from_logging_out_in_besieged_town: "%s was killed because they logged out while in a besieged town."
 
 #Added in 0.41
-msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Siege Attendance Limit (%d Battle Sessions). You can attend sieges again in %s. War Sickness will activate in %d seconds. To avoid this effect, leave the Siege-Zone immediately"
-msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Siege Attendance Limit (%d Battle Sessions). You can attend sieges again in %s. War Sickness Activated. To remove this effect, leave the Siege-Zone immediately"
+msg_battle_session_attendance_limit_exceeded_warning: "&cYou have exceeded your daily Siege Attendance Limit of %d Battle Sessions. You can attend sieges again in %s. To avoid War Sickness, leave the Siege-Zone immediately."
+msg_battle_session_attendance_limit_exceeded_punish: "&cYou have exceeded your daily Siege Attendance Limit of %d Battle Sessions. You can attend sieges again in %s. To remove the War Sickness, leave the Siege-Zone immediately."

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -510,5 +510,5 @@ msg_besieged_town_proximity_warning_text: "&cWARNING: You are in a besieged town
 msg_player_killed_from_logging_out_in_besieged_town: "%s was killed because they logged out while in a besieged town."
 
 #Added in 0.41
-msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another Battle Session in %s. War Sickness will activate in %d seconds."
-msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another Battle Session in %s. War Sickness Activated."
+msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Siege Attendance Limit (%d Battle Sessions). You can attend sieges again in %s. War Sickness will activate in %d seconds. To avoid this effect, leave the Siege-Zone immediately"
+msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Siege Attendance Limit (%d Battle Sessions). You can attend sieges again in %s. War Sickness Activated. To remove this effect, leave the Siege-Zone immediately"

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -509,6 +509,6 @@ msg_err_cannon_must_be_in_wilderness_or_besieged_town: "&cWithin SiegeZones, can
 msg_besieged_town_proximity_warning_text: "&cWARNING: You are in a besieged town!. If you log out here while not a military-ranked member of the town-friendly side, you will be killed."
 msg_player_killed_from_logging_out_in_besieged_town: "%s was killed because they logged out while in a besieged town."
 
-#Added in 0.40
-msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another battle session in %s. War sickness will activate in %d seconds."
-msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another battle session in %s. War Sickness Activated."
+#Added in 0.41
+msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another Battle Session in %s. War Sickness will activate in %d seconds."
+msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another Battle Session in %s. War Sickness Activated."

--- a/src/main/resources/lang/fr-FR.yml
+++ b/src/main/resources/lang/fr-FR.yml
@@ -1,5 +1,5 @@
 ﻿name: SiegeWar
-version: 0.40
+version: 0.41
 language: french
 author: PainOchoco
 website: "http://townyadvanced.github.io/"
@@ -461,7 +461,7 @@ hover_message_click_to_claim: "Click to claim money owed to you."
 msg_next_session_cannot_be_determined: "The next Siege Session has not been scheduled. Try again later."
 
 #Added in 0.32
-msg_war_siege_max_daily_player_battle_sessions_reached_cannot_get_banner_control: "&cBanner capture failed because you have reached your daily battle session limit (%d). Try again in %s."
+msg_war_siege_max_daily_player_battle_sessions_reached_cannot_get_banner_control: "&cBanner capture failed because you have reached your daily battle session attendance limit (%d). Try again in %s."
 msg_peaceful_town_subverted: "&b%s has been peacefully subverted and occupied by %s."
 msg_peaceful_town_revolted: "&b%s has peacefully revolted against %s, and freed itself from occupation."
 msg_town_became_peaceful: '&b%s has been confirmed as Neutral. The town is now immune to siege attacks, but vulnerable to getting subverted by nearby nations. Residents cannot enter siege-zones or gain nation-military ranks.'
@@ -519,3 +519,6 @@ msg_err_cannon_must_be_in_wilderness_or_besieged_town: "&cWithin SiegeZones, can
 #Added in 0.40
 msg_besieged_town_proximity_warning_text: "&cWARNING: You are in a besieged town!. If you log out here while not a military-ranked member of the town-friendly side, you will be killed."
 msg_player_killed_from_logging_out_in_besieged_town: "%s was killed because they logged out while in a besieged town."
+
+#Added in 0.40
+msg_max_daily_player_battle_session_attendance_limit_reached: "&cYou have reached your daily Battle Session Attendance Limit (%d). War Sickness active. You can attend another battle session in %s."

--- a/src/main/resources/lang/fr-FR.yml
+++ b/src/main/resources/lang/fr-FR.yml
@@ -521,4 +521,5 @@ msg_besieged_town_proximity_warning_text: "&cWARNING: You are in a besieged town
 msg_player_killed_from_logging_out_in_besieged_town: "%s was killed because they logged out while in a besieged town."
 
 #Added in 0.40
-msg_max_daily_player_battle_session_attendance_limit_reached: "&cYou have reached your daily Battle Session Attendance Limit (%d). War Sickness active. You can attend another battle session in %s."
+msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another battle session in %s. War sickness will activate in %d seconds."
+msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another battle session in %s. War Sickness Activated."

--- a/src/main/resources/lang/fr-FR.yml
+++ b/src/main/resources/lang/fr-FR.yml
@@ -520,5 +520,5 @@ msg_besieged_town_proximity_warning_text: "&cWARNING: You are in a besieged town
 msg_player_killed_from_logging_out_in_besieged_town: "%s was killed because they logged out while in a besieged town."
 
 #Added in 0.41
-msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another Battle Session in %s. War Sickness will activate in %d seconds."
-msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another Battle Session in %s. War Sickness Activated."
+msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Siege Attendance Limit (%d Battle Sessions). You can attend sieges again in %s. War Sickness will activate in %d seconds. To avoid this effect, leave the Siege-Zone immediately"
+msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Siege Attendance Limit (%d Battle Sessions). You can attend sieges again in %s. War Sickness Activated. To remove this effect, leave the Siege-Zone immediately"

--- a/src/main/resources/lang/fr-FR.yml
+++ b/src/main/resources/lang/fr-FR.yml
@@ -461,7 +461,6 @@ hover_message_click_to_claim: "Click to claim money owed to you."
 msg_next_session_cannot_be_determined: "The next Siege Session has not been scheduled. Try again later."
 
 #Added in 0.32
-msg_war_siege_max_daily_player_battle_sessions_reached_cannot_get_banner_control: "&cBanner capture failed because you have reached your daily battle session attendance limit (%d). Try again in %s."
 msg_peaceful_town_subverted: "&b%s has been peacefully subverted and occupied by %s."
 msg_peaceful_town_revolted: "&b%s has peacefully revolted against %s, and freed itself from occupation."
 msg_town_became_peaceful: '&b%s has been confirmed as Neutral. The town is now immune to siege attacks, but vulnerable to getting subverted by nearby nations. Residents cannot enter siege-zones or gain nation-military ranks.'
@@ -520,6 +519,6 @@ msg_err_cannon_must_be_in_wilderness_or_besieged_town: "&cWithin SiegeZones, can
 msg_besieged_town_proximity_warning_text: "&cWARNING: You are in a besieged town!. If you log out here while not a military-ranked member of the town-friendly side, you will be killed."
 msg_player_killed_from_logging_out_in_besieged_town: "%s was killed because they logged out while in a besieged town."
 
-#Added in 0.40
-msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another battle session in %s. War sickness will activate in %d seconds."
-msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another battle session in %s. War Sickness Activated."
+#Added in 0.41
+msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another Battle Session in %s. War Sickness will activate in %d seconds."
+msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Battle Session Attendance Limit (%d). You can attend another Battle Session in %s. War Sickness Activated."

--- a/src/main/resources/lang/fr-FR.yml
+++ b/src/main/resources/lang/fr-FR.yml
@@ -520,5 +520,5 @@ msg_besieged_town_proximity_warning_text: "&cWARNING: You are in a besieged town
 msg_player_killed_from_logging_out_in_besieged_town: "%s was killed because they logged out while in a besieged town."
 
 #Added in 0.41
-msg_battle_session_attendance_limit_exceeded_warning: "&cYou have reached your daily Siege Attendance Limit (%d Battle Sessions). You can attend sieges again in %s. War Sickness will activate in %d seconds. To avoid this effect, leave the Siege-Zone immediately"
-msg_battle_session_attendance_limit_exceeded_punish: "&cYou have reached your daily Siege Attendance Limit (%d Battle Sessions). You can attend sieges again in %s. War Sickness Activated. To remove this effect, leave the Siege-Zone immediately"
+msg_battle_session_attendance_limit_exceeded_warning: "&cYou have exceeded your daily Siege Attendance Limit of %d Battle Sessions. You can attend sieges again in %s. To avoid War Sickness, leave the Siege-Zone immediately."
+msg_battle_session_attendance_limit_exceeded_punish: "&cYou have exceeded your daily Siege Attendance Limit of %d Battle Sessions. You can attend sieges again in %s. To remove the War Sickness, leave the Siege-Zone immediately."


### PR DESCRIPTION
#### Description: 
As described in #501 , the current feature of the Capping Limiter has a key problem:
- It does not actually stop players from attending sieges once they hit their limit.
- Thus player's don't truly get any break, and may feel the need to log overtime to counter an opponent who is logging overtime.
- This PR solves the issue: 
  - Feature renamed. Capping Limiter -> Siege Attendance Limiter
  - Players can no longer attend sieges once they hit their limit (due to war sickness)
  - Attendance is marked if a player caps, damages, or is damages by another player at a Siege.
  - Weekend/Weekday limits are increased by +1
---
### Siege Attendance Limiter

#### Overview
- An essential Health & Safety feature.
- Without this feature, Sieges can often become races to see who can spend the most time online.
- This has a bad effect on player health & safety, with players skipping work/school etc.
- The Siege Attendance Limiter fixes the problem as follows:
  - Each individual player is limited to a sensible maximum daily sieging duration.
  - Default is 3 battle sessions on weekdays, and 6 on weekend days.

#### Benefits & Challenges for players:  
- Benefit: Increased health & safety, as described above.
- Benefit: Teams are discouraged from trying to execute night capping, because
  - A. The team can no longer cap all night in full force, but is limited to just 3 battle sessions (on weekdays) :
    - Thus opponents don't have to attend as many sessions to counterattack.
    - Thus opponents will find it easier to counterattack.
  - B. The reworked reversal bonus enhances attacks by cross-timezone allied armies v.s. skeleton crews of cappers.
  - C. The new Siege Balance Cap means that a team cannot get as far ahead as before. 
  - D. Night capping can no longer be effective if the team uses its limited battle sessions during the day. So to execute the strategy effectively requires the team to give up on many exciting daytime battles.
- Challenge: Teams cannot use overtime-play to win, thus:
  - A. Teams must find new ways to battle fight-avoiding enemies, e.g. finding cross-timezone allies, starting sieges at times which suit them rather than the enemy, and recruiting off the back of their struggle with a cowardly enemy.
  - B. Teams must find new ways to battle cross-timezone enemies, e.g. finding cross-timezone allies, also also simply talking to the enemy to arrange a fight schedule (*the enemy will often just as frustrated at not being able to PVP*).

#### Benefits & Challenges for server:
- Benefit: Increased player health & safety, as described above.
- Challenge: This feature works well in combination with low defeat costs (e.g. low plunder, keep-inv-on-siege-death):
  - The feature, in combo with the Siege-Balance-Cap and Reversal-Bonus, is a "Stick" against no-life capping, making that tactic riskier, less effective and even more boring than before.
  - On its own, this change might not have the expected effect, because as long as the no-lifer is still highly motivated to avoid losing, they may continue their tactics, but just have much less fun doing so.
  - Alternatively, if this "Stick" can be combined with a "Carrot" of low defeat costs, then teams are doubly influenced to give up on no-life tactics, and to meet their opponents on the field of battle.
  
____
#### New Nodes/Commands/C1onfigOptions: 
```
	WAR_SIEGE_ATTENDANCE_LIMITER(
			"war.siege.attendance_limiter",
			"",
			"",
			"",
			"############################################################",
			"# +------------------------------------------------------+ #",
			"# |                 Attendance Limiter                     #",
			"# +------------------------------------------------------+ #",
			"############################################################",
			""),
	SIEGE_ATTENDANCE_LIMITER_WEEKDAY_BATTLE_SESSIONS(
			"siege_attendance_limiter.weekday_battle_sessions",
			"3",
			"",
			"# This value determines the maximum number of week-day battle sessions which each player can attend.",
			"# To disable the feature, set the value to -1.",
			"# TIP: This feature is critical to prevent teams trying to win sieges via excessive-online-time, including skipping school or work."),
	SIEGE_ATTENDANCE_LIMITER_WEEKEND_DAY_BATTLE_SESSIONS(
			"siege_attendance_limiter.weekend_day_battle_sessions",
			"6",
			"",
			"# This value determines the maximum number of weekend-day battle sessions which each player can attend.",
			"# To disable the feature, set the value to -1.",
			"# TIP: This feature is critical to prevent teams trying to win sieges via excessive-online-time, including skipping school or work."),
	SIEGE_ATTENDANCE_LIMITER_SICKNESS_WARNING_DURATION_SECONDS(
			"siege_attendance_limiter.sickness_warning_duration_seconds",
			"5",
			"",
			"# This value determines the number of warning seconds before sickness applies."),

```
____
#### Relevant Issue ticket:
Closes #501 

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
