### PR TITLE
Scheduler method fix

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -44,9 +44,9 @@ public class SiegeWarBattleSessionUtil {
 		int millisUntilStart;
 		int startTimeClip = SiegeWarSettings.getWarSiegeBattleSessionsStartTimeClip();
 		int currentMinutes = LocalDateTime.now().getMinute();
-		if(currentMinutes <= startTimeClip) {
+		if(currentMinutes < startTimeClip) {
 			//The next session will occur this hour
-			minutesUntilStart = startTimeClip - currentMinutes -1;
+			minutesUntilStart = startTimeClip - currentMinutes;
 		} else {
 			//This next session will occur next hour
 			minutesUntilStart = (60 - currentMinutes) + startTimeClip;


### PR DESCRIPTION
#### Description: 
- The battle session scheduler method (not to be confused with the feature) sometimes starts too soon.
- In particular if an admin force-ends the session in the same minute as it is due, it will start immediately.
- This PR fixes the issue

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [ N/A very small fix should be fine ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
