### PR TITLE
Fixed double death points when logging out

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -228,13 +228,12 @@ public class SiegeWarBukkitEventListener implements Listener {
 		}
 
 		//Kill players in Siege-Zones
-		if(SiegeWarSettings.getKillPlayersWhoLogoutInSiegeZones()
+		if(event.getPlayer().getHealth() > 0
+				&& SiegeWarSettings.getKillPlayersWhoLogoutInSiegeZones()
 				&& TownyAPI.getInstance().getTownyWorld(event.getPlayer().getWorld()).isWarAllowed()
 				&& SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getPlayer().getLocation())) {
-			if(event.getPlayer().getHealth() > 0) {
-				event.setQuitMessage(Translation.of("msg_player_killed_for_logging_out_in_siege_zone", event.getPlayer().getName()));
-				event.getPlayer().setHealth(0);
-			}
+			event.setQuitMessage(Translation.of("msg_player_killed_for_logging_out_in_siege_zone", event.getPlayer().getName()));
+			event.getPlayer().setHealth(0);
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -231,8 +231,10 @@ public class SiegeWarBukkitEventListener implements Listener {
 		if(SiegeWarSettings.getKillPlayersWhoLogoutInSiegeZones()
 				&& TownyAPI.getInstance().getTownyWorld(event.getPlayer().getWorld()).isWarAllowed()
 				&& SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getPlayer().getLocation())) {
-			event.setQuitMessage(Translation.of("msg_player_killed_for_logging_out_in_siege_zone", event.getPlayer().getName()));
-			event.getPlayer().setHealth(0);
+			if(event.getPlayer().getHealth() > 0) {
+				event.setQuitMessage(Translation.of("msg_player_killed_for_logging_out_in_siege_zone", event.getPlayer().getName()));
+				event.getPlayer().setHealth(0);
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Description: 
- On servers with combat tag, with current code, if a player logs out in a SZ they get double death points
- First combat tag kills them, then SW awards points
- Then SW kills them again (lol), giving a second SW points award
- This PR fixes the issue

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [ N/A ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
