### PR TITLE
Pvp unprotection configs

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -272,21 +272,21 @@ public class SiegeWarBukkitEventListener implements Listener {
 		if(!(event.getEntity() instanceof Player))
 			return;
 
-		//Return if event is not in a SiegeZone
-		boolean eventIsInActiveSiegeZone = SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getEntity().getLocation());
-		if(!eventIsInActiveSiegeZone)
-			return;
-
-		/*
-		 * Undo any cancellation by non-Towny plugins
-		 * Note that we will have already undone any Towny cancellation
-		 */
-		if(event.isCancelled()) {
-			event.setCancelled(false);
-		}
-
 		//PVP or EVP event ?:
 		if(event.getDamager() instanceof Player) {
+
+			/*
+			 * Catch-all pvp-protection cancellation
+			 */
+			if(event.isCancelled()) {
+				if(SiegeWarSettings.isStopAllPvpProtection() && SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getEntity().getLocation()))
+					event.setCancelled(false);  //Event un-cancelled
+				else
+					return; //Event stays cancelled
+			} else {
+				if(!SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getEntity().getLocation()))
+					return; // Event not in SiegeZone
+			}
 
 			//If the damager is op, return
 			if(event.getDamager().isOp())
@@ -297,7 +297,12 @@ public class SiegeWarBukkitEventListener implements Listener {
 				event.setCancelled(true);
 				return;
 			}
