### PR TITLE
Fix bug with swa setplundered/setinvaded

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -635,14 +635,14 @@ public class SiegeWarAdminCommand implements TabExecutor {
 				Messaging.sendErrorMsg(sender, Translatable.of("msg_err_town_not_registered", args[0]));
 				return;
 			}
-			List<String> ignoreActiveSiegeArgs = Arrays.asList("setplundered","setcaptured","remove");
-			if (!SiegeController.hasActiveSiege(town) && !ignoreActiveSiegeArgs.contains(args[1].toLowerCase())) {
-				Messaging.sendErrorMsg(sender, Translatable.of("msg_err_not_being_sieged", town.getName()));
+			if (!SiegeController.hasSiege(town)) {
+				Messaging.sendErrorMsg(sender, Translatable.of("msg_err_siege_war_no_siege_on_target_town", town.getName()));
 				return;
 			}
-			if (!SiegeController.hasSiege(town) && ignoreActiveSiegeArgs.contains(args[1].toLowerCase())) {
-				Messaging.sendErrorMsg(sender, Translatable.of("msg_err_not_being_sieged", town.getName()));
-				return;				
+			List<String> commandsNotAllowedOnActiveSieges = Arrays.asList("setplundered","setinvaded");
+			if (SiegeController.hasActiveSiege(town) && commandsNotAllowedOnActiveSieges.contains(args[1].toLowerCase())) {
+				Messaging.sendErrorMsg(sender, Translatable.of("msg_err_command_not_allowed_on_active_siege", town.getName()));
+				return;
 			}
 			Siege siege = SiegeController.getSiege(town);
 
@@ -657,13 +657,11 @@ public class SiegeWarAdminCommand implements TabExecutor {
 						Messaging.sendErrorMsg(sender, Translatable.of("msg_error_must_be_num"));
 						return;
 					}
-
 					int newPoints = Integer.parseInt(args[2]);
 					siege.setSiegeBalance(newPoints);
 					SiegeController.saveSiege(siege);
 					Messaging.sendMsg(sender, Translatable.of("msg_swa_set_siege_balance_success", newPoints, town.getName()));
 					return;
-
 				case "end":
 					if (siege.getSiegeBalance() < 1)
 						DefenderTimedWin.defenderTimedWin(siege);
@@ -693,7 +691,6 @@ public class SiegeWarAdminCommand implements TabExecutor {
 					Messaging.sendMsg(sender, Translatable.of("msg_swa_remove_siege_success"));
 					return;
 			}
-
 		} else
 			showSiegeHelp(sender);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 public class SiegeWarAdminCommand implements TabExecutor {
 
@@ -640,7 +641,8 @@ public class SiegeWarAdminCommand implements TabExecutor {
 				return;
 			}
 			List<String> commandsNotAllowedOnActiveSieges = Arrays.asList("setplundered","setinvaded");
-			if (SiegeController.hasActiveSiege(town) && commandsNotAllowedOnActiveSieges.contains(args[1].toLowerCase())) {
+
+			if (SiegeController.hasActiveSiege(town) && commandsNotAllowedOnActiveSieges.contains(args[1].toLowerCase(Locale.ROOT))) {
 				Messaging.sendErrorMsg(sender, Translatable.of("msg_err_command_not_allowed_on_active_siege", town.getName()));
 				return;
 			}
@@ -657,11 +659,13 @@ public class SiegeWarAdminCommand implements TabExecutor {
 						Messaging.sendErrorMsg(sender, Translatable.of("msg_error_must_be_num"));
 						return;
 					}
+
 					int newPoints = Integer.parseInt(args[2]);
 					siege.setSiegeBalance(newPoints);
 					SiegeController.saveSiege(siege);
 					Messaging.sendMsg(sender, Translatable.of("msg_swa_set_siege_balance_success", newPoints, town.getName()));
 					return;
+
 				case "end":
 					if (siege.getSiegeBalance() < 1)
 						DefenderTimedWin.defenderTimedWin(siege);
@@ -691,6 +695,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 					Messaging.sendMsg(sender, Translatable.of("msg_swa_remove_siege_success"));
 					return;
 			}
+
 		} else
 			showSiegeHelp(sender);
 	}

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -567,4 +567,4 @@ msg_swa_town_occupation_change_success: '&bSuccessfully changed the occupation s
 
 #swa
 
-msg_err_command_not_allowed_on_active_siege: "You cannot run this command unless the siege has ended"
+msg_err_command_not_allowed_on_active_siege: "You cannot run this command unless the siege has ended."

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -564,3 +564,7 @@ msg_revolt_siege_defender_surrender: '&bREVOLT SIEGE at %s > The former occupyin
 msg_revolt_siege_started: '&bThe townspeople of %s have risen up against the occupying nation of %s, and declared themselves free to choose their own destiny. A REVOLT SIEGE has begun!'
 msg_err_neutral_towns_cannot_revolt: '&cPeaceful towns cannot revolt'
 msg_swa_town_occupation_change_success: '&bSuccessfully changed the occupation status of %s to %s.'
+
+#swa
+
+msg_err_command_not_allowed_on_active_siege: "You cannot run this command unless the siege has ended"


### PR DESCRIPTION
#### Description:
- *WARNING* Not reviewable until PR 720 is merged
- Currently there is a bug where you need an active siege to do swa siege x setplundered/setinvaded
- This very small PR fixes the issue

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A


____
- [NA too trivial] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
