### PR TITLE
Changed terminology - "Invaded" to "Captured"

### DIFF
--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -262,7 +262,6 @@ status_town_siege_status_pending_attacker_abandon: 'Attacker Abandon Pending, in
 status_town_siege_status_defender_surrender: 'Defender Surrender'
 status_town_siege_status_pending_defender_surrender: 'Defender Surrender Pending, in %s'
 status_town_siege_status_plundered: '&2 > Town Plundered: %s'
-status_town_siege_status_invaded: '   &2Town Invaded: %s'
 
 # Siege statuses
 siege_status_attacker_abandon: 'Attacker Abandon'
@@ -295,17 +294,8 @@ msg_pending_attacker_victory: " Attacker victory will be confirmed in %s."
 msg_immediate_defender_victory: " The defenders are victorious!"
 msg_pending_defender_victory: " Defender victory will be confirmed in %s."
 
-# Invasions
-msg_err_cannot_invade_own_town: '&cYou cannot invade your own town.'
-msg_err_cannot_invade_without_victory: "&cYou cannot invade the town unless your nation is victorious in the siege."
-msg_err_cannot_invade_siege_still_in_progress: '&cYou cannot invade while the siege is still in progress.'
-msg_err_cannot_invade_town_already_occupied: '&cThere is no need to invade because your nation already occupies the town.'
-
 # Plunder
 msg_err_siege_war_plunder_not_possible_rebels_won: '&cPlunder not possible because the town rebels won the siege.'
-
-# Admin commands
-msg_swa_set_invade_success: '&bSet invaded to %s for %s.'
 
 # Added in 0.16
 
@@ -547,14 +537,13 @@ msg_err_siege_war_nation_refund_unavailable: "There is no nation refund availabl
 #Invasion
 
 msg_err_cannot_invade_town_already_invaded: '&cYour nation has already captured the town.'
-msg_neutral_town_invaded: '&b%s has been invaded and captured by %s!'
-msg_nation_town_invaded: '&b%s, belonging to %s, has been invaded and captured by %s!'
+msg_neutral_town_invaded: '&b%s has been captured by %s!'
+msg_nation_town_invaded: '&b%s, belonging to %s, has been captured by %s!'
 
 #Subverting
 
 msg_peaceful_town_subverted: "&b%s has been peacefully subverted and captured by %s."
-msg_err_cannot_subvert_town_already_occupied: "&cThere is no need to subvert this town, because your nation already owns it."
-
+msg_err_cannot_subvert_town_already_occupied: "&cThere is no need to subvert this town, because your nation already owns and occupies it."
 #Surrendering Defence
 
 msg_revolt_siege_defender_surrender: '&bREVOLT SIEGE at %s > The former occupying army, belonging to %s, has admitted defeat and retreated from the town.'
@@ -563,8 +552,19 @@ msg_revolt_siege_defender_surrender: '&bREVOLT SIEGE at %s > The former occupyin
 
 msg_revolt_siege_started: '&bThe townspeople of %s have risen up against the occupying nation of %s, and declared themselves free to choose their own destiny. A REVOLT SIEGE has begun!'
 msg_err_neutral_towns_cannot_revolt: '&cPeaceful towns cannot revolt'
-msg_swa_town_occupation_change_success: '&bSuccessfully changed the occupation status of %s to %s.'
 
 #swa
 
-msg_err_command_not_allowed_on_active_siege: "You cannot run this command unless the siege has ended."
+msg_swa_set_invade_success: '&bSet captured to %s for %s.'
+msg_swa_town_occupation_change_success: '&bSuccessfully changed the occupation status of %s to %s.'
+msg_err_command_not_allowed_on_active_siege: "You cannot run this command unless the siege has ended"
+
+#Town Screen
+
+status_town_siege_status_invaded: '   &2Town Captured: %s'
+
+#Capture
+
+msg_err_cannot_invade_without_victory: "&cYou cannot capture this town unless your nation is victorious in the siege."
+msg_err_cannot_invade_siege_still_in_progress: '&cYou cannot capture this town while the siege is still in progress.'
+msg_err_cannot_invade_town_already_occupied: '&cThere is no need to capture this town, because your nation already owns and occupies it.'


### PR DESCRIPTION
#### Description:
- *WARNING* Not reviewable until the PR 723 is merged
- This small PR changes the terminology of "Invaded" to "Captured", as "Captured" feels like a more intuitive description given the recent simplification of the occuopation system.

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A


____
- [N/A changes were too low risk] I have tested this pull request for defects on a server. 

```
By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
****