### PR TITLE
Remove restriction of prevening siege-starting by residents of towns with is !isAllowedToWar

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -295,6 +295,9 @@ public class PlaceBlock {
 														   TownBlock nearbyTownBlock,
 														   Town nearbyTown,
 														   Block bannerBlock) throws TownyException {
+		if(!nearbyTown.isAllowedToWar())
+			throw new TownyException(Translatable.of("msg_err_this_town_is_not_allowed_to_be_attacked"));
+
 		if(nearbyTown.isNeutral()) {
 			//Town is peaceful, so this action is a subversion or peaceful-revolt attempt
 			if(residentsTown == nearbyTown) {

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -197,9 +197,6 @@ public class PlaceBlock {
 		Town residentsTown = resident.getTownOrNull();
 		Nation residentsNation = resident.getNationOrNull();
 		
-		if (!residentsTown.isAllowedToWar())
-			throw new TownyException(translator.of("msg_err_your_town_is_not_allowed_to_start_a_siege"));
-
 		//Ensure there is at least 1 adjacent town
 		List<TownBlock> adjacentCardinalTownBlocks = SiegeWarBlockUtil.getCardinalAdjacentTownBlocks(block);
 		List<TownBlock> adjacentNonCardinalTownBlocks = SiegeWarBlockUtil.getNonCardinalAdjacentTownBlocks(block);
@@ -298,9 +295,6 @@ public class PlaceBlock {
 														   TownBlock nearbyTownBlock,
 														   Town nearbyTown,
 														   Block bannerBlock) throws TownyException {
-		if(!nearbyTown.isAllowedToWar())
-			throw new TownyException(Translatable.of("msg_err_this_town_is_not_allowed_to_be_sieged"));
-
 		if(nearbyTown.isNeutral()) {
 			//Town is peaceful, so this action is a subversion or peaceful-revolt attempt
 			if(residentsTown == nearbyTown) {

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -440,12 +440,6 @@ msg_err_besieged_capital_cannot_change_king: "&cYour nation is not allowed to ch
 #Shown when a siege assembly is started in a town which already has a siege assembly.
 msg_err_town_already_has_a_siege_assembly: '&cThis town already has an active Siege Assembly.'
 
-#Shown when a town cannot start a siege because of their isAllowedToWar setting.
-msg_err_your_town_is_not_allowed_to_start_a_siege: 'Your town is not allowed to start sieges because they are not allowed to war.'
-
-#Shown when a town cannot start a siege because of the target town's isAllowedToWar setting.
-msg_err_this_town_is_not_allowed_to_be_sieged: 'You cannot siege this Town because they are not allowed to war.'
-
 #Shown when a nation cannot afford to start a siege.
 msg_err_you_cannot_afford_to_siege_for_x: "Your nation cannot afford to begin this Siege, it would cost %s."
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -440,6 +440,9 @@ msg_err_besieged_capital_cannot_change_king: "&cYour nation is not allowed to ch
 #Shown when a siege assembly is started in a town which already has a siege assembly.
 msg_err_town_already_has_a_siege_assembly: '&cThis town already has an active Siege Assembly.'
 
+#Shown when a town cannot be sieged or subverted because of the target town's isAllowedToWar setting.
+msg_err_this_town_is_not_allowed_to_be_attacked: 'You cannot siege or subvert this town, because they are not allowed to war.'
+
 #Shown when a nation cannot afford to start a siege.
 msg_err_you_cannot_afford_to_siege_for_x: "Your nation cannot afford to begin this Siege, it would cost %s."
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
- town.isAllowedToWar() is used for towny capture sites, and admin/spawn towns, to protect those towns.
- It makes sense that SiegeWar should respect those protections
- However there doesn't appear to be any scenario, where it makes sense to restrict players from those towns from starting sieges. Example: admins from admin towns will actually sometimes want to start test sieges.
- Thus this PR removes that start-siege restriction.

____
#### New Nodes/Commands/ConfigOptions: 


____
#### Relevant Issue ticket:

____
- [N/A too trivial] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
