### PR TITLE
Add Siegezone Proximity Caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>0.7.12</version>
+  <version>0.8.0</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -38,7 +38,6 @@ import com.gmail.goosius.siegewar.playeractions.PlayerDeath;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.SiegeWarBlockUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
-import com.gmail.goosius.siegewar.utils.SiegeWarBattleSessionUtil;
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;
@@ -204,9 +203,12 @@ public class SiegeWarBukkitEventListener implements Listener {
 
 	@EventHandler
 	public void on(PlayerJoinEvent event) {
-		if(SiegeWarSettings.getWarSiegeEnabled()
-			&& TownyAPI.getInstance().getTownyWorld(event.getPlayer().getWorld()).isWarAllowed()) {
-			SiegeWarNotificationUtil.warnPlayerOfSiegeDanger(event.getPlayer());
+		if(SiegeWarSettings.getWarSiegeEnabled() && TownyAPI.getInstance().getTownyWorld(event.getPlayer().getWorld()).isWarAllowed()) {
+		    Siege siegeAtPlayerLocation = SiegeController.getActiveSiegeAtLocation(event.getPlayer().getLocation());	    
+		    if(siegeAtPlayerLocation != null) {
+		    	SiegeWarDistanceUtil.registerPlayerToActiveSiegeZone(event.getPlayer(), siegeAtPlayerLocation);
+		    	SiegeWarNotificationUtil.warnPlayerOfActiveSiegeDanger(event.getPlayer(), siegeAtPlayerLocation);
+			}
 		}
 	}
 
@@ -272,8 +274,8 @@ public class SiegeWarBukkitEventListener implements Listener {
 		if(!(event.getEntity() instanceof Player))
 			return;
 
-		//Return if event is not in a SiegeZone
-		boolean eventIsInActiveSiegeZone = SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getEntity().getLocation());
+		//Return if player being damaged is not in a SiegeZone
+		boolean eventIsInActiveSiegeZone = SiegeWarDistanceUtil.isPlayerRegisteredToActiveSiegeZone((Player)event.getEntity());
 		if(!eventIsInActiveSiegeZone)
 			return;
 
@@ -315,7 +317,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 				&& !event.isCancelled()
 				&& event.getEntity() instanceof Player
 				&& event.getEntity().hasPermission(SiegeWarPermissionNodes.SIEGEWAR_SIEGEZONE_DAMAGE_IMMUNITY.getNode())
-				&& SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getEntity().getLocation())) {
+				&& SiegeWarDistanceUtil.isPlayerRegisteredToActiveSiegeZone((Player)event.getEntity())) {
 			event.setCancelled(true);
 		}
 	}			
@@ -328,7 +330,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 				&& event.getEntity().getShooter() instanceof Player
 				&& !((Player)event.getEntity().getShooter()).isOp()
 				&& ((Player)event.getEntity().getShooter()).hasPermission(SiegeWarPermissionNodes.SIEGEWAR_SIEGEZONE_CANNOT_THROW_POTIONS.getNode())
-				&& SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getEntity().getLocation())) {
+				&& SiegeWarDistanceUtil.isPlayerRegisteredToActiveSiegeZone((Player)event.getEntity().getShooter())) {
 			event.setCancelled(true);
 		}
 	}			
@@ -341,7 +343,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 				&& event.getEntity().getShooter() instanceof Player
 				&& !((Player)event.getEntity().getShooter()).isOp()
 				&& ((Player)event.getEntity().getShooter()).hasPermission(SiegeWarPermissionNodes.SIEGEWAR_SIEGEZONE_CANNOT_THROW_POTIONS.getNode())
