### PR TITLE
War-sickness improvements

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -334,4 +334,13 @@ public class SiegeWarDistanceUtil {
 	private static boolean isTownTooFarFromNationCapitalByWorld(Nation nation, Town town) throws TownyException {
 		return TownySettings.getNationRequiresProximity() > 0 && !nation.getCapital().getHomeBlock().getWorld().getName().equals(town.getHomeBlock().getWorld().getName());
 	}
+
+	public static boolean isInANonBesiegedTown(Location location) {
+		Town town = TownyAPI.getInstance().getTown(location);
+		if(town != null & !SiegeController.hasActiveSiege(town)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
@@ -41,10 +41,12 @@ public class SiegeWarSicknessUtil {
             // Players immune to war nausea won't be punished
             if (player.isOp() || player.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_IMMUNE_TO_WAR_NAUSEA.getNode()))
                 continue;
+
             // check if in a siege zone
             Siege siege = SiegeController.getActiveSiegeAtLocation(location);
             if (siege == null)
                 continue;
+
             Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
             if (resident == null)
                 continue;
@@ -68,6 +70,7 @@ public class SiegeWarSicknessUtil {
             }
         }
     }
+
     /**
      * Give player full war sickness, with a warning beforehand
      *
@@ -85,6 +88,7 @@ public class SiegeWarSicknessUtil {
             int warningDurationInSeconds,
             Translatable warningTranslatable,
             Translatable punishmentTranslatable) {
+
         if(!playersWithFullWarSickness.contains(player)) {
             //Send warning
             if (warningDurationInSeconds >= 1)
@@ -109,6 +113,7 @@ public class SiegeWarSicknessUtil {
             }
         }, warningDurationInSeconds * 20);
     }
+
     /**
      * Give player full war sickness effects now
      * @param player the player
@@ -124,6 +129,7 @@ public class SiegeWarSicknessUtil {
         player.addPotionEffects(potionEffects);
         player.setHealth(1);
     }
+
     /**
      * Give player special war sickness effects now
      * @param player the player

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
@@ -34,7 +34,7 @@ public class SiegeWarSicknessUtil {
      */
     public static void evaluateWarSickness() {
         boolean nonOfficialLimiterEnabled = SiegeWarSettings.getPunishingNonSiegeParticipantsInSiegeZone();
-
+        
         for (Player player : Bukkit.getOnlinePlayers()) {
             Location location = player.getLocation();
 
@@ -60,12 +60,12 @@ public class SiegeWarSicknessUtil {
                     //Full war sickness
                     int warningDurationInSeconds = SiegeWarSettings.getNonResidentSicknessWarningTimeSeconds();
                     givePlayerFullWarSicknessWithWarning(
-                            player,
-                            resident,
-                            siege,
-                            warningDurationInSeconds,
-                            Translatable.of("msg_you_will_get_sickness", warningDurationInSeconds),
-                            Translatable.of("msg_you_received_war_sickness"));
+                        player, 
+                        resident,
+                        siege,
+                        warningDurationInSeconds,
+                        Translatable.of("msg_you_will_get_sickness", warningDurationInSeconds),
+                        Translatable.of("msg_you_received_war_sickness"));
                 }
             }
         }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
