### PR TITLE
Added Cap-Zone option to trap mitigation

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -160,13 +160,13 @@ public class SiegeWarTownyEventListener implements Listener {
      *
      * @return filtered list
      */
-    private static List<Block> filterExplodeListByTrapWarfareMitigation(List<Block> givenExplodeList) {       
+    private static List<Block> filterExplodeListByTrapWarfareMitigation(List<Block> givenExplodeList) {
         if(!SiegeWarSettings.isTrapWarfareMitigationEnabled())
             return givenExplodeList;
-
+        boolean capZoneMitigationOnly = SiegeWarSettings.isTrapWarfareMitigationCapZoneOnly();
         List<Block> filteredList = new ArrayList<>(givenExplodeList);
         for(Block block: givenExplodeList) {
-            if (SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(block.getLocation())) {
+            if(SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(block.getLocation(), capZoneMitigationOnly)) {
                 //Remove block from final explode list
                 filteredList.remove(block);
             } 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -125,7 +125,7 @@ public class SiegeWarTownyEventListener implements Listener {
      * @throws TownyException if something is misconfigured
      */
     @EventHandler(priority = EventPriority.HIGH)
-    public void onBlockExploding(TownyExplodingBlocksEvent event) throws TownyException {       
+    public void onBlockExploding(TownyExplodingBlocksEvent event) throws TownyException {
         if(!SiegeWarSettings.getWarSiegeEnabled())
             return;
         if (event.getEntity() != null && !TownyAPI.getInstance().getTownyWorld(event.getEntity().getWorld()).isWarAllowed())

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -125,7 +125,7 @@ public class SiegeWarTownyEventListener implements Listener {
      * @throws TownyException if something is misconfigured
      */
     @EventHandler(priority = EventPriority.HIGH)
-    public void onBlockExploding(TownyExplodingBlocksEvent event) throws TownyException {
+    public void onBlockExploding(TownyExplodingBlocksEvent event) throws TownyException {       
         if(!SiegeWarSettings.getWarSiegeEnabled())
             return;
         if (event.getEntity() != null && !TownyAPI.getInstance().getTownyWorld(event.getEntity().getWorld()).isWarAllowed())

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
@@ -45,21 +45,21 @@ public class DestroyBlock {
 
 		final Translator translator = Translator.locale(Translation.getLocale(event.getPlayer()));
 
-        //Trap warfare block protection
-        if(SiegeWarSettings.isTrapWarfareMitigationEnabled()
-                && SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(event.getBlock().getLocation())) {
-            event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.DARK_RED + translator.of("msg_err_cannot_alter_blocks_below_banner_in_siege_zone")));
-            event.setCancelled(true);
-            return;
-        }
+		//Trap warfare block protection
+		if(SiegeWarSettings.isTrapWarfareMitigationEnabled()
+				&& SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(event.getBlock().getLocation(), SiegeWarSettings.isTrapWarfareMitigationCapZoneOnly())) {
+			event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.DARK_RED + translator.of("msg_err_cannot_alter_blocks_below_banner_in_siege_zone")));
+			event.setCancelled(true);
+			return;
+		}
 
-        //Prevent destruction of siege-banner or support block
-        if (SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())
-        || SiegeWarBlockUtil.isBlockNearAnActiveSiegeCampBanner(event.getBlock())) {
-            event.setMessage(translator.of("msg_err_siege_war_cannot_destroy_siege_banner"));
-            event.setCancelled(true);
-            return;
-        }
+		//Prevent destruction of siege-banner or support block
+		if (SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())
+				|| SiegeWarBlockUtil.isBlockNearAnActiveSiegeCampBanner(event.getBlock())) {
+			event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.DARK_RED + translator.of("msg_err_siege_war_cannot_destroy_siege_banner")));
+			event.setCancelled(true);
+			return;
+		}
     }
 
 	/**

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
@@ -55,7 +55,7 @@ public class DestroyBlock {
 
         //Prevent destruction of siege-banner or support block
         if (SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())
-        	|| SiegeWarBlockUtil.isBlockNearAnActiveSiegeCampBanner(event.getBlock())) {
+        || SiegeWarBlockUtil.isBlockNearAnActiveSiegeCampBanner(event.getBlock())) {
             event.setMessage(translator.of("msg_err_siege_war_cannot_destroy_siege_banner"));
             event.setCancelled(true);
             return;

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
@@ -55,7 +55,7 @@ public class DestroyBlock {
 
         //Prevent destruction of siege-banner or support block
         if (SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())
-        		|| SiegeWarBlockUtil.isBlockNearAnActiveSiegeCampBanner(event.getBlock())) {
+        	|| SiegeWarBlockUtil.isBlockNearAnActiveSiegeCampBanner(event.getBlock())) {
             event.setMessage(translator.of("msg_err_siege_war_cannot_destroy_siege_banner"));
             event.setCancelled(true);
             return;

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
@@ -45,21 +45,21 @@ public class DestroyBlock {
 
 		final Translator translator = Translator.locale(Translation.getLocale(event.getPlayer()));
 
-		//Trap warfare block protection
-		if(SiegeWarSettings.isTrapWarfareMitigationEnabled()
-				&& SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(event.getBlock().getLocation(), SiegeWarSettings.isTrapWarfareMitigationCapZoneOnly())) {
-			event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.DARK_RED + translator.of("msg_err_cannot_alter_blocks_below_banner_in_siege_zone")));
-			event.setCancelled(true);
-			return;
-		}
+        //Trap warfare block protection
+        if(SiegeWarSettings.isTrapWarfareMitigationEnabled()
+                && SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(event.getBlock().getLocation(), SiegeWarSettings.isTrapWarfareMitigationCapZoneOnly())) {
+            event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.DARK_RED + translator.of("msg_err_cannot_alter_blocks_below_banner_in_siege_zone")));
+            event.setCancelled(true);
+            return;
+        }
 
-		//Prevent destruction of siege-banner or support block
-		if (SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())
-				|| SiegeWarBlockUtil.isBlockNearAnActiveSiegeCampBanner(event.getBlock())) {
-			event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.DARK_RED + translator.of("msg_err_siege_war_cannot_destroy_siege_banner")));
-			event.setCancelled(true);
-			return;
-		}
+        //Prevent destruction of siege-banner or support block
+        if (SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())
+        		|| SiegeWarBlockUtil.isBlockNearAnActiveSiegeCampBanner(event.getBlock())) {
+            event.setMessage(translator.of("msg_err_siege_war_cannot_destroy_siege_banner"));
+            event.setCancelled(true);
+            return;
+        }
     }
 
 	/**

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -68,7 +68,7 @@ public class PlaceBlock {
 
 			//Enforce Anti-Trap warfare build block if below siege banner altitude.
 			if (SiegeWarSettings.isTrapWarfareMitigationEnabled()
-					&& SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(event.getBlock().getLocation())) {
+					&& SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(event.getBlock().getLocation(), SiegeWarSettings.isTrapWarfareMitigationCapZoneOnly())) {
 				event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.DARK_RED + translator.of("msg_err_cannot_alter_blocks_below_banner_in_siege_zone")));
 				event.setCancelled(true);
 				return;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -128,16 +128,6 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# If this setting is true, then Siegewar statistics will be shown on nation status screens."),
-	WAR_SIEGE_SWITCHES_TRAP_WARFARE_MITIGATION_ENABLED(
-			"war.siege.switches.wilderness_pit_mitigation_enabled",
-			"true",
-			"",
-			"# If this setting is true, then ",
-			"# 1. Players cannot build/destroy blocks in the Siege-Zone wilderness below the siege banner altitude, and",
-			"# 2. Banner control cannot be gained if the player is below the siege banner altitude",
-			"# TIP: ",
-			"# When this feature is enabled, ",
-			"# Make sure to also have a server rule forbidding pits being created in the Siege-Zone BEFORE the banner is placed"),
 	WAR_SIEGE_KILL_PLAYERS_WHO_LOG_OUT_IN_SIEGE_ZONES(
 			"war.siege.switches.kill_players_who_log_out_in_siege_zones",
 			"true",
@@ -1023,7 +1013,32 @@ public enum ConfigNodes {
 			"false",
 			"",
 			"# If true, then all PVP protections are disabled within Siege-Zones, including from non-TownyAdvanced plugins.",
-			"# WARNING : This setting may result in incorrect pvp-protection messaging information!.");
+			"# WARNING : This setting may result in incorrect pvp-protection messaging information!."),
+	TRAP_WARFARE_MITIGATION(
+			"trap_warfare_mitigation",
+			"",
+			"",
+			"",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |               TRAP WARFARE MITIGATION                | #",
+			"# +------------------------------------------------------+ #",
+			"############################################################",
+			""),
+	TRAP_WARFARE_MITIGATION_ENABLED(
+			"trap_warfare_mitigation.enabled",
+			"true",
+			"",
+			"# If this setting is true, then players cannot build/destroy blocks in the Siege-Zone below the siege banner altitude.",
+			"# Also banner control cannot be gained if the player is below the siege banner altitude",
+			"# TIP: ",
+			"# If this feature is enabled, ",
+			"# Also have a server rule making attackers responsible for removing all traps BEFORE the banner is placed"),
+	TRAP_WARFARE_MITIGATION_CAP_ZONE_ONLY(
+			"trap_warfare_mitigation.cap_zone_only",
+			"true",
+			"",
+			"# If this setting is false, then the restrictions apply only to the Cap-Zone.");
 
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -305,7 +305,11 @@ public class SiegeWarSettings {
 	}
 
 	public static boolean isTrapWarfareMitigationEnabled() {
-		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_SWITCHES_TRAP_WARFARE_MITIGATION_ENABLED);
+		return Settings.getBoolean(ConfigNodes.TRAP_WARFARE_MITIGATION_ENABLED);
+	}
+
+	public static boolean isTrapWarfareMitigationCapZoneOnly() {
+		return Settings.getBoolean(ConfigNodes.TRAP_WARFARE_MITIGATION_CAP_ZONE_ONLY);
 	}
 
 	public static boolean isNationSiegeImmunityEnabled() {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -198,9 +198,11 @@ public class SiegeWarDistanceUtil {
 	 * This method is used in Anti-trap warfare mitigation
 	 *
 	 * @param location given location
+	 * @param verifyCapZone if true, then the location must also be in the cap zone to qualify
+	 *
 	 * @return true of the location is in an active siege zone wilderness AND below siege banner altitude
 	 */
-	public static boolean isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(Location location) {
+	public static boolean isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(Location location, boolean verifyCapZone) {
 		//Return false if not wilderness
 		if(!TownyAPI.getInstance().isWilderness(location))
 			return false;
@@ -210,8 +212,15 @@ public class SiegeWarDistanceUtil {
 		if(siege == null)
 			return false;
 
-		//true if below siege banner altitude, false otherwise
-		return location.getY() < siege.getFlagLocation().getY();
+		//false if above siege banner altitude
+		if(location.getY() < siege.getFlagLocation().getY())
+			return false;
+
+		if(verifyCapZone) {
+			return SiegeWarDistanceUtil.isInTimedPointZone(location, siege);
+		} else {
+			return true;
+		}
 	}
 
 	/**

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -212,8 +212,8 @@ public class SiegeWarDistanceUtil {
 		if(siege == null)
 			return false;
 
-		//false if above siege banner altitude
-		if(location.getY() > siege.getFlagLocation().getY())
+		//false if at or above siege banner altitude
+		if(location.getY() >= siege.getFlagLocation().getY())
 			return false;
 
 		if(verifyCapZone) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -213,7 +213,7 @@ public class SiegeWarDistanceUtil {
 			return false;
 
 		//false if above siege banner altitude
-		if(location.getY() < siege.getFlagLocation().getY())
+		if(location.getY() > siege.getFlagLocation().getY())
 			return false;
 
 		if(verifyCapZone) {

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -506,9 +506,10 @@ msg_err_cannon_must_be_in_wilderness_or_besieged_town: "&cWithin SiegeZones, can
 msg_capping_limiter_limit_exceeded_warning: "&cYou have exceeded your daily Capping Limit of %d Battle Sessions. You can cap again in %s."
 msg_war_siege_peaceful_player_warned_for_being_in_siegezone: '&cAs a peaceful town resident, you cannot pass easily through Siege-Zones. To avoid War Sickness, leave the Siege-Zone immediately.'
 msg_war_siege_peaceful_player_punished_for_being_in_siegezone: '&cAs a peaceful town resident, you cannot pass easily through Siege-Zones. To remove the War Sickness, leave the Siege-Zone immediately.'
-msg_err_cannot_alter_blocks_below_banner_in_siege_zone: 'You cannot place/destroy blocks below banner altitude in the Siege-Zone.'
 
 #Added on 0.42
 msg_siege_zone_proximity_warning: "&cWARNING: You are in a Siege-Zone!. PVP protections are disabled here."
 msg_siege_zone_proximity_warning_with_logout_risk: "&cWARNING: You are in a Siege-Zone!. PVP protections are disabled here. You will be killed if you logout while in the Siege-Zone."
 msg_player_killed_for_logging_out_in_siege_zone: "%s was killed because they logged out while in a Siege-Zone."
+msg_err_cannot_alter_blocks_below_banner_in_siege_zone: 'You cannot place/destroy blocks below banner altitude in this area.'
+


### PR DESCRIPTION
#### Description: 
Closes #535 
Closes #534 .... don't know if this was fixed before this PR. But with this PR it is confirmed by testing as not an issue.

____
#### New Nodes/Commands/ConfigOptions: 
```
	TRAP_WARFARE_MITIGATION(
			"trap_warfare_mitigation",
			"",
			"",
			"",
			"############################################################",
			"# +------------------------------------------------------+ #",
			"# |               TRAP WARFARE MITIGATION                | #",
			"# +------------------------------------------------------+ #",
			"############################################################",
			""),
	TRAP_WARFARE_MITIGATION_ENABLED(
			"trap_warfare_mitigation.enabled",
			"true",
			"",
			"# If this setting is true, then players cannot build/destroy blocks in the Siege-Zone below the siege banner altitude.",
			"# Also banner control cannot be gained if the player is below the siege banner altitude",
			"# TIP: ",
			"# If this feature is enabled, ",
			"# Also have a server rule making attackers responsible for removing all traps BEFORE the banner is placed"),
	TRAP_WARFARE_MITIGATION_CAP_ZONE_ONLY(
			"trap_warfare_mitigation.cap_zone_only",
			"true",
			"",
			"# If this setting is false, then the restrictions apply only to the Cap-Zone.");

```

____
#### Relevant Issue ticket:
Closes #535 

____
- [  N/A  ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
