### PR TITLE
Trap mitigation tweak

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -162,10 +162,10 @@ public class SiegeWarTownyEventListener implements Listener {
     private static List<Block> filterExplodeListByTrapWarfareMitigation(List<Block> givenExplodeList) {
         if(!SiegeWarSettings.isTrapWarfareMitigationEnabled())
             return givenExplodeList;
-        boolean capZoneMitigationOnly = SiegeWarSettings.isTrapWarfareMitigationCapZoneOnly();
+        boolean nearBannerOnly = SiegeWarSettings.isTrapWarfareMitigationNearBannerOnly();
         List<Block> filteredList = new ArrayList<>(givenExplodeList);
         for(Block block: givenExplodeList) {
-            if(SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(block.getLocation(), capZoneMitigationOnly)) {
+            if(SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(block.getLocation(), nearBannerOnly)) {
                 //Remove block from final explode list
                 filteredList.remove(block);
             } 

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
@@ -47,7 +47,7 @@ public class DestroyBlock {
 
         //Trap warfare block protection
         if(SiegeWarSettings.isTrapWarfareMitigationEnabled()
-                && SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(event.getBlock().getLocation(), SiegeWarSettings.isTrapWarfareMitigationCapZoneOnly())) {
+                && SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(event.getBlock().getLocation(), SiegeWarSettings.isTrapWarfareMitigationNearBannerOnly())) {
             event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.DARK_RED + translator.of("msg_err_cannot_alter_blocks_below_banner_in_siege_zone")));
             event.setCancelled(true);
             return;

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -68,7 +68,7 @@ public class PlaceBlock {
 
 			//Enforce Anti-Trap warfare build block if below siege banner altitude.
 			if (SiegeWarSettings.isTrapWarfareMitigationEnabled()
-					&& SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(event.getBlock().getLocation(), SiegeWarSettings.isTrapWarfareMitigationCapZoneOnly())) {
+					&& SiegeWarDistanceUtil.isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(event.getBlock().getLocation(), SiegeWarSettings.isTrapWarfareMitigationNearBannerOnly())) {
 				event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.DARK_RED + translator.of("msg_err_cannot_alter_blocks_below_banner_in_siege_zone")));
 				event.setCancelled(true);
 				return;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -1034,11 +1034,11 @@ public enum ConfigNodes {
 			"# TIP: ",
 			"# If this feature is enabled, ",
 			"# Also have a server rule making attackers responsible for removing all traps BEFORE the banner is placed"),
-	TRAP_WARFARE_MITIGATION_CAP_ZONE_ONLY(
-			"trap_warfare_mitigation.cap_zone_only",
+	TRAP_WARFARE_MITIGATION_NEAR_BANNER_ONLY(
+			"trap_warfare_mitigation.near_banner_only",
 			"true",
 			"",
-			"# If this setting is false, then the restrictions apply only to the Cap-Zone.");
+			"# If this setting is true, then the restrictions apply only to a 16 block horizontal radius around the Siege-Banner.");
 
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -308,8 +308,8 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.TRAP_WARFARE_MITIGATION_ENABLED);
 	}
 
-	public static boolean isTrapWarfareMitigationCapZoneOnly() {
-		return Settings.getBoolean(ConfigNodes.TRAP_WARFARE_MITIGATION_CAP_ZONE_ONLY);
+	public static boolean isTrapWarfareMitigationNearBannerOnly() {
+		return Settings.getBoolean(ConfigNodes.TRAP_WARFARE_MITIGATION_NEAR_BANNER_ONLY);
 	}
 
 	public static boolean isNationSiegeImmunityEnabled() {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -198,11 +198,11 @@ public class SiegeWarDistanceUtil {
 	 * This method is used in Anti-trap warfare mitigation
 	 *
 	 * @param location given location
-	 * @param verifyCapZone if true, then the location must also be in the cap zone to qualify
+	 * @param nearBannerOnly if true, then the location must also be near the siege banner (16 block radius) to qualify
 	 *
 	 * @return true of the location is in an active siege zone wilderness AND below siege banner altitude
 	 */
-	public static boolean isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(Location location, boolean verifyCapZone) {
+	public static boolean isLocationInSiegeZoneWildernessAndBelowSiegeBannerAltitude(Location location, boolean nearBannerOnly) {
 		//Return false if not wilderness
 		if(!TownyAPI.getInstance().isWilderness(location))
 			return false;
@@ -216,8 +216,8 @@ public class SiegeWarDistanceUtil {
 		if(location.getY() >= siege.getFlagLocation().getY())
 			return false;
 
-		if(verifyCapZone) {
-			return SiegeWarDistanceUtil.isInTimedPointZone(location, siege);
+		if(nearBannerOnly) {
+			return SiegeWarDistanceUtil.areLocationsCloseHorizontally(location, siege.getFlagLocation(), TownySettings.getTownBlockSize());
 		} else {
 			return true;
 		}


### PR DESCRIPTION
#### Description: 
- With current code, if trap mitigation is on, there is a weird effect where just below banner you cannot do block interactions, but a few blocks lower down, you can
- This PR tweaks it so that the protect radius is 16 block horizontally, including all verticals
 
____
#### New Nodes/Commands/ConfigOptions: 
```
	TRAP_WARFARE_MITIGATION_NEAR_BANNER_ONLY(
			"trap_warfare_mitigation.near_banner_only",
			"true",
			"",
			"# If this setting is true, then the restrictions apply only to a 16 block horizontal radius around the Siege-Banner.");
```
____
#### Relevant Issue ticket:
N/A

____
- [ x ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
