### PR TITLE
Move peaceful town flag into SiegeWar metadata

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -6,6 +6,7 @@ import com.gmail.goosius.siegewar.metadata.ResidentMetaDataController;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -90,8 +91,9 @@ public class SiegeWar extends JavaPlugin {
 		registerPlayerCommands();
 		registerListeners();
 		checkIntegrations();
-		migrateTownOccupationData();
+		migrateTownOccupationData(); //Keep this line before deleteLegacyMetadata
 		deleteLegacyMetaData();
+		migrateTownNeutralityData();
 
 
 		if(siegeWarPluginError) {
@@ -280,5 +282,31 @@ public class SiegeWar extends JavaPlugin {
 		}
 		if (success)
 			SiegeWar.info("Old Town Occupation Data migrated...");
+	}
+
+	/**
+	 * In some previous SW versions,
+	 * the towny "neutral" flag was being re-used/hijacked to indicate peacefulness
+	 * -
+	 * However this was not suitable for either SW or Towny, because:
+	 * 1. The indicated Towny flag comes with an extra monetary cost which interfered with SW's system balance.
+	 * 2. The hijacking forced towny to support duplicate commands like /t toggle neutral, and /t toggle peaceful
+	 * -
+	 * This method migrates the old data,
+	 * so that if a town is found with neutral=true,
+	 * that town will be set to neutral=false, and the appropriate SW peaceful metadata flag will be set.
+	 * -
+	 */
+	public static void migrateTownNeutralityData() {
+		boolean success = false;
+		for(Town town: new ArrayList<>(TownyAPI.getInstance().getTowns())) {
+			if(town.isNeutral()) {
+				TownPeacefulnessUtil.setPeacefulness(town, true);
+				town.setNeutral(false);
+				success = true;
+			}
+		}
+		if (success)
+			SiegeWar.info("Old Town Neutrality Data migrated...");
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -44,7 +44,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 	private static final List<String> siegewaradminSiegeImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
 	private static final List<String> siegewaradminRevoltImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
 	private static final List<String> siegewaradminSiegeTabCompletes = Arrays.asList("setbalance","end","setplundered","setinvaded","remove");
-	private static final List<String> siegewaradminTownTabCompletes = Arrays.asList("setpeaceful, setoccupied");
+	private static final List<String> siegewaradminTownTabCompletes = Arrays.asList("setpeaceful", "setoccupied");
 	private static final List<String> siegewaradminNationTabCompletes = Arrays.asList("setplundergained","setplunderlost","settownsgained","settownslost");
 	private static final List<String> siegewaradminBattleSessionTabCompletes = Arrays.asList("end","start");
 	private static final List<String> siegeDurationTabCompletes = Arrays.asList("addhours");

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -121,6 +121,9 @@ public class SiegeWarAdminCommand implements TabExecutor {
 				if (args[2].equalsIgnoreCase("setoccupied")) {
 					return Arrays.asList("true","false");
 				}
+				if (args[2].equalsIgnoreCase("setpeaceful")) {
+					return Arrays.asList("true","false");
+				}
 			}
 		case "nation":
 			if (args.length == 2)

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -13,6 +13,7 @@ import com.gmail.goosius.siegewar.settings.Settings;
 import com.gmail.goosius.siegewar.timeractions.AttackerTimedWin;
 import com.gmail.goosius.siegewar.timeractions.DefenderTimedWin;
 import com.gmail.goosius.siegewar.utils.SiegeWarBattleSessionUtil;
+import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
 import com.palmergames.bukkit.config.CommentedConfiguration;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
@@ -43,7 +44,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 	private static final List<String> siegewaradminSiegeImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
 	private static final List<String> siegewaradminRevoltImmunityTabCompletes = Arrays.asList("town","nation","alltowns");
 	private static final List<String> siegewaradminSiegeTabCompletes = Arrays.asList("setbalance","end","setplundered","setinvaded","remove");
-	private static final List<String> siegewaradminTownTabCompletes = Arrays.asList("setoccupied");
+	private static final List<String> siegewaradminTownTabCompletes = Arrays.asList("setpeaceful, setoccupied");
 	private static final List<String> siegewaradminNationTabCompletes = Arrays.asList("setplundergained","setplunderlost","settownsgained","settownslost");
 	private static final List<String> siegewaradminBattleSessionTabCompletes = Arrays.asList("end","start");
 	private static final List<String> siegeDurationTabCompletes = Arrays.asList("addhours");
@@ -373,6 +374,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/swa", "siege [town_name] end", ""));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/swa", "siege [town_name] setplundered [true/false]", ""));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/swa", "siege [town_name] remove", ""));
+		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/swa", "town [town_name] setpeaceful [true/false]", ""));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/swa", "town [town_name] setoccupied [true/false]", ""));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/swa", "nation [nation_name] setplundergained [amount]", ""));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/swa", "nation [nation_name] setplunderlost [amount]", ""));
@@ -411,6 +413,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 
 	private void showTownHelp(CommandSender sender) {
 		TownyMessaging.sendMessage(sender, ChatTools.formatTitle("/swa town"));
+		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/swa", "town [town_name] setpeaceful [true/false]", ""));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/swa", "town [town_name] setoccupied [true/false]", ""));
 	}
 
