### PR TITLE
Fixed Artefact Explode not damaging holder

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDominationAwardsUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDominationAwardsUtil.java
@@ -370,7 +370,7 @@ public class SiegeWarDominationAwardsUtil {
                 explosionPower = SiegeWarSettings.getDominationAwardsArtefactExpiryExplosionsBasePower()
                                     + (SiegeWarSettings.getDominationAwardsArtefactExpiryExplosionsExtraPowerPerExpiredArtefact() * numExpiredArtefacts);
                 int finalExplosionPower = Math.min(explosionPower, SiegeWarSettings.getDominationAwardsArtefactExpiryExplosionsMaxPower());                
-                Bukkit.getScheduler().runTask(SiegeWar.getSiegeWar(), ()-> player.getWorld().createExplosion(player.getEyeLocation(), finalExplosionPower, true));
+                Bukkit.getScheduler().runTask(SiegeWar.getSiegeWar(), ()-> player.getWorld().createExplosion(player.getLocation(), finalExplosionPower, true));
             }
         }
     }


### PR DESCRIPTION
#### Description: 
- With current code artefact explosions do not damage the player who carries the artefacts
- This has something to do with the location being player.getEyeLocation() but I don't understand why
- This PR fixes the issue by setting location to simply player.getLocation()

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [ x ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
