### PR TITLE
Bugfix: Prevent residents inside nearby towns being killed for logging out near a Sieged town

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -245,10 +245,12 @@ public class SiegeWarBukkitEventListener implements Listener {
 				&& SiegeWarSettings.getKillPlayersWhoLogoutInSiegeZones()
 				&& SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getPlayer().getLocation())) {
 			Town playerTown = TownyAPI.getInstance().getTown(event.getPlayer().getLocation());
-			Town siegedTown = SiegeWarDistanceUtil.getActiveSiegeZoneWherePlayerIsRegistered(event.getPlayer()).getTown();
-			if(siegedTown != null && playerTown != siegedTown) return;
-			event.setQuitMessage(Translatable.of("msg_player_killed_for_logging_out_in_siege_zone", event.getPlayer().getName()).translate());
-			event.getPlayer().setHealth(0);
+			if(playerTown != null && playerTown.hasResident(event.getPlayer())) {
+				Town siegedTown = SiegeWarDistanceUtil.getActiveSiegeZoneWherePlayerIsRegistered(event.getPlayer()).getTown();
+				if (siegedTown != null && playerTown != siegedTown) return;
+				event.setQuitMessage(Translatable.of("msg_player_killed_for_logging_out_in_siege_zone", event.getPlayer().getName()).translate());
+				event.getPlayer().setHealth(0);
+			}
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -245,7 +245,8 @@ public class SiegeWarBukkitEventListener implements Listener {
 				&& SiegeWarSettings.getKillPlayersWhoLogoutInSiegeZones()
 				&& SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getPlayer().getLocation())) {
 			Town playerTown = TownyAPI.getInstance().getTown(event.getPlayer().getLocation());
-			if(playerTown != SiegeWarDistanceUtil.getActiveSiegeZoneWherePlayerIsRegistered(event.getPlayer()).getTown()) return;
+			Town siegedTown = SiegeWarDistanceUtil.getActiveSiegeZoneWherePlayerIsRegistered(event.getPlayer()).getTown();
+			if(siegedTown != null && playerTown != siegedTown) return;
 			event.setQuitMessage(Translatable.of("msg_player_killed_for_logging_out_in_siege_zone", event.getPlayer().getName()).translate());
 			event.getPlayer().setHealth(0);
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -244,6 +244,8 @@ public class SiegeWarBukkitEventListener implements Listener {
 		if(event.getPlayer().getHealth() > 0
 				&& SiegeWarSettings.getKillPlayersWhoLogoutInSiegeZones()
 				&& SiegeWarDistanceUtil.isLocationInActiveSiegeZone(event.getPlayer().getLocation())) {
+			Town playerTown = TownyAPI.getInstance().getTown(event.getPlayer().getLocation());
+			if(playerTown != SiegeWarDistanceUtil.getActiveSiegeZoneWherePlayerIsRegistered(event.getPlayer()).getTown()) return;
 			event.setQuitMessage(Translatable.of("msg_player_killed_for_logging_out_in_siege_zone", event.getPlayer().getName()).translate());
 			event.getPlayer().setHealth(0);
 		}


### PR DESCRIPTION
#### Description: 
Currently, if you have a town that is near a Sieged town, you will still receive the Siege Zone sickness even if you are in your own claim. This PR fixes that issue.
____
#### New Nodes/Commands/ConfigOptions: 
N/A
____
#### Relevant Issue ticket:
N/A
____
- [ X ] I have tested this pull request for defects on a server.

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