@@ -690,17 +693,29 @@ public class SiegeWarAdminCommand implements TabExecutor {
 				Messaging.sendErrorMsg(sender, Translatable.of("msg_err_town_not_registered", args[0]));
 				return;
 			}
-			if(!args[1].equalsIgnoreCase("setoccupied")) {
-				showSiegeHelp(sender);
-				return;
+			switch(args[1].toLowerCase()) {
+				case "setpeaceful":
+					//set peaceful flag
+					boolean peaceful = Boolean.parseBoolean(args[2]);
+					TownPeacefulnessUtil.setPeacefulness(town, peaceful);
+					//Save data
+					town.save();
+					//Send message
+					Messaging.sendMsg(sender, Translatable.of("msg_swa_town_peacefulness_change_success", town.getName(), Boolean.toString(peaceful)));
+					break;
+				case "setoccupied":
+					//set occupied flag
+					boolean occupied = Boolean.parseBoolean(args[2]);
+					town.setConquered(occupied);
+					//Save data
+					town.save();
+					//Send message
+					Messaging.sendMsg(sender, Translatable.of("msg_swa_town_occupation_change_success", town.getName(), Boolean.toString(occupied)));
+					break;
+				default:
+					showSiegeHelp(sender);
+					return;
 			}
-			//set occupied flag
-			boolean occupied = Boolean.parseBoolean(args[2]);
-			town.setConquered(occupied);
-			//Save data
-			town.save();
-			//Send message
-			Messaging.sendMsg(sender, Translatable.of("msg_swa_town_occupation_change_success", town.getName(), Boolean.toString(occupied)));
 		} else
 			showTownHelp(sender);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -10,6 +10,7 @@ import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.BossBarUtil;
 import com.gmail.goosius.siegewar.utils.CosmeticUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
+import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyMessaging;
@@ -36,6 +37,8 @@ import java.util.*;
 public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 	
 	private static final List<String> siegewarTabCompletes = Arrays.asList("collect", "town", "nation", "hud", "preference", "version", "nextsession");
+
+	private static final List<String> siegewarTownTabCompletes = Arrays.asList("togglepeaceful");
 	
 	private static final List<String> siegewarNationTabCompletes = Arrays.asList("paysoldiers", "claimrefund");
 
@@ -47,6 +50,10 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 			case "nation":
 				if (args.length == 2)
 					return NameUtil.filterByStart(siegewarNationTabCompletes, args[1]);
+				break;
+			case "town":
+				if (args.length == 2)
+					return NameUtil.filterByStart(siegewarTownTabCompletes, args[1]);
 				break;
 			case "hud":
 				if (args.length == 2)
