### PR TITLE
Set winner takes all to be false by default

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -520,7 +520,7 @@ public enum ConfigNodes {
 			""),
 	WAR_SIEGE_POINTS_BALANCING_END_OF_BATTLE_POINTS_DISTRIBUTION_WINNER_TAKES_ALL(
 			"war.siege.points_balancing.end_of_battle_points_distribution.winner_takes_all",
-			"true",
+			"false",
 			"",
 			"# If true, at the end of a battle, only the battle points of the winner are applied to the siege balance.",
 			"# If false, the battle points of the losing side are also applied to the siege balance."),


### PR DESCRIPTION
#### Description: 
- This PR switches changes a default value to a more sensible one
  - (Players seem generally to expect winner take all to false)
  
____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [ N/A ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
