### PR TITLE
Fix 0 balance warchest awarded message shown upon winning a revolt siege.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerWin.java
@@ -27,9 +27,6 @@ public class AttackerWin {
 			case CONQUEST:
 				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getAttacker());
 				break;
-			case REVOLT:
-				TownOccupationController.removeTownOccupation(siege.getTown());
-				break;
 		}
     }
 

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
@@ -26,9 +26,6 @@ public class DefenderWin
 			case CONQUEST:
 				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefendingNationIfPossibleElseTown());
 				break;
-			case REVOLT:
-				SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefender());
-				break;
 		}
     }
 


### PR DESCRIPTION
#### Description:
- *WARNING* Not reviewable until the PR 721 is merged
- Currently there is a bug where the warchest (of 0) is granted with message on a revolt siege win
- Remove this grant & message, because in revolt sieges, there is no warchest

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A


____
- [NA too trivial] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
