### PR TITLE
Make glowing for banner control sessions optional.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>1.3.1</version>
+  <version>1.4.0</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -147,6 +147,11 @@ public enum ConfigNodes {
 			"",
 			"# When true, if an attackers wins the battlesession against a sieged town, that",
 			"# town's jailed players that belong to the attacking nation will be freed from the town's jail."),
+	WAR_SIEGE_GLOWING(
+			"war.siege.switches.enabled_glowing_on_players",
+			"true",
+			"",
+			"# When true, players will have a glowing effect."),
 
 	WAR_SIEGE_MONEY(
 			"war.siege.money",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -907,4 +907,8 @@ public class SiegeWarSettings {
 	public static boolean isUnjailingAttackerResidents() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_UNJAIL_RESIDENTS_WHEN_ATTACKERS_WIN_SESSION);
 	}
+
+	public static boolean isGlowingEnabled() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_GLOWING);
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -336,6 +336,9 @@ public class SiegeWarBannerControlUtil {
 	 * @param siege the siege
 	 */
 	private static void evaluatePlayerGlowing(Siege siege) throws Exception {
+		if (!SiegeWarSettings.isGlowingEnabled())
+			return;
+
 		//Create attacker and defender capper maps
 		Set<BannerControlSession> attackerSessions = new HashSet<>();
 		Set<BannerControlSession> defenderSessions = new HashSet<>();


### PR DESCRIPTION

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New Config Option: war.siege.switches.enabled_glowing_on_players
  - Default: true
  - When true, players will have a glowing effect.


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
