### PR TITLE
Config Option: prevent capitals becoming peaceful.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -107,6 +107,14 @@ public class SiegeWarTownEventListener implements Listener {
 			return;
 		}
 		
+		// Check if we're becoming peaceful, a capital city and capitals cannot become peaceful. 
+		if (event.getFutureState() && event.getTown().isCapital() 
+				&& !SiegeWarSettings.capitalsAllowedTownPeacefulness() && !event.isAdminAction()) {
+			event.setCancelMessage(Translation.of("msg_err_command_disable"));
+			event.setCancelled(true);
+			return;
+		}
+		
 		Town town = event.getTown();
 		
 		if (event.isAdminAction()) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -706,6 +706,11 @@ public enum ConfigNodes {
             "# - Town may get automatically peacefully occupied without a siege.",
 			"#   (see user guide for full details)",
 			"#"),
+	PEACEFUL_CAPITALS_ENABLED(
+			"neutral_towns.capitals_allowed_neutrality",
+			"true",
+			"",
+			"# If this is true, a nation capital can be a peaceful town. If false, any capital will not be able to turn peaceful."),
 	PEACEFUL_TOWNS_CONFIRMATION_REQUIREMENT_DAYS(
 			"neutral_towns.confirmation_requirement_days",
 			"5",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -172,6 +172,10 @@ public class SiegeWarSettings {
 	public static boolean getWarCommonPeacefulTownsEnabled() {
 		return Settings.getBoolean(ConfigNodes.PEACEFUL_TOWNS_ENABLED);
 	}
+	
+	public static boolean capitalsAllowedTownPeacefulness() {
+		return Settings.getBoolean(ConfigNodes.PEACEFUL_CAPITALS_ENABLED);
+	}
 
 	public static int getWarCommonPeacefulTownsConfirmationRequirementDays() {
 		return Settings.getInt(ConfigNodes.PEACEFUL_TOWNS_CONFIRMATION_REQUIREMENT_DAYS);


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Some servers may want to prevent any nation capital city from becoming peaceful on the town-level.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New Config Option: neutral_towns.capitals_allowed_neutrality
  - default: "true"
  - If this is true, a nation capital can be a peaceful town. If false, any capital will not be able to turn peaceful.

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