+
 		} else {
+
+			//Return if event is not in a SiegeZone
+			if(!SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getEntity().getLocation()))
+				return;
 
 			//Stop TNT/Minecarts from damaging players in SiegeZone wilderness
 			if (SiegeWarSettings.getSiegeZoneWildernessForbiddenExplodeEntityTypes().contains(event.getDamager().getType())

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -273,22 +273,20 @@ public class SiegeWarBukkitEventListener implements Listener {
 		//Return if the entity being damaged is not a player
 		if(!(event.getEntity() instanceof Player))
 			return;
+		
+		//Return if player being damaged is not in a SiegeZone
+		if(!SiegeWarDistanceUtil.isPlayerRegisteredToActiveSiegeZone((Player)event.getEntity()))
+			return;
+
+		/*
+		 * Catch-All to undo any remaining damage cancellation
+		 */
+		if(SiegeWarSettings.isStopAllPvpProtection() && event.isCancelled()) {
+			event.setCancelled(false);
+		}
 
 		//PVP or EVP event ?:
 		if(event.getDamager() instanceof Player) {
-
-			/*
-			 * Catch-all pvp-protection cancellation
-			 */
-			if(event.isCancelled()) {
-				if(SiegeWarSettings.isStopAllPvpProtection() && SiegeWarDistanceUtil.isPlayerRegisteredToActiveSiegeZone((Player)event.getEntity()))
-					event.setCancelled(false);  //Event un-cancelled
-				else
-					return; //Event stays cancelled
-			} else {
-				if(!SiegeWarDistanceUtil.isPlayerRegisteredToActiveSiegeZone((Player)event.getEntity()))
-					return; // Event not in SiegeZone.
-			}
 
 			//If the damager is op, return
 			if(event.getDamager().isOp())
@@ -301,14 +299,6 @@ public class SiegeWarBukkitEventListener implements Listener {
 			}
 
 		} else {
-
-			//Return if event is cancelled
-			if(event.isCancelled())
-				return;
-
-			//Return if player is not in a SiegeZone
-			if(!SiegeWarDistanceUtil.isPlayerRegisteredToActiveSiegeZone((Player)event.getEntity()))
-				return;
 
 			//Stop TNT/Minecarts from damaging players in SiegeZone wilderness
 			if (SiegeWarSettings.getSiegeZoneWildernessForbiddenExplodeEntityTypes().contains(event.getDamager().getType())

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -281,7 +281,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 		/*
 		 * Catch-All to undo any remaining damage cancellation
 		 */
-		if(SiegeWarSettings.isStopAllPvpProtection() && event.isCancelled()) {
+		if(event.isCancelled() && SiegeWarSettings.isStopAllPvpProtection()) {
 			event.setCancelled(false);
 		}
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -273,7 +273,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 		//Return if the entity being damaged is not a player
 		if(!(event.getEntity() instanceof Player))
 			return;
-		
+
 		//Return if player being damaged is not in a SiegeZone
 		if(!SiegeWarDistanceUtil.isPlayerRegisteredToActiveSiegeZone((Player)event.getEntity()))
 			return;
@@ -297,7 +297,6 @@ public class SiegeWarBukkitEventListener implements Listener {
 				event.setCancelled(true);
 				return;
 			}
-
 		} else {
 
 			//Stop TNT/Minecarts from damaging players in SiegeZone wilderness

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarPlotEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarPlotEventListener.java
@@ -24,6 +24,7 @@ public class SiegeWarPlotEventListener implements Listener {
 	public void onTownBlockPVPTest(TownBlockPVPTestEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()
 		    && event.getTownBlock().getWorld().isWarAllowed()
+		    && SiegeWarSettings.isStopTownyPlotPvpProtection()
 		    && !event.getTownBlock().getPermissions().pvp
 		    && SiegeWarDistanceUtil.isTownBlockInActiveSiegeZone(event.getTownBlock())) {
 				event.setPvp(true);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -212,7 +212,9 @@ public class SiegeWarTownyEventListener implements Listener {
      */
     @EventHandler
     public void on (TownyFriendlyFireTestEvent event) {
-        if (SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getAttacker().getLocation()))
+        if (SiegeWarSettings.getWarSiegeEnabled()
+                && SiegeWarSettings.isStopTownyFriendlyFireProtection()
+                && SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getAttacker().getLocation()))
             event.setPVP(true);
     }
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -1001,7 +1001,7 @@ public enum ConfigNodes {
 			"#                                                          #",
 			"# Other plugins, including Towny, can protect players      #",
 			"# from PVP, even when those players are in Siege-Zones.    #",
-			"# 						                                    #",
+			"# 						            #",
 			"# This section allows server owners to override those      #",
 			"# protections, and stop them from working in Siege-Zones.  #",
 			"############################################################",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -1006,19 +1006,23 @@ public enum ConfigNodes {
 			"# protections, and stop them from working in Siege-Zones.  #",
 			"############################################################",
 			""),
+	PVP_PROTECTION_OVERRIDES_STOP_TOWNY_PLOT_PVP_PROTECTION(
+			"pvp.protection.override.stop_towny_plot_protection",
+			"true",
+			"",
+			"# If true, then Towny plot protection is disabled in Siege-Zones.",
+			"# TIP: This value is generally set to true, to avoid having unnatural safe claims within Siege-Zones."),
 	PVP_PROTECTION_OVERRIDES_STOP_TOWNY_FRIENDLY_FIRE_PROTECTION(
 			"pvp.protection.override.stop_towny_friendly_fire_protection",
 			"false",
 			"",
-			"# If true, then Towny friendly-fire protection is disabled in Siege-Zones.",
-			"# WARNING: Setting this to true may cause lag!."),
+			"# If true, then Towny friendly-fire protection is disabled within Siege-Zones."),
 	PVP_PROTECTION_OVERRIDES_STOP_ALL_PVP_PROTECTION(
 			"pvp.protection.override.stop_all_protection",
 			"false",
 			"",
-			"# If true, then all PVP protections are disabled in Siege-Zones.",
-			"# WARNING 1 : Setting this to true may cause lag!.",
-			"# WARNING 2 : This setting may result in incorrect pvp-protection messaging information!.");
+			"# If true, then all PVP protections are disabled within Siege-Zones, including from non-TownyAdvanced plugins.",
+			"# WARNING : This setting may result in incorrect pvp-protection messaging information!.");
 
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -988,7 +988,37 @@ public enum ConfigNodes {
 			"",
 			"# This value determines the maximum number of weekend-day battle sessions which each player can at.",
 			"# To disable the feature, set the value to -1.",
-			"# TIP: This feature helps to prevent teams trying to win by fight-avoidance with capping.");
+			"# TIP: This feature helps to prevent teams trying to win by fight-avoidance with capping."),
+	PVP_PROTECTION_OVERRIDES(
+			"pvp.protection.overrides",
+			"",
+			"",
+			"",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |               PVP Protection Overrides               | #",
+			"# +------------------------------------------------------+ #",
+			"#                                                          #",
+			"# Other plugins, including Towny, can protect players      #",
+			"# from PVP, even when those players are in Siege-Zones.    #",
+			"# 						                                    #",
+			"# This section allows server owners to override those      #",
+			"# protections, and stop them from working in Siege-Zones.  #",
+			"############################################################",
+			""),
+	PVP_PROTECTION_OVERRIDES_STOP_TOWNY_FRIENDLY_FIRE_PROTECTION(
+			"pvp.protection.override.stop_towny_friendly_fire_protection",
+			"false",
+			"",
+			"# If true, then Towny friendly-fire protection is disabled in Siege-Zones.",
+			"# WARNING: Setting this to true may cause lag!."),
+	PVP_PROTECTION_OVERRIDES_STOP_ALL_PVP_PROTECTION(
+			"pvp.protection.override.stop_all_protection",
+			"false",
+			"",
+			"# If true, then all PVP protections are disabled in Siege-Zones.",
+			"# WARNING 1 : Setting this to true may cause lag!.",
+			"# WARNING 2 : This setting may result in incorrect pvp-protection messaging information!.");
 
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -990,7 +990,7 @@ public enum ConfigNodes {
 			"# To disable the feature, set the value to -1.",
 			"# TIP: This feature helps to prevent teams trying to win by fight-avoidance with capping."),
 	PVP_PROTECTION_OVERRIDES(
-			"pvp.protection.overrides",
+			"pvp_protection_overrides",
 			"",
 			"",
 			"",
@@ -1007,18 +1007,18 @@ public enum ConfigNodes {
 			"############################################################",
 			""),
 	PVP_PROTECTION_OVERRIDES_STOP_TOWNY_PLOT_PVP_PROTECTION(
-			"pvp.protection.override.stop_towny_plot_protection",
+			"pvp_protection_overrides.stop_towny_plot_protection",
 			"true",
 			"",
 			"# If true, then Towny plot protection is disabled in Siege-Zones.",
 			"# TIP: This value is generally set to true, to avoid having unnatural safe claims within Siege-Zones."),
 	PVP_PROTECTION_OVERRIDES_STOP_TOWNY_FRIENDLY_FIRE_PROTECTION(
-			"pvp.protection.override.stop_towny_friendly_fire_protection",
+			"pvp_protection_overrides.stop_towny_friendly_fire_protection",
 			"false",
 			"",
 			"# If true, then Towny friendly-fire protection is disabled within Siege-Zones."),
 	PVP_PROTECTION_OVERRIDES_STOP_ALL_PVP_PROTECTION(
-			"pvp.protection.override.stop_all_protection",
+			"pvp_protection_overrides.stop_all_protection",
 			"false",
 			"",
 			"# If true, then all PVP protections are disabled within Siege-Zones, including from non-TownyAdvanced plugins.",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -480,6 +480,10 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_KILL_HOSTILE_PLAYERS_WHO_LOG_OUT_IN_BESIEGED_TOWNS);
 	}
 
+	public static boolean isStopTownyPlotPvpProtection() {
+		return Settings.getBoolean(ConfigNodes.PVP_PROTECTION_OVERRIDES_STOP_TOWNY_PLOT_PVP_PROTECTION);
+	}
+
 	public static boolean isStopTownyFriendlyFireProtection() {
 		return Settings.getBoolean(ConfigNodes.PVP_PROTECTION_OVERRIDES_STOP_TOWNY_FRIENDLY_FIRE_PROTECTION);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -480,4 +480,12 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_KILL_HOSTILE_PLAYERS_WHO_LOG_OUT_IN_BESIEGED_TOWNS);
 	}
 
+	public static boolean isStopTownyFriendlyFireProtection() {
+		return Settings.getBoolean(ConfigNodes.PVP_PROTECTION_OVERRIDES_STOP_TOWNY_FRIENDLY_FIRE_PROTECTION);
+	}
+
+	public static boolean isStopAllPvpProtection() {
+		return Settings.getBoolean(ConfigNodes.PVP_PROTECTION_OVERRIDES_STOP_ALL_PVP_PROTECTION);
+	}
+
 }


### PR DESCRIPTION
#### Description: 
- With current code some pvp un-protection features are not configged
- This PR adds the configs

____
#### New Nodes/Commands/ConfigOptions: 
```
	PVP_PROTECTION_OVERRIDES(
			"pvp_protection_overrides",
			"",
			"",
			"",
			"############################################################",
			"# +------------------------------------------------------+ #",
			"# |               PVP Protection Overrides               | #",
			"# +------------------------------------------------------+ #",
			"#                                                          #",
			"# Other plugins, including Towny, can protect players      #",
			"# from PVP, even when those players are in Siege-Zones.    #",
			"# 						            #",
			"# This section allows server owners to override those      #",
			"# protections, and stop them from working in Siege-Zones.  #",
			"############################################################",
			""),
	PVP_PROTECTION_OVERRIDES_STOP_TOWNY_PLOT_PVP_PROTECTION(
			"pvp_protection_overrides.stop_towny_plot_protection",
			"true",
			"",
			"# If true, then Towny plot protection is disabled in Siege-Zones.",
			"# TIP: This value is generally set to true, to avoid having unnatural safe claims within Siege-Zones."),
	PVP_PROTECTION_OVERRIDES_STOP_TOWNY_FRIENDLY_FIRE_PROTECTION(
			"pvp_protection_overrides.stop_towny_friendly_fire_protection",
			"false",
			"",
			"# If true, then Towny friendly-fire protection is disabled within Siege-Zones."),
	PVP_PROTECTION_OVERRIDES_STOP_ALL_PVP_PROTECTION(
			"pvp_protection_overrides.stop_all_protection",
			"false",
			"",
			"# If true, then all PVP protections are disabled within Siege-Zones, including from non-TownyAdvanced plugins.",
			"# WARNING : This setting may result in incorrect pvp-protection messaging information!.");

```
____
#### Relevant Issue ticket:
N/A

____
- [  N/A ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
