### PR TITLE
Add option to prevent sieged nations from changing their capital. (Configurable.)

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -23,11 +23,12 @@ import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumTownsCalc
 import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumResidentsCalculationEvent;
 import com.palmergames.bukkit.towny.event.nation.NationListDisplayedNumTownBlocksCalculationEvent;
 import com.palmergames.bukkit.towny.event.nation.DisplayedNationsListSortEvent;
-
+import com.palmergames.bukkit.towny.event.nation.NationKingChangeEvent;
 import com.palmergames.bukkit.towny.event.nation.toggle.NationToggleNeutralEvent;
 import com.palmergames.bukkit.towny.event.townblockstatus.NationZoneTownBlockStatusEvent;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translation;
 
 import org.bukkit.Bukkit;
@@ -316,6 +317,18 @@ public class SiegeWarNationEventListener implements Listener {
 		if (event.getFutureState()) {
 			event.setCancelled(true);
 			event.setCancelMessage(Translation.of("msg_err_nation_neutrality_not_supported"));
+		}
+	}
+
+	public void onNationChangeKingEvent(NationKingChangeEvent event) {
+		Town oldCapital = event.getOldKing().getTownOrNull();
+		Town newCapital = event.getNewKing().getTownOrNull();
+		if (SiegeWarSettings.getWarSiegeEnabled()
+			&& SiegeWarSettings.getWarSiegeBesiegedCapitalsCannotChangeKing()
+			&& event.isCapitalChange()
+			&& (SiegeController.hasSiege(oldCapital) || SiegeController.hasSiege(newCapital))) {
+			event.setCancelled(true);
+			event.setCancelMessage(Translation.of("plugin_prefix") + Translation.of("msg_err_besieged_capital_cannot_change_king"));
 		}
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -123,6 +123,12 @@ public enum ConfigNodes {
 			"",
 			"# If this value is true, then a town under active siege cannot unclaim.",
 			"#  This setting is recommended if invasion/occupation is enabled, to avoid occupation escape exploits."),
+	WAR_SIEGE_BESIEGED_TOWN_CANNOT_CHANGE_KING(
+			"war.siege.switches.besieged_capitals_cannot_change_kings",
+			"false",
+			"",
+			"# If this value is true, then a town which is a capital of a nation that is under siege, cannot",
+			"# change capital to another city via /n set king|capital."),
 	WAR_SIEGE_NATION_STATISTICS_ENABLED(
 			"war.siege.switches.nation_statistics_enabled",
 			"true",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -188,6 +188,10 @@ public class SiegeWarSettings {
 	public static boolean getWarSiegeBesiegedTownUnClaimingDisabled() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_BESIEGED_TOWN_UNCLAIMING_DISABLED);
 	}
+	
+	public static boolean getWarSiegeBesiegedCapitalsCannotChangeKing() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_BESIEGED_TOWN_CANNOT_CHANGE_KING);
+	}
 
 	public static int getWarSiegeExtraMoneyPercentagePerTownLevel() {
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_EXTRA_MONEY_PERCENTAGE_PER_TOWN_LEVEL);

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -1,5 +1,5 @@
 name: SiegeWar
-version: 0.48
+version: 0.49
 language: english
 author: Goosius
 website: 'http://townyadvanced.github.io/'
@@ -578,3 +578,7 @@ artefact_custom_effect_lore_slow_on_hit: '&7Slowness on Hit'
 hours_added_to_sieges: '%s hours have been added to all sieges'' durations.'
 #Shown when SW cancels a battle session because there's no active sieges.
 battle_session_cancelled_no_sieges: 'No active Sieges, cancelling Battle Session'
+
+#Added in 0.49
+#Shown when a nation tries to set their capital city while it is sieged.
+msg_err_besieged_capital_cannot_change_king: "&cYour nation is not allowed to change kings while your cities are sieged."


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->


When either the new capital or old capital are sieged, prevent that
king-change event.



____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

New Config Option:
war.siege.switches.besieged_capitals_cannot_change_kings
  - Default: false
  - If this value is true, then a town which is a capital of a nation
that is under siege, cannot change capital to another city via /n set
king|capital.
____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


Closes #641.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
