### PR TITLE
Add PreInvadeEvent which can stop the invasion of a town after a successful siege.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>0.8.1</version>
+  <version>0.8.2</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/TownOccupationController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/TownOccupationController.java
@@ -1,6 +1,7 @@
 package com.gmail.goosius.siegewar;
 
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
+import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -39,7 +40,7 @@ public class TownOccupationController {
             occupyingNationUUID = TownMetaDataController.getOccupyingNationUUID(town);
             if (occupyingNationUUID == null) {
                 //Occupier uuid not found. Fix data if required and move to next town
-                if (town.isConquered()) {
+                if (town.isConquered() && SiegeWarSettings.getWarCommonOccupiedTownCorrectConquerStatus()) {
                     town.setConquered(false);
                     town.save();
                 }
@@ -122,7 +123,7 @@ public class TownOccupationController {
      public static boolean isTownOccupied(Town occupiedTown) {
          String occupierUUID = TownMetaDataController.getOccupyingNationUUID(occupiedTown);
          if (occupierUUID == null) {
-             if(occupiedTown.isConquered())
+             if(occupiedTown.isConquered() && SiegeWarSettings.getWarCommonOccupiedTownCorrectConquerStatus())
                  occupiedTown.setConquered(false); //Fix data if required
              return false;
          } else {
@@ -156,8 +157,10 @@ public class TownOccupationController {
             } else {
                 //Nation could not be loaded. Fix data
                 TownMetaDataController.removeOccupationMetadata(occupiedTown);
-                occupiedTown.setConquered(false);
-                occupiedTown.save();
+                if (SiegeWarSettings.getWarCommonOccupiedTownCorrectConquerStatus()) {
+                    occupiedTown.setConquered(false);
+                    occupiedTown.save();
+                }
                 throw new RuntimeException("Error loading occupier data for " + occupiedTown.getName() + " Data fixed automatically by de-occupying town");
             }
         }

--- a/src/main/java/com/gmail/goosius/siegewar/events/PreInvadeEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/PreInvadeEvent.java
@@ -1,0 +1,79 @@
+package com.gmail.goosius.siegewar.events;
+
+import com.gmail.goosius.siegewar.objects.Siege;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A cancellable event that is called right before a Nation invades and occupies
+ * a town which has lost a siege.
+ * 
+ * When cancelled, SiegeWar will not occupy the town and your plugin should do
+ * something else.
+ * 
+ * If the cancellation message is not set to empty then it will be shown to the
+ * player who tried to invade.
+ *
+ * @author LlmDl
+ * @since 0.8.1
+ */
+public class PreInvadeEvent extends Event implements Cancellable {
+
+	private static final HandlerList handlers = new HandlerList();
+	private final Nation nation;
+	private final Town town;
+	private final Siege siege;
+
+	private boolean isCancelled;
+	private String cancellationMsg = "Invasion prevented by another plugin.";
+
+	public PreInvadeEvent(Nation nation, Town town, Siege siege) {
+		this.nation = nation;
+		this.town = town;
+		this.siege = siege;
+	}
+
+	@NotNull
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+	public Town getInvadedTown() {
+		return town;
+	}
+
+	public Nation getInvadingNation() {
+		return nation;
+	}
+
+	public Siege getSiege() {
+		return siege;
+	}
+
+	@Override
+	public boolean isCancelled() {
+		return isCancelled;
+	}
+
+	@Override
+	public void setCancelled(boolean b) {
+		isCancelled = b;
+	}
+
+	public String getCancellationMsg() {
+		return cancellationMsg;
+	}
+
+	public void setCancellationMsg(String cancellationMsg) {
+		this.cancellationMsg = cancellationMsg;
+	}
+}

--- a/src/main/java/com/gmail/goosius/siegewar/events/PreInvadeEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/PreInvadeEvent.java
@@ -3,6 +3,8 @@ package com.gmail.goosius.siegewar.events;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
+
+import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -19,11 +21,12 @@ import org.jetbrains.annotations.NotNull;
  * player who tried to invade.
  *
  * @author LlmDl
- * @since 0.8.1
+ * @since 0.8.2
  */
 public class PreInvadeEvent extends Event implements Cancellable {
 
 	private static final HandlerList handlers = new HandlerList();
+	private final Player player;
 	private final Nation nation;
 	private final Town town;
 	private final Siege siege;
@@ -31,7 +34,8 @@ public class PreInvadeEvent extends Event implements Cancellable {
 	private boolean isCancelled;
 	private String cancellationMsg = "Invasion prevented by another plugin.";
 
-	public PreInvadeEvent(Nation nation, Town town, Siege siege) {
+	public PreInvadeEvent(Player player, Nation nation, Town town, Siege siege) {
+		this.player = player;
 		this.nation = nation;
 		this.town = town;
 		this.siege = siege;
@@ -45,6 +49,10 @@ public class PreInvadeEvent extends Event implements Cancellable {
 
 	public static HandlerList getHandlerList() {
 		return handlers;
+	}
+
+	public Player getPlayer() {
+		return player;
 	}
 
 	public Town getInvadedTown() {

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -85,7 +85,7 @@ public class InvadeTown {
 			}
 		}
 
-		PreInvadeEvent preEvent = new PreInvadeEvent(residentsNation, nearbyTown, siege);
+		PreInvadeEvent preEvent = new PreInvadeEvent(player, residentsNation, nearbyTown, siege);
 		Bukkit.getPluginManager().callEvent(preEvent);
 		if (preEvent.isCancelled()) {
 			if (!preEvent.getCancellationMsg().isEmpty())

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -5,6 +5,7 @@ import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.TownOccupationController;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
+import com.gmail.goosius.siegewar.events.PreInvadeEvent;
 import com.gmail.goosius.siegewar.metadata.NationMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
@@ -20,6 +21,7 @@ import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 /**
@@ -81,6 +83,14 @@ public class InvadeTown {
 			if (effectiveNumTowns >= TownySettings.getMaxTownsPerNation()){
 				throw new TownyException(String.format(translator.of("msg_err_nation_over_town_limit"), TownySettings.getMaxTownsPerNation()));
 			}
+		}
+
+		PreInvadeEvent preEvent = new PreInvadeEvent(residentsNation, nearbyTown, siege);
+		Bukkit.getPluginManager().callEvent(preEvent);
+		if (preEvent.isCancelled()) {
+			if (!preEvent.getCancellationMsg().isEmpty())
+				Messaging.sendErrorMsg(player, preEvent.getCancellationMsg());
+			return;
 		}
 
 		invadeTown(residentsNation, nearbyTown, siege);

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -90,10 +90,9 @@ public class InvadeTown {
 		if (preEvent.isCancelled()) {
 			if (!preEvent.getCancellationMsg().isEmpty())
 				Messaging.sendErrorMsg(player, preEvent.getCancellationMsg());
-			return;
+		} else {
+			invadeTown(residentsNation, nearbyTown, siege);	
 		}
-
-		invadeTown(residentsNation, nearbyTown, siege);
 	}
 
 	/**
@@ -101,7 +100,7 @@ public class InvadeTown {
 	 *
 	 * @param siege the siege
 	 */
-    private static void invadeTown(Nation invadingNation, Town invadedTown, Siege siege) {
+    public static void invadeTown(Nation invadingNation, Town invadedTown, Siege siege) {
 		Nation nationOfInvadedTown = null;
 
         if(invadedTown.hasNation()) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -752,6 +752,12 @@ public enum ConfigNodes {
 			"",
 			"# If this value is true, then a town under occupation cannot unclaim.",
 			"#  This setting is recommended, to avoid occupation escape exploits."),
+	OCCUPIED_TOWN_CORRECT_CONQUERED_STATUS(
+			"occupied_towns.automatically_remove_conquered_status_when_unable_to_load_nation",
+			"true",
+			"",
+			"# Leave this setting to true. Only used under very specific circumstances for which you will be given instructions personally."),
+	
 	PUNISH_NON_SIEGE_PARTICIPANTS_IN_SIEGE_ZONE(
 			"punish_non_siege_participants_in_siege_zones",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -193,6 +193,10 @@ public class SiegeWarSettings {
 	public static boolean getWarCommonOccupiedTownUnClaimingDisabled() {
 		return Settings.getBoolean(ConfigNodes.OCCUPIED_TOWN_UNCLAIMING_DISABLED);
 	}
+	
+	public static boolean getWarCommonOccupiedTownCorrectConquerStatus() {
+		return Settings.getBoolean(ConfigNodes.OCCUPIED_TOWN_CORRECT_CONQUERED_STATUS);
+	}
 
 	public static boolean isWarSiegeCounterattackBoosterEnabled() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_POINTS_BALANCING_COUNTERATTACK_BOOSTER_ENABLED);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #604 via a separate plugin.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
