### PR TITLE
Jailbreaks triggered by attackers winning battle sessions.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -141,6 +141,13 @@ public enum ConfigNodes {
 			"# If this value is true then players who log out in Siege-Zones will be killed.",
 			"# TIP 1: This setting is important to prevent reinforcements/ambushers appearing unnaturally in SiegeZones.",
 			"# TIP 2: The setting is essential when using the Wall Breaching feature, to stop players logging in/out at the homeblock"),
+	WAR_SIEGE_UNJAIL_RESIDENTS_WHEN_ATTACKERS_WIN_SESSION(
+			"war.siege.switches.unjail_residents_when_attackers_win_battle_session",
+			"false",
+			"",
+			"# When true, if an attackers wins the battlesession against a sieged town, that",
+			"# town's jailed players that belong to the attacking nation will be freed from the town's jail."),
+
 	WAR_SIEGE_MONEY(
 			"war.siege.money",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -891,4 +891,8 @@ public class SiegeWarSettings {
 	public static int getDominationAwardsArtefactExpiryExplosionsMaxPower() {
 		return Settings.getInt(ConfigNodes.DOMINATION_AWARDS_ARTEFACT_EXPIRY_EXPLOSIONS_MAX_POWER);
 	}
+
+	public static boolean isUnjailingAttackerResidents() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_UNJAIL_RESIDENTS_WHEN_ATTACKERS_WIN_SESSION);
+	}
 }

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -598,3 +598,6 @@ msg_err_you_cannot_afford_to_siege_for_x: "Your nation cannot afford to begin th
 
 #Show when a nation tries to start a siege when the economy is not active.
 msg_err_no_siege_economy_not_active: "You cannot start a siege while the Economy is disabled in Towny."
+
+#Shown when the attackers win a battle session and their jailed players are freed from the defender's jail.
+msg_attackers_have_triggered_a_jail_break_freeing: "The attackers have won the battle session, resulting in a prison break, freeing %s."


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

New Config Node:
war.siege.switches.unjail_residents_when_attackers_win_battle_session
  - Default: false
  - When true, if an attackers wins the battlesession against a sieged town, that town's jailed players that belong to the attacking nation will be freed from the town's jail.

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #701.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
