### PR TITLE
Fix global domination expiry times being set incorrectly.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDominationAwardsUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDominationAwardsUtil.java
@@ -286,7 +286,7 @@ public class SiegeWarDominationAwardsUtil {
             ItemStack artefact = offer.clone();
             ItemMeta itemMeta =  artefact.getItemMeta();
             //Set expiration time
-            long expirationTime = System.currentTimeMillis() + (long)(SiegeWarSettings.getDominationAwardsArtefactExpiryLifetimeDays() * 864500000); 
+            long expirationTime = System.currentTimeMillis() + (long)(SiegeWarSettings.getDominationAwardsArtefactExpiryLifetimeDays() * 86400000); 
             itemMeta.getPersistentDataContainer().set(EXPIRATION_TIME_KEY, EXPIRATION_TIME_KEY_TYPE, expirationTime);
             artefact.setItemMeta(itemMeta);
             //Add to result


### PR DESCRIPTION
Expiry times had an added 5 in the multiplier used to calculate millis per day, leading to expiry days counting for about 10 days each.

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
