### PR TITLE
fix for attendance limiter culling

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -317,12 +317,9 @@ public class SiegeWarBattleSessionUtil {
 		if(SiegeWarSettings.getSiegeAttendanceLimiterBattleSessions() == -1)
 			return;
 
-		Resident resident;
 		List<String> recentBattleSessionsList;
 		List<String> recalculatedRecentBattleSessionsList;
-		for(Player player: Bukkit.getOnlinePlayers()) {
-			resident = TownyAPI.getInstance().getResident(player);
-
+		for(Resident resident: TownyAPI.getInstance().getResidents()) {
 			//Recalculate recent-sessions list, keeping only entries which are newer then 24 hours old
 			recentBattleSessionsList = ResidentMetaDataController.getRecentBattleSessionsAsList(resident);
 			recalculatedRecentBattleSessionsList = new ArrayList<>();


### PR DESCRIPTION
#### Description: 
- Currently attendance limiter only culls old sessions from a player if that player online when a session starts
- Not good
- This PR fixes the issue (very small code change)
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [  N/A ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
