### PR TITLE
Enable non-participant punish feature by default

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -912,7 +912,7 @@ public enum ConfigNodes {
 			""),
 	ENABLE_SICKNESS(
 			"punish_non_siege_participants_in_siege_zone.enable_sickness",
-			"false",
+			"true",
 			"",
 			"# If true, players that are not participating in a siege will receive war sickness",
 			"# A non-participant is a player who does not have a military rank, is not allied to either the attacker or the defender, or is neutral.",
@@ -924,7 +924,7 @@ public enum ConfigNodes {
 	),
 	SECONDS_BEFORE_SICKNESS(
 			"punish_non_siege_participants_in_siege_zone.seconds_warning",
-			"5",
+			"20",
 			"",
 			"# This is how many seconds a player has to leave the siege zone before he gets war sickness",
 			"# If this is set to 0, no warn will be given and non-participants will receive war sickness instantly, if enabled"

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -900,7 +900,7 @@ public enum ConfigNodes {
 			"# If this value is true, then a town under occupation cannot unclaim.",
 			"#  This setting is recommended, to avoid occupation escape exploits."),
 	PUNISH_NON_SIEGE_PARTICIPANTS_IN_SIEGE_ZONE(
-			"punish_non_siege_participants_in_siege_zone",
+			"punish_non_siege_participants_in_siege_zones",
 			"",
 			"",
 			"",
@@ -911,7 +911,7 @@ public enum ConfigNodes {
 			"############################################################",
 			""),
 	ENABLE_SICKNESS(
-			"punish_non_siege_participants_in_siege_zone.enable_sickness",
+			"punish_non_siege_participants_in_siege_zones.enable_sickness",
 			"true",
 			"",
 			"# If true, players that are not participating in a siege will receive war sickness",
@@ -920,10 +920,10 @@ public enum ConfigNodes {
 			"# Special war sickness is only given if a non-participant is at his town that happened to be in a siege zone",
 			"#   - Effects: Weakness V",
 			"# Full sickness is given to all players that are not allied to either side, do not have a military rank, or is neutral, and are not in their own town.",
-			"#   - Effects: Nausea V, Poison V, Weakness V, Slowness III, Mining Fatigue III"
+			"#   - Effects: Health 1, Nausea V, Poison V, Weakness V, Slowness III, Mining Fatigue III"
 	),
 	SECONDS_BEFORE_SICKNESS(
-			"punish_non_siege_participants_in_siege_zone.seconds_warning",
+			"punish_non_siege_participants_in_siege_zones.seconds_warning",
 			"20",
 			"",
 			"# This is how many seconds a player has to leave the siege zone before he gets war sickness",


### PR DESCRIPTION
#### Description: 
- This feature by Ceedric is pretty much standard now, so this is overdue.
- Also with the upcoming changes to keep inv, this feature becomes critical to keeping non-participants from interfering.
- Given the criticality, I updated the name slightly to that it will auto-enable on all servers (of course they can later configure it off)
- I also updated the warning time to a more reasonable default of 20 seconds.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [ N/A ] I have tested this pull request for defects on a server. 
- 
By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
