### PR TITLE
Validate user-input from domination awards config to be sure it will load.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -778,7 +778,7 @@ public class SiegeWarSettings {
 	// Make sure that the config has been given a valid PotionEffectType or Enchantment name.
     private static boolean validateEffect(Material material, String name) {
         return !name.isEmpty()
-                && !name.equals("custom_effect") // ignore custom_effect
+                && name.equals("custom_effect") // ignore custom_effect
                 && ((isPotionBased(material) && !validatePotionEffectType(name))
                     || !isPotionBased(material) && !validateEnchantmentType(name));
     }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -779,7 +779,7 @@ public class SiegeWarSettings {
     private static boolean validateEffect(Material material, String name) {
         return !name.isEmpty()
                 && name.equals("custom_effect") // ignore custom_effect
-                && ((isPotionBased(material) && !validatePotionEffectType(name))
+                || ((isPotionBased(material) && !validatePotionEffectType(name))
                     || !isPotionBased(material) && !validateEnchantmentType(name));
     }
 

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -693,7 +693,7 @@ public class SiegeWarSettings {
 			itemMeta.setDisplayName(name);
 			//Add special effects
 			if (!addSpecialEffects(artefact, itemMeta, specificationFields)) {
-			    SiegeWar.info("Domination Awards Artefact Offer: " +  specificationFields[0] + " cannot be loaded, check the PotionEffecType.");
+			    SiegeWar.severe("Domination Awards Artefact Offer: " +  specificationFields[0] + " cannot be loaded, check the " + (isPotionBased(material) ? "PotionEffectType" : "EnchantmentType") + ". Skipping...");
 			    continue;
 			}
 			//Add non-effect lore
@@ -783,12 +783,12 @@ public class SiegeWarSettings {
                     || !isPotionBased(material) && !validateEnchantmentType(name));
     }
 
-	private static boolean validateEnchantmentType(String enchantSpec) {
+    private static boolean validateEnchantmentType(String enchantSpec) {
         return Enchantment.getByKey(NamespacedKey.fromString("minecraft:"+ enchantSpec)) != null;
     }
 
     private static boolean validatePotionEffectType(String effectSpec) {
-	    return PotionEffectType.getByName(effectSpec) != null;
+        return PotionEffectType.getByName(effectSpec) != null;
     }
 
     private static boolean isPotionBased(Material material) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -692,7 +692,10 @@ public class SiegeWarSettings {
 			ItemMeta itemMeta = artefact.getItemMeta();
 			itemMeta.setDisplayName(name);
 			//Add special effects
-			addSpecialEffects(artefact, itemMeta, specificationFields);
+			if (!addSpecialEffects(artefact, itemMeta, specificationFields)) {
+			    SiegeWar.info("Domination Awards Artefact Offer: " +  specificationFields[0] + " cannot be loaded, check the PotionEffecType.");
+			    continue;
+			}
 			//Add non-effect lore
 			List<String> lore = itemMeta.hasLore() ? itemMeta.getLore() : new ArrayList<>();
 			lore.add(ChatColor.translateAlternateColorCodes('&', Translatable.of("artefact_lore_summary_line",tier+1).translate()));
@@ -754,7 +757,7 @@ public class SiegeWarSettings {
 		cachedDominationAwardsArtefactOffers = result;
 	}
 
-	private static void addSpecialEffects(ItemStack artefact, ItemMeta itemMeta, String[] specificationFields) {
+	private static boolean addSpecialEffects(ItemStack artefact, ItemMeta itemMeta, String[] specificationFields) {
 		//Create convenience variables
 		Material material = artefact.getType();
         List<String[]> effectSpecs = new ArrayList<>();
@@ -763,19 +766,42 @@ public class SiegeWarSettings {
         }
 		//Add special effects
 		for(String[] effectSpec: effectSpecs) {
+		    if (!validateEffect(material, effectSpec[0]))
+		        return false;
 			addSpecialEffect(material, itemMeta, effectSpec);
 		}
 		//Set updated item meta
 		artefact.setItemMeta(itemMeta);
+		return true;
 	}
 
-	private static void addSpecialEffect(Material material, ItemMeta itemMeta, String[] effectSpec) {
-		if(effectSpec[0].equalsIgnoreCase("custom_effect")) {
-			addCustomEffect(itemMeta, effectSpec);
-		} else if(material == Material.POTION
+	// Make sure that the config has been given a valid PotionEffectType or Enchantment name.
+    private static boolean validateEffect(Material material, String name) {
+        return !name.isEmpty()
+                && !name.equals("custom_effect") // ignore custom_effect
+                && ((isPotionBased(material) && !validatePotionEffectType(name))
+                    || !isPotionBased(material) && !validateEnchantmentType(name));
+    }
+
+	private static boolean validateEnchantmentType(String enchantSpec) {
+        return Enchantment.getByKey(NamespacedKey.fromString("minecraft:"+ enchantSpec)) != null;
+    }
+
+    private static boolean validatePotionEffectType(String effectSpec) {
+	    return PotionEffectType.getByName(effectSpec) != null;
+    }
+
+    private static boolean isPotionBased(Material material) {
+        return material == Material.POTION
                 || material == Material.SPLASH_POTION
                 || material == Material.LINGERING_POTION
-                || material == Material.TIPPED_ARROW ) {
+                || material == Material.TIPPED_ARROW;
+    }
+
+    private static void addSpecialEffect(Material material, ItemMeta itemMeta, String[] effectSpec) {
+		if(effectSpec[0].equalsIgnoreCase("custom_effect")) {
+			addCustomEffect(itemMeta, effectSpec);
+		} else if (isPotionBased(material)) {
 			PotionEffect potionEffect = generatePotionEffect(effectSpec);
 			((PotionMeta)itemMeta).addCustomEffect(potionEffect, true);
 		} else {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -28,7 +28,6 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
-import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.*;
 import org.jetbrains.annotations.Nullable;
 
@@ -766,7 +765,7 @@ public class SiegeWarSettings {
         }
 		//Add special effects
 		for(String[] effectSpec: effectSpecs) {
-		    if (!validateEffect(material, effectSpec[0]))
+		    if (!validEffect(material, effectSpec[0]))
 		        return false;
 			addSpecialEffect(material, itemMeta, effectSpec);
 		}
@@ -776,11 +775,13 @@ public class SiegeWarSettings {
 	}
 
 	// Make sure that the config has been given a valid PotionEffectType or Enchantment name.
-    private static boolean validateEffect(Material material, String name) {
-        return !name.isEmpty()
-                && name.equals("custom_effect") // ignore custom_effect
-                || ((isPotionBased(material) && !validatePotionEffectType(name))
-                    || !isPotionBased(material) && !validateEnchantmentType(name));
+    private static boolean validEffect(Material material, String name) {
+        return !name.isEmpty() && (name.equalsIgnoreCase("custom_effect") || isValid(material, name));
+    }
+
+    private static boolean isValid(Material material, String name) {
+        return (isPotionBased(material) && validatePotionEffectType(name))
+            || (!isPotionBased(material) && validateEnchantmentType(name));
     }
 
     private static boolean validateEnchantmentType(String enchantSpec) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Adds a test during Domination Awards loading, that skips over any awards that are:
 - not custom_effect
 - an invalid PotionEffectType
 - an invalid EnchantmentType

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
