### PR TITLE
Cancel battle sessions starting if there is no active sieges.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -30,6 +30,7 @@ import com.gmail.goosius.siegewar.listeners.SiegeWarBukkitEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarNationEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarPlotEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarSafeModeListener;
+import com.gmail.goosius.siegewar.listeners.SiegeWarSelfListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarStatusScreenListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarTownEventListener;
 import com.gmail.goosius.siegewar.listeners.SiegeWarTownyEventListener;
@@ -164,6 +165,7 @@ public class SiegeWar extends JavaPlugin {
 			pm.registerEvents(new SiegeWarPlotEventListener(this), this);
 			pm.registerEvents(new SiegeWarStatusScreenListener(), this);
 			pm.registerEvents(new SiegeWarArtefactListener(this), this);
+			pm.registerEvents(new SiegeWarSelfListener(), this);
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSelfListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSelfListener.java
@@ -1,0 +1,21 @@
+package com.gmail.goosius.siegewar.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import com.gmail.goosius.siegewar.SiegeController;
+import com.gmail.goosius.siegewar.events.BattleSessionPreStartEvent;
+import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.palmergames.bukkit.towny.object.Translatable;
+
+public class SiegeWarSelfListener implements Listener {
+	
+	@EventHandler
+	public void onBattleSessionPreStart(BattleSessionPreStartEvent event) {
+		if (SiegeWarSettings.cancelBattleSessionWhenNoActiveSieges()
+		&& (SiegeController.getSieges().isEmpty() || SiegeController.getSieges().stream().noneMatch(siege -> siege.getStatus().isActive()))) {
+			event.setCancelled(true);
+			event.setCancellationMsg(Translatable.of("battle_session_cancelled_no_sieges").defaultLocale());
+		}
+	}
+}

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -978,6 +978,11 @@ public enum ConfigNodes {
 			"",
 			"# This value determines the duration of each battle session.",
 			"# TIP: The default value of 50 is deliberately designed to give players a 10 minute break after each battle session, for reasons of health and safety."),
+	BATTLE_SESSION_SCHEDULER_CANCEL_SESSION_WHEN_NO_SIEGES(
+			"battle_session_scheduler.cancel_session_when_no_active_sieges",
+			"true",
+			"",
+			"# Should sessions be cancelled when there are no active sieges?"),
 	CAPPING_LIMITER(
 			"capping_limiter",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -628,6 +628,10 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.BATTLE_SESSION_SCHEDULER_DURATION_MINUTES);
 	}
 
+	public static boolean cancelBattleSessionWhenNoActiveSieges() {
+		return Settings.getBoolean(ConfigNodes.BATTLE_SESSION_SCHEDULER_CANCEL_SESSION_WHEN_NO_SIEGES);
+	}
+
 	public static boolean isDominationAwardsGlobalEnabled() {
 		return Settings.getBoolean(ConfigNodes.DOMINATION_AWARDS_GLOBAL_ENABLED);
 	}

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -573,4 +573,8 @@ artefact_custom_effect_lore_strong_poison_on_hit: '&7Strong Poison on Hit'
 artefact_custom_effect_lore_slow_on_hit: '&7Slowness on Hit'
 
 #Added in 0.48
+
+#Shown when an admin adds hours using /swa siegeduration addhours
 hours_added_to_sieges: '%s hours have been added to all sieges'' durations.'
+#Shown when SW cancels a battle session because there's no active sieges.
+battle_session_cancelled_no_sieges: 'No active Sieges, cancelling Battle Session'


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Battle Sessions don't need to run if there's no sieges to fight over.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New Config Option:
battle_session_scheduler.cancel_session_when_no_active_sieges
  - Default: true
  - Should sessions be cancelled when there are no active sieges?

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #619

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