@@ -60,7 +60,7 @@ public class SiegeWarSicknessUtil {
                     //Full war sickness
                     int warningDurationInSeconds = SiegeWarSettings.getNonResidentSicknessWarningTimeSeconds();
                     givePlayerFullWarSicknessWithWarning(
-                        player, 
+                        player,
                         resident,
                         siege,
                         warningDurationInSeconds,
@@ -148,6 +148,7 @@ public class SiegeWarSicknessUtil {
             return false;
 
         SiegeSide siegeSide = SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, TownyAPI.getInstance().getResidentTownOrNull(resident), siege);
+
         return siegeSide != SiegeSide.NOBODY;
     }
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -583,4 +583,3 @@ status_town_siege_status_invaded: '   &2Town Captured: %s'
 msg_err_cannot_invade_without_victory: "&cYou cannot capture this town unless your nation is victorious in the siege."
 msg_err_cannot_invade_siege_still_in_progress: '&cYou cannot capture this town while the siege is still in progress.'
 msg_err_cannot_invade_town_already_occupied: '&cThere is no need to capture this town, because your nation already owns and occupies it.'
-

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -134,7 +134,6 @@ dynmap_siege_time_left: 'Time Left: %s'
 #Added in 0.06:
 msg_inventory_degrade_warning: '&4WARNING: &cSome of your gear is close to breaking due to inventory degradation.'
 msg_swa_remove_siege_success: '&bSuccessfully removed siege.'
-msg_you_will_get_sickness: '&cYou are not a participant of this siege and cannot be in the Siege Zone. Please leave or you will receive war sickness in %s seconds.'
 
 #Added in 0.08:
 msg_swa_set_towns_gained_success: '&bSuccessfully set towns gained to %d for %s.'
@@ -522,8 +521,8 @@ msg_err_cannot_subvert_town_already_occupied: "&cThere is no need to subvert thi
 msg_revolt_siege_started: '&bThe townspeople of %s have risen up against the occupying nation of %s, and declared themselves free to choose their own destiny. A REVOLT SIEGE has begun!'
 
 #war sickness
-
-msg_you_received_war_sickness: '&cYou are not a participant of this siege and cannot be in the Siege Zone. Please leave to remove the war sickness. Common causes of war sickness: being in a peaceful town, not having a military rank or not being allied to either side.'
+msg_you_will_get_sickness: '&cYou are not an official participant of this siege and cannot be in the Siege Zone. Please leave or you will receive war sickness in %s seconds.'
+msg_you_received_war_sickness: '&cYou are not an official participant of this siege and cannot be in the Siege Zone. Please leave to remove the war sickness. Common causes of war sickness: Not having a military rank or not being allied to either side.'
 
 #Town Status Screen
 
@@ -534,11 +533,11 @@ status_town_peacefulness_status_change_timer: '&2Countdown To Peaceful Status Ch
 
 msg_war_common_town_declared_peaceful: '&bNPeacefulness Declared! The town will be confirmed as Peaceful in %d day(s).'
 msg_war_common_town_declared_non_peaceful: '&bNon-Peacefulness Declared! The town will be confirmed as Non-Peaceful in %d day(s).'
-msg_town_became_peaceful: '&b%s has been confirmed as Peaceful. The town is now immune to siege attacks, but vulnerable to getting subverted by nearby nations. Residents cannot enter siege-zones or gain nation-military ranks.'
-msg_town_became_non_peaceful: '&b%s has been confirmed as Non-Peaceful. The town is no longer immune to siege attacks, and no longer vulnerable to getting subverted by nearby nations. Residents can enter siege-zones and gain nation-military ranks.'
+msg_town_became_peaceful: '&b%s has been confirmed as Peaceful. The town is now immune to siege attacks, but vulnerable to getting subverted by nearby nations. Residents cannot gain nation-military ranks.'
+msg_town_became_non_peaceful: '&b%s has been confirmed as Non-Peaceful. The town is no longer immune to siege attacks, and no longer vulnerable to getting subverted by nearby nations. Residents can now gain nation-military ranks.'
 msg_war_common_town_peacefulness_countdown_cancelled: '&bThe Peaceful status change countdown was cancelled.'
-msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident: '&cUnable to add military rank to resident, because they are in a Peaceful town.'
-msg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."
+msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident: '&cUnable to add nation military rank to resident, because they belong to a Peaceful town.'
+sg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."
 msg_err_peaceful_towns_cannot_revolt: '&cPeaceful towns cannot revolt'
 
 #Nation Peacefulness
@@ -584,3 +583,4 @@ status_town_siege_status_invaded: '   &2Town Captured: %s'
 msg_err_cannot_invade_without_victory: "&cYou cannot capture this town unless your nation is victorious in the siege."
 msg_err_cannot_invade_siege_still_in_progress: '&cYou cannot capture this town while the siege is still in progress.'
 msg_err_cannot_invade_town_already_occupied: '&cThere is no need to capture this town, because your nation already owns and occupies it.'
+


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
- *WARNING* Not reviewable until the PR 732 is merged
- Given that Ceedric's non-official-participant war sickness is now de-rigeur, and that peaceful town residents cannot be official participants due to not having nation rank,  this means that any specific code for "peaceful town war sickness" is now effectively redundant and can be removed.
- This PR does this
- It also tweaks the rules around war sickness,  so that any unofficial-participant in a non-besieged town only gets special war sickness. This is expected to particularly help peaceful shop towns, to stop their customer's getting overly sick due to nearby sieges.

____
#### New Nodes/Commands/ConfigOptions: 

____
#### Relevant Issue ticket:

____
- [N/A low risk] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