@@ -72,6 +79,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw collect", "", Translatable.of("nation_help_11").forLocale(sender)));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw nation", "paysoldiers [amount]", Translatable.of("nation_help_12").forLocale(sender)));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw nation", "claimrefund [amount]", Translatable.of("nation_help_refund").forLocale(sender)));
+		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw town", "togglepeaceful", Translatable.of("town_help_toggle_peaceful").forLocale(sender)));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw preference", "beacons [on/off]", ""));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw nextsession", "", ""));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw version", "", ""));
@@ -81,6 +89,11 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 		TownyMessaging.sendMessage(sender, ChatTools.formatTitle("/siegewar nation"));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw nation", "paysoldiers [amount]", Translatable.of("nation_help_12").forLocale(sender)));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw nation", "claimrefund [amount]", Translatable.of("nation_help_refund").forLocale(sender)));
+	}
+
+	private void showTownHelp(CommandSender sender) {
+		TownyMessaging.sendMessage(sender, ChatTools.formatTitle("/siegewar town"));
+		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw town", "togglepeaceful", Translatable.of("town_help_toggle_peaceful").forLocale(sender)));
 	}
 
 	private void showPreferenceHelp(CommandSender sender) {
@@ -115,6 +128,9 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 		case "focus":
 		case "hud":
 			parseSiegeWarHudCommand(player, StringMgmt.remFirstArg(args));
+			break;
+		case "town":
+			parseSiegeWarTownCommand(player, StringMgmt.remFirstArg(args));
 			break;
 		case "nation":
 			parseSiegeWarNationCommand(player, StringMgmt.remFirstArg(args));
@@ -282,6 +298,27 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 
 			default:
 				showNationHelp(player);
+		}
+	}
+
+	private void parseSiegeWarTownCommand(Player player, String[] args) {
+		if (!player.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_COMMAND_SIEGEWAR_TOWN.getNode(args[0]))) {
+			player.sendMessage(Translatable.of("msg_err_command_disable").forLocale(player));
+			return;
+		}
+
+		switch (args[0]) {
+
+			case "togglepeaceful":
+				if (args.length != 1) {
+					showTownHelp(player);
+					return;
+				}
+				TownPeacefulnessUtil.toggleTownPeacefulness(player);
+				break;
+
+			default:
+				showTownHelp(player);
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
@@ -34,14 +34,15 @@ public enum SiegeWarPermissionNodes {
 	
 	// ----- Player Command Nodes -----
 	SIEGEWAR_COMMAND_SIEGEWAR("siegewar.command.siegewar.*"),
-		SIEGEWAR_COMMAND_SIEGEWAR_TOWN("siegewar.command.siegewar.town.*"),
-		SIEGEWAR_COMMAND_SIEGEWAR_NATION("siegewar.command.siegewar.nation.*"),
-			SIEGEWAR_COMMAND_SIEGEWAR_NATION_PAYSOLDIERS("siegewar.command.siegewar.nation.paysoldiers"),
-			SIEGEWAR_COMMAND_SIEGEWAR_NATION_CLAIMREFUND("siegewar.command.siegewar.nation.claimrefund"),
-		SIEGEWAR_COMMAND_SIEGEWAR_COLLECT("siegewar.command.siegewar.collect"),
-		SIEGEWAR_COMMAND_SIEGEWAR_HUD("siegewar.command.siegewar.hud"),
-		SIEGEWAR_COMMAND_SIEGEWAR_PREFERENCE("siegewar.command.siegewar.preference"),
-		SIEGEWAR_COMMAND_SIEGEWAR_NEXTSESSION("siegewar.command.siegewar.nextsession"),
+	SIEGEWAR_COMMAND_SIEGEWAR_TOWN("siegewar.command.siegewar.town.*"),
+		SIEGEWAR_COMMAND_SIEGEWAR_TOWN_TOGGLEPEACEFUL("siegewar.command.siegewar.town.togglepeaceful"),
+	SIEGEWAR_COMMAND_SIEGEWAR_NATION("siegewar.command.siegewar.nation.*"),
+		SIEGEWAR_COMMAND_SIEGEWAR_NATION_PAYSOLDIERS("siegewar.command.siegewar.nation.paysoldiers"),
+		SIEGEWAR_COMMAND_SIEGEWAR_NATION_CLAIMREFUND("siegewar.command.siegewar.nation.claimrefund"),
+	SIEGEWAR_COMMAND_SIEGEWAR_COLLECT("siegewar.command.siegewar.collect"),
+	SIEGEWAR_COMMAND_SIEGEWAR_HUD("siegewar.command.siegewar.hud"),
+	SIEGEWAR_COMMAND_SIEGEWAR_PREFERENCE("siegewar.command.siegewar.preference"),
+	SIEGEWAR_COMMAND_SIEGEWAR_NEXTSESSION("siegewar.command.siegewar.nextsession"),
 
 	// ----- Admin Command Nodes -----
 	SIEGEWAR_COMMAND_SIEGEWARADMIN("siegewar.command.siegewaradmin.*"),

--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
@@ -34,6 +34,7 @@ public enum SiegeWarPermissionNodes {
 	
 	// ----- Player Command Nodes -----
 	SIEGEWAR_COMMAND_SIEGEWAR("siegewar.command.siegewar.*"),
+		SIEGEWAR_COMMAND_SIEGEWAR_TOWN("siegewar.command.siegewar.town.*"),
 		SIEGEWAR_COMMAND_SIEGEWAR_NATION("siegewar.command.siegewar.nation.*"),
 			SIEGEWAR_COMMAND_SIEGEWAR_NATION_PAYSOLDIERS("siegewar.command.siegewar.nation.paysoldiers"),
 			SIEGEWAR_COMMAND_SIEGEWAR_NATION_CLAIMREFUND("siegewar.command.siegewar.nation.claimrefund"),

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -161,7 +161,7 @@ public class SiegeWarNationEventListener implements Listener {
 
 		if (event.getFutureState()) {
 			event.setCancelled(true);
-			event.setCancelMessage(Translation.of("msg_err_nation_peacefulness_not_supported"));
+			event.setCancelMessage(Translation.of("msg_err_nation_neutrality_not_supported"));
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -7,6 +7,7 @@ import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.PermissionUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
+import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.event.NationPreRemoveEnemyEvent;
 import com.palmergames.bukkit.towny.event.DeleteNationEvent;
@@ -35,7 +36,7 @@ public class SiegeWarNationEventListener implements Listener {
 		if(SiegeWarSettings.getWarSiegeEnabled()
 			&& SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
 			&& PermissionUtil.doesNationRankAllowPermissionNode(event.getRank(), SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS)
-			&& TownyAPI.getInstance().getResidentTownOrNull(event.getResident()).isNeutral()) { // We know that the resident's town will not be null based on the tests already done.
+			&& TownPeacefulnessUtil.isTownPeaceful(TownyAPI.getInstance().getResidentTownOrNull(event.getResident()))) { // We know that the resident's town will not be null based on the tests already done.
 			event.setCancelled(true);
 			event.setCancelMessage(Translation.of("siegewar_plugin_prefix") + Translation.of("msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident"));
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -147,7 +147,7 @@ public class SiegeWarStatusScreenListener implements Listener {
 					event.getStatusScreen().addComponentOf("siegeWarOccupationTax", comp);
 				}
 			}
-
+			
 			if (TownMetaDataController.hasPlunderDebt(town)) {
 				int days = TownMetaDataController.getPlunderDebtDays(town);
 				double amount = TownMetaDataController.getDailyPlunderDebt(town);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -147,7 +147,6 @@ public class SiegeWarStatusScreenListener implements Listener {
 					event.getStatusScreen().addComponentOf("siegeWarOccupationTax", comp);
 				}
 			}
-			
 
 			if (TownMetaDataController.hasPlunderDebt(town)) {
 				int days = TownMetaDataController.getPlunderDebtDays(town);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.gmail.goosius.siegewar.TownOccupationController;
+import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
@@ -112,6 +113,11 @@ public class SiegeWarStatusScreenListener implements Listener {
 			
 			Town town = event.getTown();
 
+			if(TownPeacefulnessUtil.isTownPeaceful(town)) {
+				Component peacefulnessFlag = Component.text(translator.of("status_town_peacefulness_flag"));
+				event.getStatusScreen().addComponentOf("subtitle", peacefulnessFlag);
+			}
+
 			if(TownyEconomyHandler.isActive() && TownOccupationController.isTownOccupied(town)) {
 				double occupationTax = TownOccupationController.getNationOccupationTax(town);
 				if (occupationTax > 0) {
@@ -121,6 +127,7 @@ public class SiegeWarStatusScreenListener implements Listener {
 				}
 			}
 			
+
 			if (TownMetaDataController.hasPlunderDebt(town)) {
 				int days = TownMetaDataController.getPlunderDebtDays(town);
 				double amount = TownMetaDataController.getDailyPlunderDebt(town);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -10,6 +10,7 @@ import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.PermissionUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
+import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.event.DeleteTownEvent;
@@ -123,7 +124,7 @@ public class SiegeWarTownEventListener implements Listener {
 			if (TownMetaDataController.getPeacefulnessChangeConfirmationCounterDays(town) == 0) {
 				
 				//Here, no countdown is in progress, and the town wishes to change peacefulness status
-				TownMetaDataController.setDesiredPeacefulnessSetting(town, !town.isNeutral());
+				TownMetaDataController.setDesiredPeacefulnessSetting(town, !TownPeacefulnessUtil.isTownPeaceful(town));
 				TownMetaDataController.setPeacefulnessChangeDays(town, days);
 				
 				//Send message to town
@@ -145,7 +146,7 @@ public class SiegeWarTownEventListener implements Listener {
 				
 			} else {
 				//Here, a countdown is in progress, and the town wishes to cancel the countdown,
-				TownMetaDataController.setDesiredPeacefulnessSetting(town, town.isNeutral());
+				TownMetaDataController.setDesiredPeacefulnessSetting(town, TownPeacefulnessUtil.isTownPeaceful(town));
 				TownMetaDataController.setPeacefulnessChangeDays(town, 0);
 				//Send message to town
 				TownyMessaging.sendPrefixedTownMessage(town, String.format(Translation.of("msg_war_common_town_peacefulness_countdown_cancelled")));				
@@ -227,7 +228,7 @@ public class SiegeWarTownEventListener implements Listener {
 	public void on(TownPreSetHomeBlockEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			if(SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
-				&& event.getTown().isNeutral()) {
+				&& TownPeacefulnessUtil.isTownPeaceful(event.getTown())) {
 				event.setCancelled(true);
 				event.setCancelMessage(Translation.of("siegewar_plugin_prefix") + Translation.of("msg_err_peaceful_town_cannot_move_homeblock"));
 			}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -17,6 +17,7 @@ import com.palmergames.bukkit.towny.event.DeleteTownEvent;
 import com.palmergames.bukkit.towny.event.NewTownEvent;
 import com.palmergames.bukkit.towny.event.TownPreAddResidentEvent;
 import com.palmergames.bukkit.towny.event.TownPreClaimEvent;
+import com.palmergames.bukkit.towny.event.nation.toggle.NationToggleNeutralEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreMergeEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreUnclaimCmdEvent;
 import com.palmergames.bukkit.towny.event.town.TownRuinedEvent;
@@ -82,77 +83,6 @@ public class SiegeWarTownEventListener implements Listener {
 			TownMetaDataController.setSiegeImmunityEndTime(town, System.currentTimeMillis() + (long)(SiegeWarSettings.getWarSiegeSiegeImmunityTimeNewTownsHours() * TimeMgmt.ONE_HOUR_IN_MILLIS));
 			TownMetaDataController.setDesiredPeacefulnessSetting(town, TownySettings.getTownDefaultNeutral());
 			town.save();
-		}
-	}
-
-	/*
-	 * On toggle neutral, SW will evaluate a number of things.
-	 */
-	@EventHandler (ignoreCancelled = true)
-	public void onTownToggleNeutral(TownToggleNeutralEvent event) {
-		if (!SiegeWarSettings.getWarSiegeEnabled())
-			return;
-		
-		if(!SiegeWarSettings.getWarCommonPeacefulTownsEnabled() && !event.isAdminAction()) {
-			event.setCancelMessage(Translation.of("msg_err_command_disable"));
-			event.setCancelled(true);
-			return;
-		}
-		
-		// Check if we're becoming peaceful, a capital city and capitals cannot become peaceful. 
-		if (event.getFutureState() && event.getTown().isCapital() 
-				&& !SiegeWarSettings.capitalsAllowedTownPeacefulness() && !event.isAdminAction()) {
-			event.setCancelMessage(Translation.of("msg_err_command_disable"));
-			event.setCancelled(true);
-			return;
-		}
-		
-		Town town = event.getTown();
-		
-		if (event.isAdminAction()) {
-			TownMetaDataController.setDesiredPeacefulnessSetting(town, event.getFutureState());
-			TownMetaDataController.setPeacefulnessChangeDays(town, 0);
-			return;
-		} else {
-			int days;
-			if(System.currentTimeMillis() < (town.getRegistered() + (TimeMgmt.ONE_DAY_IN_MILLIS * 7))) {
-				days = SiegeWarSettings.getWarCommonPeacefulTownsNewTownConfirmationRequirementDays();
-			} else {
-				days = SiegeWarSettings.getWarCommonPeacefulTownsConfirmationRequirementDays();
-			}
-			
-			if (TownMetaDataController.getPeacefulnessChangeConfirmationCounterDays(town) == 0) {
-				
-				//Here, no countdown is in progress, and the town wishes to change peacefulness status
-				TownMetaDataController.setDesiredPeacefulnessSetting(town, !TownPeacefulnessUtil.isTownPeaceful(town));
-				TownMetaDataController.setPeacefulnessChangeDays(town, days);
-				
-				//Send message to town
-				if (TownMetaDataController.getDesiredPeacefulnessSetting(town))
-					TownyMessaging.sendPrefixedTownMessage(town, String.format(Translation.of("msg_war_common_town_declared_peaceful"), days));
-				else
-					TownyMessaging.sendPrefixedTownMessage(town, String.format(Translation.of("msg_war_common_town_declared_non_peaceful"), days));
-				
-				//Remove any military nation ranks of residents
-				for(Resident peacefulTownResident: town.getResidents()) {
-					for (String nationRank : new ArrayList<>(peacefulTownResident.getNationRanks())) {
-						if (PermissionUtil.doesNationRankAllowPermissionNode(nationRank, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS)) {
-							peacefulTownResident.removeNationRank(nationRank);
-						}
-					}
-				}
-				event.setCancelMessage(Translation.of("siegewar_plugin_prefix") + Translation.of("status_town_peacefulness_status_change_timer", days));
-				event.setCancelled(true);
-				
-			} else {
-				//Here, a countdown is in progress, and the town wishes to cancel the countdown,
-				TownMetaDataController.setDesiredPeacefulnessSetting(town, TownPeacefulnessUtil.isTownPeaceful(town));
-				TownMetaDataController.setPeacefulnessChangeDays(town, 0);
-				//Send message to town
-				TownyMessaging.sendPrefixedTownMessage(town, String.format(Translation.of("msg_war_common_town_peacefulness_countdown_cancelled")));				
-				event.setCancelMessage(Translation.of("msg_war_common_town_peacefulness_countdown_cancelled"));
-				event.setCancelled(true);
-			}
 		}
 	}
 
@@ -267,6 +197,23 @@ public class SiegeWarTownEventListener implements Listener {
 		if(TownOccupationController.isTownOccupied(event.getTown())) {
 			String mapColorHexCode = TownOccupationController.getTownOccupier(event.getTown()).getMapColorHexCode();
 			event.setMapColorHexCode(mapColorHexCode);
+		}
+	}
+
+	/**
+	 * Prevents nations using /n toggle neutral
+	 * - Because in SW this has no effect
+	 *
+	 * @param event the event
+	 */
+	@EventHandler(ignoreCancelled = true)
+	public void on(TownToggleNeutralEvent event) {
+		if(!SiegeWarSettings.getWarSiegeEnabled())
+			return;
+
+		if (event.getFutureState()) {
+			event.setCancelled(true);
+			event.setCancelMessage(Translation.of("msg_err_town_neutrality_not_supported"));
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
@@ -20,7 +20,6 @@ public class TownMetaDataController {
 
 	@SuppressWarnings("unused")
 	private SiegeWar plugin;
-	
 	private static IntegerDataField peacefulnessChangeConfirmationCounterDays = new IntegerDataField("siegewar_peacefuldays", 0, Translation.of("status_town_days_to_peacefulness_status_change"));
 	private static BooleanDataField desiredPeacefulness = new BooleanDataField("siegewar_desiredPeaceSetting", false);
 	private static BooleanDataField peacefulness = new BooleanDataField("siegewar_peaceSetting", false);

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
@@ -20,8 +20,10 @@ public class TownMetaDataController {
 
 	@SuppressWarnings("unused")
 	private SiegeWar plugin;
+	
 	private static IntegerDataField peacefulnessChangeConfirmationCounterDays = new IntegerDataField("siegewar_peacefuldays", 0, Translation.of("status_town_days_to_peacefulness_status_change"));
 	private static BooleanDataField desiredPeacefulness = new BooleanDataField("siegewar_desiredPeaceSetting", false);
+	private static BooleanDataField peacefulness = new BooleanDataField("siegewar_peaceSetting", false);
 	private static LongDataField revoltImmunityEndTime = new LongDataField("siegewar_revoltImmunityEndTime", 0l);
 	private static LongDataField siegeImmunityEndTime = new LongDataField("siegewar_siegeImmunityEndTime", 0l);
 	private static StringDataField failedCampList = new StringDataField("siegewar_failedCampList", "");
@@ -94,6 +96,23 @@ public class TownMetaDataController {
 			MetaDataUtil.setBoolean(town, bdf, bool, true);
 		} else {
 			town.addMetaData(new BooleanDataField("siegewar_desiredPeaceSetting", bool));
+		}
+	}
+	
+	public static boolean getPeacefulness(Town town) {
+		BooleanDataField bdf = (BooleanDataField) peacefulness.clone();
+		if (town.hasMeta(bdf.getKey())) {
+			return MetaDataUtil.getBoolean(town, bdf);
+		}
+		return false;
+	}
+
+	public static void setPeacefulness(Town town, boolean bool) {
+		BooleanDataField bdf = (BooleanDataField) peacefulness.clone();
+		if (town.hasMeta(bdf.getKey())) {
+			MetaDataUtil.setBoolean(town, bdf, bool, true);
+		} else {
+			town.addMetaData(new BooleanDataField("siegewar_peaceSetting", bool));
 		}
 	}
 	

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -10,6 +10,7 @@ import com.gmail.goosius.siegewar.utils.SiegeWarBlockUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarImmunityUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
+import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
 import com.palmergames.adventure.text.Component;
 import com.palmergames.adventure.text.format.NamedTextColor;
 import com.palmergames.bukkit.towny.TownyAPI;
@@ -237,7 +238,7 @@ public class PlaceBlock {
 		if(!nearbyTown.isAllowedToWar())
 			throw new TownyException(Translatable.of("msg_err_this_town_is_not_allowed_to_be_attacked"));
 
-		if(nearbyTown.isNeutral()) {
+		if(TownPeacefulnessUtil.isTownPeaceful(nearbyTown)) {
 			//Town is peaceful, so this action is a subversion or peaceful-revolt attempt
 			if(residentsTown == nearbyTown) {
 				if(TownOccupationController.isTownOccupied(residentsTown)) {

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/StartRevoltSiege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/StartRevoltSiege.java
@@ -6,6 +6,7 @@ import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.gmail.goosius.siegewar.utils.TownPeacefulnessUtil;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -60,7 +61,7 @@ public class StartRevoltSiege {
         || !TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.getPermissionNodeToStartSiege(SiegeType.REVOLT)))
             throw new TownyException(translator.of("msg_err_action_disable"));
 
-        if(targetTown.isNeutral())
+        if(TownPeacefulnessUtil.isTownPeaceful(targetTown))
             throw new TownyException(translator.of("msg_err_peaceful_towns_cannot_revolt"));
 
         if(!TownOccupationController.isTownOccupied(targetTown))

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -161,7 +161,7 @@ public class SiegeWarBannerControlUtil {
 		if (!resident.hasTown())
 			return false; //Player is a nomad
 
-		if(resident.getTownOrNull().isNeutral())
+		if (TownPeacefulnessUtil.isTownPeaceful(resident.getTownOrNull()))
 			return false; //Player if from a neutral town
 
 		if(player.isFlying() || player.isGliding())

--- a/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/TownPeacefulnessUtil.java
@@ -23,6 +23,15 @@ import java.util.LinkedHashMap;
 
 public class TownPeacefulnessUtil {
 
+	public static boolean isTownPeaceful(Town town) {
+		return TownMetaDataController.getPeacefulness(town);
+	}
+
+	public static void setPeacefulness(Town town, boolean peacefulness) {
+		TownMetaDataController.setPeacefulness(town, peacefulness);
+		town.save();
+	}
+	
 	/**
 	 * This method adjusts the peacefulness counters of all towns, where required
 	 */
@@ -40,7 +49,7 @@ public class TownPeacefulnessUtil {
 			 */
 			if (TownyUniverse.getInstance().hasTown(town.getName()) 
 				&& !town.isRuined()
-				&& town.isNeutral() != TownMetaDataController.getDesiredPeacefulnessSetting(town))
+				&& isTownPeaceful(town) != TownMetaDataController.getDesiredPeacefulnessSetting(town))
 				updateTownPeacefulnessCounters(town);
 		}
 	}
@@ -57,16 +66,18 @@ public class TownPeacefulnessUtil {
 			return;
 		}
 		TownMetaDataController.setPeacefulnessChangeDays(town, 0);
-		town.setNeutral(!town.isNeutral());
+		
+		//Reverse the town peacefulness setting
+		setPeacefulness(town, !isTownPeaceful(town));
 
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
-			if (town.isNeutral()) {
+			if (isTownPeaceful(town)) {
 				message = Translation.of("msg_town_became_peaceful", town.getFormattedName());
 			} else {
 				message = Translation.of("msg_town_became_non_peaceful", town.getFormattedName());
 			}
 		} else {
-			if (town.isNeutral()) {
+			if (isTownPeaceful(town)) {
 				message = Translation.of("msg_town_became_peaceful", town.getFormattedName());
 			} else {
 				message = Translation.of("msg_town_became_non_peaceful", town.getFormattedName());
@@ -101,7 +112,7 @@ public class TownPeacefulnessUtil {
 					continue;
 
 				//Skip if town is peaceful
-				if(town.isNeutral())
+				if(isTownPeaceful(town))
 					continue;
 
 				//Skip if town has no natural or occupying nation

--- a/src/main/resources/global.yml
+++ b/src/main/resources/global.yml
@@ -4,4 +4,3 @@
 
 # Messages can be added like so: (hint: remove the # to uncomment it)
 #siegewar_plugin_prefix: '&f[&6SiegeWar&f] '          # SiegeWar prefix seen in front of most messages.
-status_town_title_peaceful: '&b(Peaceful)'

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -507,7 +507,8 @@ status_town_days_to_peacefulness_status_change: 'Days To Peacefulness Status Cha
 status_town_peacefulness_status_change_timer: '&2Countdown To Peaceful Status Change: &a%d days'
 
 #Town Peacefulness
-
+    
+town_help_toggle_peaceful: 'Change your town peacefulness status'
 msg_war_common_town_declared_peaceful: '&bNPeacefulness Declared! The town will be confirmed as Peaceful in %d day(s).'
 msg_war_common_town_declared_non_peaceful: '&bNon-Peacefulness Declared! The town will be confirmed as Non-Peaceful in %d day(s).'
 msg_town_became_peaceful: '&b%s has been confirmed as Peaceful. The town is now immune to siege attacks, but vulnerable to getting subverted by nearby nations. Residents cannot gain nation-military ranks.'
@@ -515,11 +516,12 @@ msg_town_became_non_peaceful: '&b%s has been confirmed as Non-Peaceful. The town
 msg_war_common_town_peacefulness_countdown_cancelled: '&bThe Peaceful status change countdown was cancelled.'
 msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident: '&cUnable to add nation military rank to resident, because they belong to a Peaceful town.'
 sg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."
-msg_err_peaceful_towns_cannot_revolt: '&cPeaceful towns cannot revolt'
+msg_err_peaceful_towns_cannot_revolt: '&cPeaceful towns cannot revolt.'
+msg_err_capital_towns_cannot_go_peaceful: '&cCapital towns cannot go peaceful.'
 
-#Nation Peacefulness
+# Town neutrality
 
-msg_err_nation_peacefulness_not_supported: '&cSiegeWar does not support nation peacefulness.'
+msg_err_town_neutrality_not_supported: '&cSiegeWar does not support town neutrality. To protect your town from sieges, change your town to Peaceful, using /sw town togglepeaceful.'
 
 #swa
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -524,6 +524,7 @@ msg_err_nation_peacefulness_not_supported: '&cSiegeWar does not support nation p
 #swa
 
 msg_swa_set_invade_success: '&bSet captured to %s for %s.'
+msg_swa_town_peacefulness_change_success: '&bSuccessfully changed the peacefulness status of %s to %s.'
 msg_swa_town_occupation_change_success: '&bSuccessfully changed the occupation status of %s to %s.'
 msg_err_command_not_allowed_on_active_siege: "You cannot run this command unless the siege has ended."
 
@@ -554,6 +555,7 @@ msg_revolt_siege_defender_win_result: ' The town now stands open for invasion an
 #Town Screen
 
 status_town_siege_status_invaded: '   &2Town Captured: %s'
+status_town_peacefulness_flag: '&b(Peaceful)'
 
 #Capture
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -521,7 +521,7 @@ msg_err_capital_towns_cannot_go_peaceful: '&cCapital towns cannot go peaceful.'
 
 # Town neutrality
 
-msg_err_town_neutrality_not_supported: '&cSiegeWar does not support town neutrality. To protect your town from sieges, change your town to Peaceful, using /sw town togglepeaceful.'
+msg_err_town_neutrality_not_supported: "&cSiegeWar does not support town neutrality. To protect your town from sieges, change your town to Peaceful, using '/sw town togglepeaceful'."
 
 #swa
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -509,7 +509,7 @@ status_town_peacefulness_status_change_timer: '&2Countdown To Peaceful Status Ch
 #Town Peacefulness
     
 town_help_toggle_peaceful: 'Change your town peacefulness status'
-msg_war_common_town_declared_peaceful: '&bNPeacefulness Declared! The town will be confirmed as Peaceful in %d day(s).'
+msg_war_common_town_declared_peaceful: '&bPeacefulness Declared! The town will be confirmed as Peaceful in %d day(s).'
 msg_war_common_town_declared_non_peaceful: '&bNon-Peacefulness Declared! The town will be confirmed as Non-Peaceful in %d day(s).'
 msg_town_became_peaceful: '&b%s has been confirmed as Peaceful. The town is now immune to siege attacks, but vulnerable to getting subverted by nearby nations. Residents cannot gain nation-military ranks.'
 msg_town_became_non_peaceful: '&b%s has been confirmed as Non-Peaceful. The town is no longer immune to siege attacks, and no longer vulnerable to getting subverted by nearby nations. Residents can now gain nation-military ranks.'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -43,6 +43,7 @@ permissions:
         default: false
         children:
             siegewar.command.siegewar.hud.*: true
+            siegewar.command.siegewar.town.*: true
             siegewar.command.siegewar.nation.*: true
             siegewar.command.siegewar.collect: true
 
@@ -60,12 +61,18 @@ permissions:
         children:
             siegewar.command.siegewar.hud: true
 
+    siegewar.command.siegewar.town.*:
+        description: User is able to do all /siegewar town commands.
+        default: false
+        children:
+            siegewar.command.siegewar.town.togglepeaceful: true
+    
     siegewar.command.siegewar.nation.*:
         description: User is able to do all /siegewar nation commands.
         default: false
         children:
             siegewar.command.siegewar.nation.paysoldiers: true
-
+            
     siegewar.nation.siege.*:
         description: User holds all of the siegewar nation nodes.
         default: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -72,7 +72,7 @@ permissions:
         default: false
         children:
             siegewar.command.siegewar.nation.paysoldiers: true
-            
+
     siegewar.nation.siege.*:
         description: User holds all of the siegewar nation nodes.
         default: false


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
- With current code, SW is hijacking/re-using the native towny town "neutral" flag to indicate peacefulness
- This is bad for 2 reasons:
  - The Towny neutral flag comes with an extra daily monetary cost, which interferes with SiegeWar's system balance, because in SiegeWar, peaceful towns are already fully costed, via restrictions on their residents, vulnerability to instant capture, and occupation tax.
  - This arrangement forces towny to support duplicate commands and message e.g. "/t toggle neutral", "/t toggle peaceful"
- In this PR, I put the peaceful town flag into SiegeWar metadata.
  - SiegeWar system balance is restored.
  - And Towny developers can now remove the duplicate commands and messages!.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ x  ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
