### PR TITLE
Disable Wall Breaching

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
@@ -17,6 +17,7 @@ public enum SiegeWarPermissionNodes {
 	SIEGEWAR_NATION_SIEGE_LIBERATION_SIEGE_ABANDON("siegewar.nation.siege.liberation.siege.abandon"),
 	SIEGEWAR_NATION_SIEGE_SUPPRESSION_SIEGE_START("siegewar.nation.siege.suppression.siege.start"),
 	SIEGEWAR_NATION_SIEGE_SUPPRESSION_SIEGE_ABANDON("siegewar.nation.siege.suppression.siege.abandon"),
+	SIEGEWAR_NATION_SIEGE_REVOLT_SIEGE_SURRENDER("siegewar.town.siege.revolt.siege.surrender"),
 	SIEGEWAR_NATION_SIEGE_INVADE("siegewar.nation.siege.invade"),
 	SIEGEWAR_NATION_SIEGE_PLUNDER("siegewar.nation.siege.plunder"),
 	SIEGEWAR_NATION_SIEGE_SUBVERTPEACEFULTOWN("siegewar.nation.siege.subvertpeacefultown"),
@@ -27,9 +28,10 @@ public enum SiegeWarPermissionNodes {
 	//Battle points
 	SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS("siegewar.town.siege.battle.points"),
 	//Actions
-	SIEGEWAR_TOWN_SIEGE_REVOLT_SIEGE_START("siegewar.town.siege.revolt.siege.abandon"),
-	SIEGEWAR_TOWN_SIEGE_REVOLT_SIEGE_ABANDON("siegewar.town.siege.revolt.siege.start"),
-	SIEGEWAR_TOWN_SIEGE_SURRENDER("siegewar.town.siege.surrender"),
+	SIEGEWAR_TOWN_SIEGE_CONQUEST_SIEGE_SURRENDER("siegewar.town.siege.conquest.siege.surrender"),
+	SIEGEWAR_TOWN_SIEGE_SUPPRESSION_SIEGE_SURRENDER("siegewar.town.siege.suppression.siege.surrender"),
+	SIEGEWAR_TOWN_SIEGE_REVOLT_SIEGE_START("siegewar.town.siege.revolt.siege.start"),
+	SIEGEWAR_TOWN_SIEGE_REVOLT_SIEGE_ABANDON("siegewar.town.siege.revolt.siege.abandon"),
 	SIEGEWAR_TOWN_REVOLT_PEACEFULLY("siegewar.town.siege.revoltpeacefully"),
 	SIEGEWAR_TOWN_SIEGE_FIRE_CANNON_IN_SIEGEZONE("siegewar.town.siege.fire.cannon.in.siegezone"),
 
@@ -132,4 +134,18 @@ public enum SiegeWarPermissionNodes {
 		}
 	}
 
+	public static String getPermissionNodeToSurrenderDefence(SiegeType siegeType) {
+		switch (siegeType) {
+			case CONQUEST:
+				return SIEGEWAR_TOWN_SIEGE_CONQUEST_SIEGE_SURRENDER.getNode();
+			case LIBERATION:
+				throw new RuntimeException("Surrendering a liberation siege is not a thing.");
+			case REVOLT:
+				return SIEGEWAR_NATION_SIEGE_REVOLT_SIEGE_SURRENDER.getNode();
+			case SUPPRESSION:
+				return SIEGEWAR_TOWN_SIEGE_SUPPRESSION_SIEGE_SURRENDER.getNode();
+			default:
+				throw new RuntimeException("Unknown siege type.");
+		}
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
@@ -17,7 +17,7 @@ public enum SiegeWarPermissionNodes {
 	SIEGEWAR_NATION_SIEGE_LIBERATION_SIEGE_ABANDON("siegewar.nation.siege.liberation.siege.abandon"),
 	SIEGEWAR_NATION_SIEGE_SUPPRESSION_SIEGE_START("siegewar.nation.siege.suppression.siege.start"),
 	SIEGEWAR_NATION_SIEGE_SUPPRESSION_SIEGE_ABANDON("siegewar.nation.siege.suppression.siege.abandon"),
-	SIEGEWAR_NATION_SIEGE_REVOLT_SIEGE_SURRENDER("siegewar.town.siege.revolt.siege.surrender"),
+	SIEGEWAR_NATION_SIEGE_REVOLT_SIEGE_SURRENDER("siegewar.nation.siege.revolt.siege.surrender"),
 	SIEGEWAR_NATION_SIEGE_INVADE("siegewar.nation.siege.invade"),
 	SIEGEWAR_NATION_SIEGE_PLUNDER("siegewar.nation.siege.plunder"),
 	SIEGEWAR_NATION_SIEGE_SUBVERTPEACEFULTOWN("siegewar.nation.siege.subvertpeacefultown"),

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -19,12 +19,7 @@ import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.event.actions.TownyBuildEvent;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
-import com.palmergames.bukkit.towny.object.Nation;
-import com.palmergames.bukkit.towny.object.Resident;
-import com.palmergames.bukkit.towny.object.Town;
-import com.palmergames.bukkit.towny.object.TownBlock;
-import com.palmergames.bukkit.towny.object.Translation;
-import com.palmergames.bukkit.towny.object.Translator;
+import com.palmergames.bukkit.towny.object.*;
 
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -243,26 +238,35 @@ public class PlaceBlock {
 		switch (siege.getSiegeType()) {
 			case CONQUEST:
 				if (residentsNation != null && residentsNation == siege.getAttacker()) {
+					//Attacker
 					AbandonAttack.processAbandonAttackRequest(player, siege);
 				} else if (residentsTown == nearbyTown) {
+					//Resident of town
 					SurrenderDefence.processSurrenderDefenceRequest(player, siege);
 				} else {
 					throw new TownyException(translator.of("msg_err_action_disable"));
 				}
 				break;
-			case LIBERATION:
+			case LIBERATION:		
 				if (residentsNation != null && residentsNation == siege.getAttacker()) {
+					//'Liberator'
 					AbandonAttack.processAbandonAttackRequest(player, siege);
+				} else if (residentsTown == nearbyTown) {
+					//Resident of town
+					throw new TownyException(translator.of("msg_err_cannot_surrender_liberation_siege"));
 				} else if (residentsNation != null && TownOccupationController.isTownOccupied(nearbyTown) && TownOccupationController.getTownOccupier(nearbyTown) == residentsNation) {
-					SurrenderDefence.processSurrenderDefenceRequest(player, siege);
+					//Occupier of town
+					throw new TownyException(translator.of("msg_err_cannot_surrender_liberation_siege"));
 				} else {
 					throw new TownyException(translator.of("msg_err_action_disable"));
 				}
 				break;
 			case REVOLT:
 				if (residentsTown == nearbyTown) {
+					//Resident of town
 					AbandonAttack.processAbandonAttackRequest(player, siege);
 				} else if (residentsNation != null && TownOccupationController.isTownOccupied(nearbyTown) && TownOccupationController.getTownOccupier(nearbyTown) == residentsNation) {
+					//Occupier of town
 					SurrenderDefence.processSurrenderDefenceRequest(player, siege);
 				} else {
 					throw new TownyException(translator.of("msg_err_action_disable"));
@@ -270,8 +274,10 @@ public class PlaceBlock {
 				break;
 			case SUPPRESSION:
 				if (residentsNation != null && TownOccupationController.isTownOccupied(nearbyTown) && TownOccupationController.getTownOccupier(nearbyTown) == residentsNation) {
+					//Occupier of town
 					AbandonAttack.processAbandonAttackRequest(player, siege);
 				} else if (residentsTown == nearbyTown) {
+					//Resident of town
 					SurrenderDefence.processSurrenderDefenceRequest(player, siege);
 				} else {
 					throw new TownyException(translator.of("msg_err_action_disable"));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -19,7 +19,12 @@ import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.event.actions.TownyBuildEvent;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
-import com.palmergames.bukkit.towny.object.*;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.Translation;
+import com.palmergames.bukkit.towny.object.Translator;
 
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -247,7 +252,7 @@ public class PlaceBlock {
 					throw new TownyException(translator.of("msg_err_action_disable"));
 				}
 				break;
-			case LIBERATION:		
+			case LIBERATION:
 				if (residentsNation != null && residentsNation == siege.getAttacker()) {
 					//'Liberator'
 					AbandonAttack.processAbandonAttackRequest(player, siege);

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/StartLiberationSiege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/StartLiberationSiege.java
@@ -64,10 +64,6 @@ public class StartLiberationSiege {
         if (!nationOfSiegeStarter.hasEnemy(occupierNation))
             throw new TownyException(translator.of("msg_err_siege_war_cannot_attack_occupied_town_non_enemy_nation"));
 
-        Nation naturalNationOfTown = targetTown.getNationOrNull();
-        if(naturalNationOfTown != null && !naturalNationOfTown.hasMutualAlly(nationOfSiegeStarter))
-            throw new TownyException(translator.of("msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town"));
-
         if (TownySettings.getNationRequiresProximity() > 0) {
             Coord capitalCoord = nationOfSiegeStarter.getCapital().getHomeBlock().getCoord();
             Coord townCoord = targetTown.getHomeBlock().getCoord();

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderDefence.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderDefence.java
@@ -23,10 +23,10 @@ import org.bukkit.entity.Player;
 public class SurrenderDefence {
 
 	public static void processSurrenderDefenceRequest(Player player, Siege siege) throws TownyException {
-		if(!SiegeWarSettings.getWarSiegeAbandonEnabled())
+		if(!SiegeWarSettings.getWarSiegeSurrenderEnabled())
 			throw new TownyException(Translatable.of("msg_err_action_disable").forLocale(player));
 
-		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_SURRENDER.getNode()))
+		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.getPermissionNodeToSurrenderDefence(siege.getSiegeType())))
 			throw new TownyException(Translatable.of("msg_err_action_disable").forLocale(player));
 		
 		Confirmation

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -416,6 +416,9 @@ public enum ConfigNodes {
 			"",
 			"# This value determines the number of battle points awarded if defender dies in a siege zone.",
 			"# TIP: Set this value low enough so as not to exclude weak players from sieges, and high enough to avoid banner control being considered too OP."),
+    /*
+    TODO - Re-enable when end-of-session rollbacks are implemented. 
+    
     WAR_SIEGE_POINTS_BALANCING_WALL_BREACH_BONUS(
 			"war.siege.points_balancing.wall_breach_bonus",
 			"",
@@ -432,6 +435,7 @@ public enum ConfigNodes {
 			"# If the wall breaching feature is enabled (in the 'Wall Breaching' config section), this value determines the number of Battle Points awarded by the Wall Breach Bonus.",
 			"# To get the bonus, hostile-to-town players must capture the banner first, then get to the homeblock.",
 			"# TIP: Players are required to cap first, because otherwise they could log off at the homeblock after getting the bonus, and then in the next session, simply log back in to get the bonus again."),
+	*/
 	WAR_SIEGE_POINTS_BALANCING_BANNER_CONTROL_REVERSAL_BONUS(
 			"war.siege.points_balancing.banner_control_reversal_bonus",
 			"",
@@ -515,6 +519,9 @@ public enum ConfigNodes {
 			"",
 			"# If true, at the end of a battle, only the battle points of the winner are applied to the siege balance.",
 			"# If false, the battle points of the losing side are also applied to the siege balance."),
+	/*
+	    TODO - Re-enable when end-of-session rollbacks are implemented. 
+
 	WAR_SIEGE_WALL_BREACHING(
 			"war.siege.wall_breaching",
 			"",
@@ -654,6 +661,7 @@ public enum ConfigNodes {
 			"2",
 			"",
 			"# This value determines the cost, in Breach Points, to destroy a block via cannon fire explosion in the besieged town."),			
+	*/
 	SIEGE_MATERIAL_RESTRICTIONS(
 			"siege_material_restrictions",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -417,8 +417,8 @@ public enum ConfigNodes {
 			"# This value determines the number of battle points awarded if defender dies in a siege zone.",
 			"# TIP: Set this value low enough so as not to exclude weak players from sieges, and high enough to avoid banner control being considered too OP."),
     /*
-    TODO - Re-enable when end-of-session rollbacks are implemented. 
-    
+    TODO - Re-enable when end-of-session rollbacks are implemented.
+
     WAR_SIEGE_POINTS_BALANCING_WALL_BREACH_BONUS(
 			"war.siege.points_balancing.wall_breach_bonus",
 			"",
@@ -520,7 +520,7 @@ public enum ConfigNodes {
 			"# If true, at the end of a battle, only the battle points of the winner are applied to the siege balance.",
 			"# If false, the battle points of the losing side are also applied to the siege balance."),
 	/*
-	    TODO - Re-enable when end-of-session rollbacks are implemented. 
+	    TODO - Re-enable when end-of-session rollbacks are implemented.
 
 	WAR_SIEGE_WALL_BREACHING(
 			"war.siege.wall_breaching",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -7,8 +7,6 @@ import java.util.Locale;
 import java.util.EnumSet;
 import java.util.Set;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
-import com.palmergames.bukkit.towny.object.Translation;
-
 import org.bukkit.Material;
 
 import com.gmail.goosius.siegewar.objects.HeldItemsCombination;
@@ -381,31 +379,58 @@ public class SiegeWarSettings {
 	}
 
 	public static boolean isWallBreachingEnabled() {
-		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_WALL_BREACHING_ENABLED);
+		return false;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_WALL_BREACHING_ENABLED);		
+		 */
 	}
 	
 	public static double getWallBreachingPointGenerationRate() {
+		return 0;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		return Settings.getDouble(ConfigNodes.WAR_SIEGE_WALL_BREACHING_BREACH_POINT_GENERATION_RATE);
+		 */
 	}
 
 	public static int getWallBreachingMaxPoolSize() {
+		return 0;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_BREACH_POINT_GENERATION_MAX_POOL_SIZE);
+		 */
 	}
 
 	public static int getWallBreachBonusBattlePoints() {
+		return 0;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_POINTS_BALANCING_WALL_BREACH_BONUS_BATTLE_POINTS);
+		 */
 	}
 
 	public static int getWallBreachingBlockPlacementCost() {
+		return 0;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_PLACING_BLOCKS_COST_PER_BLOCK);
+		 */
 	}
 
 	public static int getWallBreachingBlockDestructionCost() {
+		return 0;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_DESTROYING_BLOCKS_COST_PER_BLOCK);
+		 */
 	}
 
 	public static Set<Material> getWallBreachingPlaceBlocksWhitelist() throws TownyException
 	{
+		return null;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		if(cachedWallBreachingPlaceBlocksWhitelist == null) {			
     		cachedWallBreachingPlaceBlocksWhitelist = EnumSet.noneOf(Material.class);
 			String configuredListUppercase = Settings.getString(ConfigNodes.WAR_SIEGE_WALL_BREACHING_PLACING_BLOCKS_WHITELIST).toUpperCase(Locale.ROOT);
@@ -427,17 +452,26 @@ public class SiegeWarSettings {
 			}
 		}
 		return cachedWallBreachingPlaceBlocksWhitelist;
+		 */
 	}
 
     public static boolean isWallBreachingDestroyEntityBlacklist() {
+		return false;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
+
     	if(cachedWallBreachingDestroyEntityBlacklist == null) {
     		String configuredListLowercase = Settings.getString(ConfigNodes.WAR_SIEGE_WALL_BREACHING_DESTROYING_BLOCKS_BLACKLIST).toLowerCase(Locale.ROOT);
 			cachedWallBreachingDestroyEntityBlacklist = configuredListLowercase.contains("is=entity"); 				
 		}
 		return cachedWallBreachingDestroyEntityBlacklist;
+		 */
 	}
 
 	public static Set<Material> getWallBreachingDestroyBlocksBlacklist() throws TownyException {
+		return null;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		if(cachedWallBreachingDestroyBlocksBlacklist == null) {			
     		cachedWallBreachingDestroyBlocksBlacklist = EnumSet.noneOf(Material.class);
 			String configuredListUppercase = Settings.getString(ConfigNodes.WAR_SIEGE_WALL_BREACHING_DESTROYING_BLOCKS_BLACKLIST).toUpperCase(Locale.ROOT);
@@ -454,26 +488,47 @@ public class SiegeWarSettings {
 			}
 		}
 		return cachedWallBreachingDestroyBlocksBlacklist;
+		 */
 	}
 
 	public static int getWallBreachingHomeblockBreachHeightLimitMin() {
+		return 0;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_HOMEBLOCK_BREACH_HEIGHT_LIMITS_MIN);
+		 */
 	}
 	
 	public static int getWallBreachingHomeblockBreachHeightLimitMax() {
+		return 0;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_HOMEBLOCK_BREACH_HEIGHT_LIMITS_MAX);
+		 */
 	}
 
 	public static boolean isWallBreachingCannonsIntegrationEnabled() {
+		return false;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_WALL_BREACHING_CANNONS_INTEGRATION_ENABLED);
+		 */
 	}
 
 	public static double getWallBreachingCannonFirePointGenerationRate() {
+		return 0;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		return Settings.getDouble(ConfigNodes.WAR_SIEGE_WALL_BREACHING_CANNONS_INTEGRATION_BREACH_POINT_GENERATION_RATE_FROM_CANNON_FIRE);
+		 */
 	}
 
 	public static int getWallBreachingCannonExplosionCostPerBlock() {
+		return 0;
+		/*
+		TODO - Re-enable when end-of-session rollbacks are implemented. 
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_CANNONS_INTEGRATION_EXPLODING_BLOCKS_COST_PER_BLOCK);
+		 */
 	}
 
 	public static int getSiegeBalanceCapValue() {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -7,6 +7,8 @@ import java.util.Locale;
 import java.util.EnumSet;
 import java.util.Set;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
+import com.palmergames.bukkit.towny.object.Translation;
+
 import org.bukkit.Material;
 
 import com.gmail.goosius.siegewar.objects.HeldItemsCombination;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -381,15 +381,15 @@ public class SiegeWarSettings {
 	public static boolean isWallBreachingEnabled() {
 		return false;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
-		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_WALL_BREACHING_ENABLED);		
+		TODO - Re-enable when end-of-session rollbacks are implemented.
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_WALL_BREACHING_ENABLED);
 		 */
 	}
 	
 	public static double getWallBreachingPointGenerationRate() {
 		return 0;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		return Settings.getDouble(ConfigNodes.WAR_SIEGE_WALL_BREACHING_BREACH_POINT_GENERATION_RATE);
 		 */
 	}
@@ -397,7 +397,7 @@ public class SiegeWarSettings {
 	public static int getWallBreachingMaxPoolSize() {
 		return 0;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_BREACH_POINT_GENERATION_MAX_POOL_SIZE);
 		 */
 	}
@@ -405,7 +405,7 @@ public class SiegeWarSettings {
 	public static int getWallBreachBonusBattlePoints() {
 		return 0;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_POINTS_BALANCING_WALL_BREACH_BONUS_BATTLE_POINTS);
 		 */
 	}
@@ -413,7 +413,7 @@ public class SiegeWarSettings {
 	public static int getWallBreachingBlockPlacementCost() {
 		return 0;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_PLACING_BLOCKS_COST_PER_BLOCK);
 		 */
 	}
@@ -421,7 +421,7 @@ public class SiegeWarSettings {
 	public static int getWallBreachingBlockDestructionCost() {
 		return 0;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_DESTROYING_BLOCKS_COST_PER_BLOCK);
 		 */
 	}
@@ -430,7 +430,7 @@ public class SiegeWarSettings {
 	{
 		return null;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		if(cachedWallBreachingPlaceBlocksWhitelist == null) {			
     		cachedWallBreachingPlaceBlocksWhitelist = EnumSet.noneOf(Material.class);
 			String configuredListUppercase = Settings.getString(ConfigNodes.WAR_SIEGE_WALL_BREACHING_PLACING_BLOCKS_WHITELIST).toUpperCase(Locale.ROOT);
@@ -458,7 +458,7 @@ public class SiegeWarSettings {
     public static boolean isWallBreachingDestroyEntityBlacklist() {
 		return false;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 
     	if(cachedWallBreachingDestroyEntityBlacklist == null) {
     		String configuredListLowercase = Settings.getString(ConfigNodes.WAR_SIEGE_WALL_BREACHING_DESTROYING_BLOCKS_BLACKLIST).toLowerCase(Locale.ROOT);
@@ -471,7 +471,7 @@ public class SiegeWarSettings {
 	public static Set<Material> getWallBreachingDestroyBlocksBlacklist() throws TownyException {
 		return null;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		if(cachedWallBreachingDestroyBlocksBlacklist == null) {			
     		cachedWallBreachingDestroyBlocksBlacklist = EnumSet.noneOf(Material.class);
 			String configuredListUppercase = Settings.getString(ConfigNodes.WAR_SIEGE_WALL_BREACHING_DESTROYING_BLOCKS_BLACKLIST).toUpperCase(Locale.ROOT);
@@ -494,7 +494,7 @@ public class SiegeWarSettings {
 	public static int getWallBreachingHomeblockBreachHeightLimitMin() {
 		return 0;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_HOMEBLOCK_BREACH_HEIGHT_LIMITS_MIN);
 		 */
 	}
@@ -502,7 +502,7 @@ public class SiegeWarSettings {
 	public static int getWallBreachingHomeblockBreachHeightLimitMax() {
 		return 0;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_HOMEBLOCK_BREACH_HEIGHT_LIMITS_MAX);
 		 */
 	}
@@ -510,7 +510,7 @@ public class SiegeWarSettings {
 	public static boolean isWallBreachingCannonsIntegrationEnabled() {
 		return false;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_WALL_BREACHING_CANNONS_INTEGRATION_ENABLED);
 		 */
 	}
@@ -518,7 +518,7 @@ public class SiegeWarSettings {
 	public static double getWallBreachingCannonFirePointGenerationRate() {
 		return 0;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		return Settings.getDouble(ConfigNodes.WAR_SIEGE_WALL_BREACHING_CANNONS_INTEGRATION_BREACH_POINT_GENERATION_RATE_FROM_CANNON_FIRE);
 		 */
 	}
@@ -526,7 +526,7 @@ public class SiegeWarSettings {
 	public static int getWallBreachingCannonExplosionCostPerBlock() {
 		return 0;
 		/*
-		TODO - Re-enable when end-of-session rollbacks are implemented. 
+		TODO - Re-enable when end-of-session rollbacks are implemented.
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_WALL_BREACHING_CANNONS_INTEGRATION_EXPLODING_BLOCKS_COST_PER_BLOCK);
 		 */
 	}

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.42
+version: 0.43
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -142,7 +142,6 @@ dynmap_siege_time_left: 'Time Left: %s'
 #Added in 0.06:
 msg_inventory_degrade_warning: '&4WARNING: &cSome of your gear is close to breaking due to inventory degradation.'
 msg_swa_remove_siege_success: '&bSuccessfully removed siege.'
-msg_war_siege_occupied_towns_cannot_surrender: '&cOccupied towns cannot surrender.'
 msg_you_received_war_sickness: '&cYou are not a participant of this siege and cannot be in the Siege Zone. Please leave to remove the war sickness. Common causes of war sickness: being in a neutral town, not having a military rank or not being allied to either side.'
 msg_you_will_get_sickness: '&cYou are not a participant of this siege and cannot be in the Siege Zone. Please leave or you will receive war sickness in %s seconds.'
 
@@ -489,8 +488,6 @@ msg_err_cannot_fire_cannon_without_perms: '&cYou cannot fire this cannon. Check 
 #configuration-errors
 msg_error_misconfigured_place_blocks_whitelist: '&cMisconfigured Material on Wall-Breaching-Place-Blocks-Whitelist. Problem Entry: %s.'
 msg_error_misconfigured_destroy_blocks_blacklist: '&cMisconfigured Material on Wall-Breaching-Destroy-Blocks-Blacklist. Problem Entry: %s.'
-#Liberation Siege Restriction
-msg_err_siege_war_cannot_start_liberation_siege_at_unallied_town: '&cYou cannot start a liberation siege at this town, because the nation of the town is not your ally.'
 
 #Added in 0.36
 msg_err_nation_neutrality_not_supported: '&cSiegeWar does not support nation neutrality.'
@@ -506,9 +503,11 @@ msg_capping_limiter_limit_exceeded_warning: "&cYou have exceeded your daily Capp
 msg_war_siege_peaceful_player_warned_for_being_in_siegezone: '&cAs a peaceful town resident, you cannot pass easily through Siege-Zones. To avoid War Sickness, leave the Siege-Zone immediately.'
 msg_war_siege_peaceful_player_punished_for_being_in_siegezone: '&cAs a peaceful town resident, you cannot pass easily through Siege-Zones. To remove the War Sickness, leave the Siege-Zone immediately.'
 
-#Added on 0.42
+#Added in 0.42
 msg_siege_zone_proximity_warning: "&cWARNING: You are in a Siege-Zone!. PVP protections are disabled here."
 msg_siege_zone_proximity_warning_with_logout_risk: "&cWARNING: You are in a Siege-Zone!. PVP protections are disabled here. You will be killed if you logout while in the Siege-Zone."
 msg_player_killed_for_logging_out_in_siege_zone: "%s was killed because they logged out while in a Siege-Zone."
 msg_err_cannot_alter_blocks_below_banner_in_siege_zone: 'You cannot place/destroy blocks below banner altitude in this area.'
 
+#Added in 0.43
+msg_err_cannot_surrender_liberation_siege: "&cYou cannot surrender the defence at a liberation siege."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -91,7 +91,7 @@ permissions:
             siegewar.nation.siege.conquest.siege.abandon: true
             siegewar.nation.siege.liberation.siege.start: true
             siegewar.nation.siege.liberation.siege.abandon: true
-            siegewar.nation.siege.revolt.siege.abandon: true
+            siegewar.nation.siege.revolt.siege.surrender: true
             siegewar.nation.siege.suppression.siege.start: true
             siegewar.nation.siege.suppression.siege.abandon: true
             siegewar.nation.siege.subvertpeacefultown: true
@@ -103,9 +103,10 @@ permissions:
         default: false
         children:
             siegewar.town.siege.battle.points: true
-            siegewar.town.siege.surrender: true
+            siegewar.town.siege.conquest.siege.surrender: true
             siegewar.town.siege.revolt.siege.start: true
             siegewar.town.siege.revolt.siege.abandon: true
+            siegewar.town.siege.suppression.siege.surrender: true
             siegewar.town.siege.revoltpeacefully: true
             siegewar.town.siege.fire.cannon.in.siegezone: true
             


### PR DESCRIPTION
#### Description: 
- There's a serious incompatibility between Wall Breaching & Liberation sieges:
  - Scenario A. If a non-ally of an occupied town can attack the town, then the attacker and defender may both be hostile to the town, and can collaborate to physically destroy the town via wall breaching (*Youch!*).
  - Scenario B. If the exact opposite is true (***as it is today***), then the town and its occupier may be friendly with each other, and can collaborate to completely prevent all sieges on the town (*Yikes!*).
- In the long-term, the solution is **After Session Rollbacks**, which nullify any damage caused by scenario A collaboration. 
- In the short term, this PR disables Wall Breaching, and removes the restriction of 'ally-only liberation sieges'.
- The PR also prevents surrendering of liberation sieges, which should never have been a thing.
- This PR also cleans up some code around surrendering, which were probably causing (*unreported*) usability issues.
____
#### New Nodes/Commands/ConfigOptions: 
```
SIEGEWAR_NATION_SIEGE_REVOLT_SIEGE_SURRENDER("siegewar.nation.siege.revolt.siege.surrender"),
SIEGEWAR_TOWN_SIEGE_CONQUEST_SIEGE_SURRENDER("siegewar.town.siege.conquest.siege.surrender"),
SIEGEWAR_TOWN_SIEGE_SUPPRESSION_SIEGE_SURRENDER("siegewar.town.siege.suppression.siege.surrender"),
```
____
#### Relevant Issue ticket:
N/A

____
- [ N/A ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