-				&& SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getEntity().getLocation())) {
+				&& SiegeWarDistanceUtil.isPlayerRegisteredToActiveSiegeZone((Player)event.getEntity().getShooter())) {
 			event.setCancelled(true);
 		}
 	}	

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -106,6 +106,7 @@ public class SiegeWarTownyEventListener implements Listener {
     public void onShortTime(NewShortTimeEvent event) {
         if (SiegeWarSettings.getWarSiegeEnabled()) {
             SiegeWarTimerTaskController.evaluateBattleSessions();
+            SiegeWarDistanceUtil.recalculatePlayersRegisteredToActiveSiegeZones();
             SiegeWarTimerTaskController.evaluateWarSickness();
             SiegeWarTimerTaskController.evaluateBannerControl();
             SiegeWarTimerTaskController.evaluateWallBreaching();         
@@ -113,7 +114,7 @@ public class SiegeWarTownyEventListener implements Listener {
             SiegeHUDManager.updateHUDs();
             SiegeWarTimerTaskController.evaluateBeacons();
             SiegeWarTimerTaskController.evaluateBattlefieldReporters();
-            SiegeWarNotificationUtil.warnPlayersOfSiegeDanger();
+            SiegeWarNotificationUtil.warnAllPlayersOfSiegeDanger();
         }
     }
 
@@ -201,8 +202,13 @@ public class SiegeWarTownyEventListener implements Listener {
      */
     @EventHandler
     public void onOutlawTeleportEvent(OutlawTeleportEvent event) {
-    	if (SiegeWarSettings.getWarSiegeEnabled() && SiegeController.hasActiveSiege(event.getTown())) 
+        if (SiegeWarSettings.getWarSiegeEnabled() 
+                && event.getOutlawLocation() != null
+                && event.getOutlawLocation().getWorld() != null
+                && TownyAPI.getInstance().getTownyWorld(event.getOutlawLocation().getWorld()).isWarAllowed()
+                && SiegeController.hasActiveSiege(event.getTown())) {
     		event.setCancelled(true);
+            }
     }
 
     /**
@@ -212,7 +218,10 @@ public class SiegeWarTownyEventListener implements Listener {
      */
     @EventHandler
     public void on (TownyFriendlyFireTestEvent event) {
-        if (SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getAttacker().getLocation()))
+    	if (SiegeWarSettings.getWarSiegeEnabled() 
+                && TownyAPI.getInstance().getTownyWorld(event.getAttacker().getWorld()).isWarAllowed()
+                && SiegeWarDistanceUtil.isPlayerRegisteredToActiveSiegeZone(event.getAttacker())) {
             event.setPVP(true);
+        }
     }
 }

--- a/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
@@ -530,7 +530,7 @@ public class Siege {
 		return playersWhoWereInTheBesiegedTown;
 	}
 
-	public void addPlayersWhoWasInTheBesiegedTown(Player player) {
+	public void addPlayersWhoWereInTheBesiegedTown(Player player) {
 		playersWhoWereInTheBesiegedTown.add(player);
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattlefieldObserverUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattlefieldObserverUtil.java
@@ -29,7 +29,7 @@ public class SiegeWarBattlefieldObserverUtil {
         for(Player player: Bukkit.getOnlinePlayers()) { 
             if(!player.isOp()
                 && player.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_SIEGEZONE_CANNOT_CARRY_ITEMS.getNode())
-                && SiegeWarDistanceUtil.isLocationInActiveSiegeZone(player.getLocation())) {
+                && SiegeWarDistanceUtil.isPlayerRegisteredToActiveSiegeZone(player)) {
 
                 //Player cannot carry food. So don't let them starve!.
                 if(player.getFoodLevel() < 20) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
@@ -88,21 +88,16 @@ public class SiegeWarNotificationUtil {
 		}
 	}
 
-	public static void warnPlayerOfSiegeDanger(Player player) {
-		//Return is war is not enabled at player's location
-		if(!TownyAPI.getInstance().getTownyWorld(player.getWorld()).isWarAllowed())
-			return;
-
-		//Send warning if player is in SiegeZone (& didn't already get the warning)
-		Siege siege = SiegeController.getActiveSiegeAtLocation(player.getLocation());
-		if(siege != null
-			&& siege.getStatus().isActive()
-			&& !siege.getPlayersWhoWereInTheSiegeZone().contains(player)
-			&& SiegeWarDistanceUtil.isLocationInActiveSiegeZone(player.getLocation())) {
-				Messaging.sendErrorMsg(player, Translatable.of("msg_siege_zone_proximity_warning_text"));
-				siege.addPlayerWhoWasInTheSiegeZone(player);
+	/**
+	 * Warn player who we know is in an active siege zones
+	 * @param player player
+	 * @param siege siege
+	 */
+	public static void warnPlayerOfActiveSiegeDanger(Player player, Siege siege) {
+		if(!siege.getPlayersWhoWereInTheSiegeZone().contains(player)) {
+			Messaging.sendErrorMsg(player, Translatable.of("msg_siege_zone_proximity_warning_text"));
+			siege.addPlayerWhoWasInTheSiegeZone(player);
 		}
-
 		//Send warning if player is in besieged town (& didn't already get the warning)
 		//Note: Being in the SiegeZone doesn't necessarily mean being in a besieged town
 		if(SiegeWarSettings.getKillHostilePlayersWhoLogoutInBesiegedTown()) {
@@ -114,14 +109,16 @@ public class SiegeWarNotificationUtil {
 				&& siege.getStatus().isActive()
 				&& !siege.getPlayersWhoWereInTheBesiegedTown().contains(player)) {
 					Messaging.sendErrorMsg(player, Translatable.of("msg_besieged_town_proximity_warning_text"));
-					siege.addPlayersWhoWasInTheBesiegedTown(player);
+					siege.addPlayersWhoWereInTheBesiegedTown(player);
 			}
 		}
 	}
 
-	public static void warnPlayersOfSiegeDanger() {
+	public static void warnAllPlayersOfSiegeDanger() {
 		for(Player player: Bukkit.getOnlinePlayers()) {
-			warnPlayerOfSiegeDanger(player);
+			Siege siege = SiegeWarDistanceUtil.getActiveSiegeZoneWherePlayerIsRegistered(player);
+			if(siege != null)
+				warnPlayerOfActiveSiegeDanger(player, siege); 
 		}
 	}
 }


### PR DESCRIPTION
#### Description: 
- With recent code, a few methods have been added which check for siegezone proximity on each PVP hit
- I think this could potentially be causing issues vis. lag, especially in big fights
- This PR should fix the issue, by using cached siegezone proximity checking in the following methods:
  - 4 battlefield observer related methods
  - 1 listener method for undoing PVP cancellation by Townyfriendly fire 
  - 1 listener method mainly for undoing PVP cancellation by all other plugins
  - 1 method for warning players about being in a siegezone
- Also I improved performance (but did not actually add caching) in the following listener methods
  - Townblock PVP event check

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
