### PR TITLE
Make HUD tab-prompt show only active sieges

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -55,14 +55,12 @@ public class SiegeController {
 	//private final static Map<String, Siege> sieges = new ConcurrentHashMap<>();
 	private static Map<UUID, Siege> townSiegeMap = new ConcurrentHashMap<>();
 	private static List<Town> siegedTowns = new ArrayList<>();
-	private static List<String> siegedTownNames = new ArrayList<>();
 	private static List<SiegeCamp> siegeCamps = new ArrayList<>();
 
 	public static void newSiege(Town town) {
 		Siege siege = new Siege(town);
 		townSiegeMap.put(town.getUUID(), siege);
 		siegedTowns.add(town);
-		siegedTownNames.add(town.getName());
 	}
 
 	public static List<Siege> getSieges() {
@@ -72,7 +70,6 @@ public class SiegeController {
 	public static void clearSieges() {
 		townSiegeMap.clear();
 		siegedTowns.clear();
-		siegedTownNames.clear();
 	}
 
 	public static void saveSiege(Siege siege) {
@@ -268,7 +265,6 @@ public class SiegeController {
 		//Remove siege from collections
 		townSiegeMap.remove(town.getUUID());
 		siegedTowns.remove(siege.getTown());
-		siegedTownNames.remove(siege.getTown().getName());
 
 		CosmeticUtil.removeFakeBeacons(siege);
 
@@ -296,13 +292,21 @@ public class SiegeController {
 		return Collections.unmodifiableCollection(siegedTowns);
 	}
 
-	public static Collection<String> getSiegedTownNames() {
-		return Collections.unmodifiableCollection(siegedTownNames);
+	public static Collection<String> getNamesOfSiegedTowns() {
+		Set<String> result = new HashSet<>();
+		for(Siege siege: getSieges()) {
+			result.add(siege.getTown().getName());
+		}
+		return result;
 	}
 
-	public static void renameSiegedTownName(String oldname, String newname) {
-		siegedTownNames.remove(oldname);
-		siegedTownNames.add(newname);
+	public static Collection<String> getNamesOfActivelySiegedTowns() {
+		Set<String> result = new HashSet<>();
+		for(Siege siege: getSieges()) {
+			if(siege.getStatus().isActive())
+				result.add(siege.getTown().getName());
+		}
+		return result;
 	}
 
 	@Nullable

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -92,7 +92,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 			}
 		case "siege":
 			if (args.length == 2)
-				return NameUtil.filterByStart(new ArrayList<>(SiegeController.getSiegedTownNames()), args[1]);
+				return NameUtil.filterByStart(new ArrayList<>(SiegeController.getNamesOfSiegedTowns()), args[1]);
 
 			if (args.length == 3)
 				return NameUtil.filterByStart(siegewaradminSiegeTabCompletes, args[2]);

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -73,7 +73,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 				break;					
 			case "hud":
 				if (args.length == 2)
-					return NameUtil.filterByStart(new ArrayList<>(SiegeController.getSiegedTownNames()), args[1]);
+					return NameUtil.filterByStart(new ArrayList<>(SiegeController.getNamesOfActivelySiegedTowns()), args[1]);
 				break;
 			case "preference":
 				if (args.length == 2)


### PR DESCRIPTION
#### Description: 
- Current the HUD tab-prompt shows all sieges, including inactive ones.
- This is only marginally useful, and mostly just confusing.
- This PR resolves the issue, by showing only active sieges on the HUD tab-prompt

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
Closes #547 

____
- [ N/A  ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
