### PR TITLE
Auto-apply the arrow of doom fix

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -1095,11 +1095,11 @@ public enum ConfigNodes {
 			"# +------------------------------------------------------+ #",
 			""),
 	DOMINATION_AWARDS_ARTEFACT_OFFERS_DEFAULT(
-			"domination_awards.artefact_offers.default_0_7_17",
+			"domination_awards.artefact_offers.default_0_7_18",
 			"",
 			"# These artefacts are the defaults provided by SW. Do not add custom items here."),
 	DOMINATION_AWARDS_ARTEFACT_OFFERS_DEFAULT_TIER1(
-			"domination_awards.artefact_offers.default_0_7_17.tier1",
+			"domination_awards.artefact_offers.default_0_7_18.tier1",
 			"{cobble_eater, 1, golden_pickaxe, efficiency:8, unbreaking:1}"
 			+ "{tree_feller, 1, golden_axe, efficiency:8, unbreaking:1}"
 			+ "{ground_digger, 1, golden_shovel, efficiency:8, unbreaking:1}"
@@ -1109,14 +1109,14 @@ public enum ConfigNodes {
 			+ "{potion_of_enhanced_absorbtion, 5, potion, absorption:3:120:true:true:true}",
 			""),
 	DOMINATION_AWARDS_ARTEFACT_OFFERS_DEFAULT_TIER2(
-			"domination_awards.artefact_offers.default_0_7_17.tier2",
+			"domination_awards.artefact_offers.default_0_7_18.tier2",
 			"{potion_of_true_invisibility, 3, potion, invisibility:1:300:false:false:true}"
 			+ "{splash_potion_of_enhanced_regeneration, 3, splash_potion, regeneration:3:60:true:true:true}"
 			+ "{splash_potion_of_enhanced_strength, 3, splash_potion, increase_damage:3:120:true:true:true}"
 			+ "{splash_potion_of_enhanced_absorbtion, 5, splash_potion, absorption:3:120:true:true:true}",
 			""),
 	DOMINATION_AWARDS_ARTEFACT_OFFERS_DEFAULT_TIER3(
-			"domination_awards.artefact_offers.default_0_7_17.tier3",
+			"domination_awards.artefact_offers.default_0_7_18.tier3",
 			"{arrow_of_enhanced_hunger, 5, tipped_arrow, hunger:10:50:true:true:true}"
 			+ "{potion_of_great_resistance, 3, potion, damage_resistance:5:30:true:true:true}"
 			+ "{arrow_of_knockup, 5, tipped_arrow, levitation:25:1:true:true:true}"
@@ -1124,13 +1124,13 @@ public enum ConfigNodes {
 			+ "{bountiful_pickaxe, 1, golden_pickaxe, fortune:5, efficiency:8}",
 			""),
 	DOMINATION_AWARDS_ARTEFACT_OFFERS_DEFAULT_TIER4(
-			"domination_awards.artefact_offers.default_0_7_17.tier4",
+			"domination_awards.artefact_offers.default_0_7_18.tier4",
 			"{sword_of_immolation, 1, golden_sword, fire_aspect:7}"
 			+ "{axe_of_the_berserker, 1, golden_axe, sharpness:7, efficiency:10}"
 			+ "{bow_of_displacement, 1, bow, punch: 10}",
 			""),
 	DOMINATION_AWARDS_ARTEFACT_OFFERS_DEFAULT_TIER5(
-			"domination_awards.artefact_offers.default_0_7_17.tier5",
+			"domination_awards.artefact_offers.default_0_7_18.tier5",
 			"{arrow_of_doom, 1, tipped_arrow, harm:20:1:true:true:true}"
 			+ "{vorpal_sword, 1, golden_sword, sharpness:20}"
 			+ "{chicago_typewriter, 1, crossbow, quick_charge:5}"


### PR DESCRIPTION
#### Description: 
- This PR causes the arrow-of-doom config fix to be automatically applied on deploy of 0.7.18

____
#### New Nodes/Commands/ConfigOptions: 
Na

____
#### Relevant Issue ticket:
Na


____
- [ na ] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
