### PR TITLE
initial commit

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerWin.java
@@ -24,11 +24,11 @@ public class AttackerWin {
 	public static void attackerWin(Siege siege, SiegeStatus siegeStatus) {
 		siege.setSiegeWinner(SiegeSide.ATTACKERS);
 		SiegeWarSiegeCompletionUtil.setCommonSiegeCompletionValues(siege, siegeStatus);
+
 		switch(siege.getSiegeType()) {
 			case CONQUEST:
 			case SUPPRESSION:
 				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getAttacker());
-				SiegeWarImmunityUtil.activateRevoltImmunityTimer(siege.getTown());
 				break;
 			case LIBERATION:
 				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getAttacker());

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
@@ -35,9 +35,6 @@ public class DefenderWin
 				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefendingNationIfPossibleElseTown());
 				TownOccupationController.removeTownOccupation(siege.getTown());
 				break;
-			case REVOLT:
-				SiegeWarImmunityUtil.activateRevoltImmunityTimer(siege.getTown());
-				break;
 		}
     }
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarImmunityUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarImmunityUtil.java
@@ -39,6 +39,7 @@ public class SiegeWarImmunityUtil {
 		long revoltImmunityDurationMillis = (long)(siegeImmunityDurationMillis * SiegeWarSettings.getWarSiegeRevoltImmunityTimeModifier());
 		long revoltImmunityEndTime = System.currentTimeMillis() + revoltImmunityDurationMillis;
 		TownMetaDataController.setRevoltImmunityEndTime(town, revoltImmunityEndTime);
+		town.save();
     }
 
     /**

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSiegeCompletionUtil.java
@@ -3,6 +3,7 @@ package com.gmail.goosius.siegewar.utils;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.events.SiegeEndEvent;
+import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import org.bukkit.Bukkit;
 
@@ -27,6 +28,7 @@ public class SiegeWarSiegeCompletionUtil {
 		siege.setStatus(siegeStatus);
 		siege.setActualEndTime(System.currentTimeMillis());
 		SiegeWarImmunityUtil.grantSiegeImmunityAfterEndedSiege(siege.getTown(), siege);
+		SiegeWarImmunityUtil.activateRevoltImmunityTimer(siege.getTown());
 		CosmeticUtil.removeFakeBeacons(siege);
 		/*
 		 * The siege is now historical rather than active.


### PR DESCRIPTION
#### Description: 
- With current code, when the revolt immunity timer activates, the change is not saved.....thus potentially causing issues is server restarts soon after.
- This PR fixes the issue and also links revolt immunity to siege immunity in a simpler way i.e.   when your siege immunity activates, your revolt immunity does too.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [ N/A ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
