### PR TITLE
Translate our translatable messages more thoroughly.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -44,7 +44,6 @@ import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.object.Translation;
 
 /**
  * 
@@ -485,8 +484,8 @@ public class SiegeController {
 			if (TownyEconomyHandler.isActive()) {
 				//Pay upfront cost into warchest now
 				attacker.getAccount().withdraw(siege.getWarChestAmount(), "Cost of starting a siege.");
-				String moneyMessage =
-						Translation.of("msg_siege_war_attack_pay_war_chest",
+				Translatable moneyMessage =
+						Translatable.of("msg_siege_war_attack_pay_war_chest",
 								attacker.getName(),
 								TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount()));
 
@@ -619,12 +618,12 @@ public class SiegeController {
 	public static void beginSiegeCamp(SiegeCamp camp) throws TownyException {
 		// Another SiegeCamp is already present.
 		if (SiegeWarDistanceUtil.campTooClose(camp.getBannerBlock().getLocation()))
-			throw new TownyException(Translation.of("msg_err_siegecamp_too_close_to_another_siegecamp"));
+			throw new TownyException(Translatable.of("msg_err_siegecamp_too_close_to_another_siegecamp"));
 		
 		// Town initiating the SiegeCamp has a failed SiegeCamp on this 
 		// town and not enough time has passed. 
 		if (SiegeCampUtil.hasFailedCamp(camp.getTargetTown(), camp.getTownOfSiegeStarter()))
-			throw new TownyException(Translation.of("msg_err_too_soon_since_your_last_siegecamp"));
+			throw new TownyException(Translatable.of("msg_err_too_soon_since_your_last_siegecamp"));
 
 		// Broadcast a message
 		Messaging.sendGlobalMessage(Translatable.of("attacker_has_begun_a_siegecamp_session", camp.getTownOfSiegeStarter(), camp.getTargetTown(), SiegeWarSettings.getSiegeCampPointsForSuccess(), SiegeWarSettings.getSiegeCampDurationInMinutes()));

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -21,7 +21,6 @@ import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.permissions.TownyPerms;
 import com.palmergames.bukkit.towny.utils.NameUtil;
 import com.palmergames.bukkit.util.ChatTools;
@@ -497,7 +496,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 				TownMetaDataController.setSiegeImmunityEndTime(town, System.currentTimeMillis() + (long)(Long.parseLong(args[2]) * TimeMgmt.ONE_HOUR_IN_MILLIS));
 				timeDuration = Long.parseLong(args[2]) + Translatable.of("msg_hours").forLocale(sender);
 			}
-			TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_set_siege_immunities_town", town.getName(), timeDuration));
+			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_set_siege_immunities_town", town.getName(), timeDuration));
 			Messaging.sendMsg(sender, Translatable.of("msg_set_siege_immunities_town", town.getName(), timeDuration));
 		} else if (args.length >= 3 && args[0].equalsIgnoreCase("nation")) {
 			//nation {nationname} {hours}
@@ -517,7 +516,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 			for (Town town : nation.getTowns()) {
 				TownMetaDataController.setSiegeImmunityEndTime(town, endTime);
 			}
-			TownyMessaging.sendPrefixedNationMessage(nation, Translation.of("msg_set_siege_immunities_nation", nation.getName(), timeDuration));
+			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_set_siege_immunities_nation", nation.getName(), timeDuration));
 			Messaging.sendMsg(sender, Translatable.of("msg_set_siege_immunities_nation", nation.getName(), timeDuration));
 
 		} else if (args[0].equalsIgnoreCase("alltowns")) {
@@ -525,10 +524,10 @@ public class SiegeWarAdminCommand implements TabExecutor {
 			long endTime;
 			if (args[1].equalsIgnoreCase("permanent")) {
 				endTime = -1l;
-				timeDuration = Translation.of("msg_permanent");
+				timeDuration = Translatable.of("msg_permanent").forLocale(sender);
 			} else {
 				endTime = System.currentTimeMillis() + (long)(Long.parseLong(args[1]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
-				timeDuration = Long.parseLong(args[1]) + com.palmergames.bukkit.towny.object.Translation.of("msg_hours");
+				timeDuration = Long.parseLong(args[1]) + Translatable.of("msg_hours").forLocale(sender);
 			}
 			for (Town town : new ArrayList<>(TownyUniverse.getInstance().getTowns()))  {
 				TownMetaDataController.setSiegeImmunityEndTime(town, endTime);
@@ -573,7 +572,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 				TownMetaDataController.setRevoltImmunityEndTime(town, System.currentTimeMillis() + (long)(Long.parseLong(args[2]) * TimeMgmt.ONE_HOUR_IN_MILLIS));
 				timeDuration = Long.parseLong(args[2]) + Translatable.of("msg_hours").forLocale(sender);
 			}
-			TownyMessaging.sendPrefixedTownMessage(town, Translation.of("msg_set_revolt_immunities_town", town, timeDuration));
+			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_set_revolt_immunities_town", town, timeDuration));
 			Messaging.sendMsg(sender, Translatable.of("msg_set_revolt_immunities_town", town, timeDuration));
 
 		} else if (args.length >= 3 && args[0].equalsIgnoreCase("nation")) {
@@ -595,7 +594,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 			for (Town town : nation.getTowns()) {
 				TownMetaDataController.setRevoltImmunityEndTime(town, endTime);
 			}
-			TownyMessaging.sendPrefixedNationMessage(nation, Translation.of("msg_set_revolt_immunities_nation", nation, timeDuration));
+			TownyMessaging.sendPrefixedNationMessage(nation, Translatable.of("msg_set_revolt_immunities_nation", nation, timeDuration));
 			Messaging.sendMsg(sender, Translatable.of("msg_set_revolt_immunities_nation", nation, timeDuration));
 
 		} else if (args[0].equalsIgnoreCase("alltowns")) {
@@ -603,10 +602,10 @@ public class SiegeWarAdminCommand implements TabExecutor {
 			long endTime;
 			if (args[1].equalsIgnoreCase("permanent")) {
 				endTime = -1l;
-				timeDuration = Translation.of("msg_permanent");
+				timeDuration = Translatable.of("msg_permanent").forLocale(sender);
 			} else {
 				endTime = System.currentTimeMillis() + (long)(Long.parseLong(args[1]) * TimeMgmt.ONE_HOUR_IN_MILLIS);
-				timeDuration = Long.parseLong(args[1]) + com.palmergames.bukkit.towny.object.Translation.of("msg_hours");
+				timeDuration = Long.parseLong(args[1]) + Translatable.of("msg_hours").forLocale(sender);
 			}
 			for (Town town : new ArrayList<>(TownyUniverse.getInstance().getTowns()))  {
 				TownMetaDataController.setRevoltImmunityEndTime(town, endTime);

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -193,15 +193,15 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 			} else {
 				Town town = TownyUniverse.getInstance().getTown(args[0]);
 				if (town == null) 
-					throw new Exception(Translatable.of("msg_err_town_not_registered", args[0]).forLocale(player));
+					throw new TownyException(Translatable.of("msg_err_town_not_registered", args[0]));
 
 				if (!SiegeController.getSiegedTowns().contains(town))
-					throw new Exception(Translatable.of("msg_err_not_being_sieged", town.getName()).forLocale(player));
+					throw new TownyException(Translatable.of("msg_err_not_being_sieged", town.getName()));
 
 				SiegeWar.getSiegeHUDManager().toggleWarHud(player, SiegeController.getSiege(town));
 			}
-		} catch (Exception e) {
-			Messaging.sendErrorMsg(player, e.getMessage());
+		} catch (TownyException e) {
+			Messaging.sendErrorMsg(player, e.getMessage(player));
 		}
 	}
 
@@ -280,7 +280,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 						throw new TownyException(Translatable.of("msg_err_siege_war_no_soldiers_to_pay").forLocale(player));
 
 				} catch (TownyException te) {
-					Messaging.sendErrorMsg(player, te.getMessage());
+					Messaging.sendErrorMsg(player, te.getMessage(player));
 				}
 				break;
 
@@ -292,7 +292,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 					}
 					SiegeWarMoneyUtil.claimNationRefund(player);
 				} catch (TownyException te) {
-					Messaging.sendErrorMsg(player, te.getMessage());
+					Messaging.sendErrorMsg(player, te.getMessage(player));
 				}
 				break;
 

--- a/src/main/java/com/gmail/goosius/siegewar/hud/SiegeWarHud.java
+++ b/src/main/java/com/gmail/goosius/siegewar/hud/SiegeWarHud.java
@@ -2,9 +2,7 @@ package com.gmail.goosius.siegewar.hud;
 
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.objects.Siege;
-import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -21,7 +19,7 @@ public class SiegeWarHud {
             toggleOn(p, siege);
             return;
         }
-        final Translator translator = Translator.locale(Translation.getLocale(p));
+        final Translator translator = Translator.locale(p);
         board.getObjective("WAR_HUD_OBJ").setDisplayName(SiegeHUDManager.checkLength(ChatColor.GOLD + "§l" + siege.getTown().getName()) + " " + translator.of("hud_title"));
         board.getTeam("siegeType").setSuffix(SiegeHUDManager.checkLength(siege.getSiegeType().getTranslatedName().forLocale(p)));
         board.getTeam("attackers").setSuffix(SiegeHUDManager.checkLength(siege.getAttackerNameForDisplay()));
@@ -42,7 +40,7 @@ public class SiegeWarHud {
     }
 
     public static void toggleOn(Player p, Siege siege) {
-    	final Translator translator = Translator.locale(Translation.getLocale(p));
+    	final Translator translator = Translator.locale(p);
         Scoreboard board = Bukkit.getScoreboardManager().getNewScoreboard();
         Objective objective = board.registerNewObjective("WAR_HUD_OBJ", "", translator.of("hud_title"));
         objective.setDisplaySlot(DisplaySlot.SIDEBAR);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -18,6 +18,7 @@ import com.palmergames.bukkit.towny.event.townblockstatus.NationZoneTownBlockSta
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translation;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -161,7 +162,7 @@ public class SiegeWarNationEventListener implements Listener {
 
 		if (event.getFutureState()) {
 			event.setCancelled(true);
-			event.setCancelMessage(Translation.of("msg_err_nation_neutrality_not_supported"));
+			event.setCancelMessage(Translatable.of("msg_err_nation_neutrality_not_supported").forLocale(event.getSender()));
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -3,7 +3,6 @@ package com.gmail.goosius.siegewar.listeners;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.utils.SiegeWarTownOccupationUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarTownPeacefulnessUtil;
 import com.palmergames.bukkit.towny.TownyAPI;
@@ -49,7 +48,7 @@ public class SiegeWarStatusScreenListener implements Listener {
 	public void onResidentStatusScreen(ResidentStatusScreenEvent event) {
 		int salary = ResidentMetaDataController.getMilitarySalaryAmount(event.getResident());
 		if (salary > 0) {
-			final Translator translator = Translator.locale(Translation.getLocale(event.getCommandSender()));
+			final Translator translator = Translator.locale(event.getCommandSender());
 			event.getStatusScreen().addComponentOf("siegeWarNationSalary",
 					formatKeyValue(translator.of("status_military_salary"), formatMoney(salary)),
 					HoverEvent.showText(Component.text(translator.of("hover_message_click_to_claim"))),
@@ -63,7 +62,7 @@ public class SiegeWarStatusScreenListener implements Listener {
 	@EventHandler
 	public void onNationStatusScreen(NationStatusScreenEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
-			final Translator translator = Translator.locale(Translation.getLocale(event.getCommandSender()));
+			final Translator translator = Translator.locale(event.getCommandSender());
 			Nation nation = event.getNation();
 
 			/*
@@ -128,7 +127,7 @@ public class SiegeWarStatusScreenListener implements Listener {
 	@EventHandler
 	public void onTownStatusScreen(TownStatusScreenEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
-			final Translator translator = Translator.locale(Translation.getLocale(event.getCommandSender()));
+			final Translator translator = Translator.locale(event.getCommandSender());
 			
 			Town town = event.getTown();
 
@@ -191,7 +190,7 @@ public class SiegeWarStatusScreenListener implements Listener {
 
 			//Days to Peacefulness Status Change: 2
 			if(SiegeWarTownPeacefulnessUtil.getTownPeacefulnessChangeCountdownDays(town) > 0) {
-				Component peacefulnessCountdownDays = Component.text(Translation.of("status_town_days_to_peacefulness_status_change", SiegeWarTownPeacefulnessUtil.getTownPeacefulnessChangeCountdownDays(town)));
+				Component peacefulnessCountdownDays = Component.text(translator.of("status_town_days_to_peacefulness_status_change", SiegeWarTownPeacefulnessUtil.getTownPeacefulnessChangeCountdownDays(town)));
 				event.getStatusScreen().addComponentOf("siegeWar_peacefulnessCountdownDays", peacefulnessCountdownDays);
 			}
 
@@ -310,12 +309,12 @@ public class SiegeWarStatusScreenListener implements Listener {
 					|| immunity == -1l) {
 	                //Siege:
 	                // > Immunity Timer: 40.8 hours
-					String time = immunity == -1l ? Translation.of("msg_permanent") : TimeMgmt.getFormattedTimeValue(immunity- System.currentTimeMillis());
+					String time = immunity == -1l ? translator.of("msg_permanent") : TimeMgmt.getFormattedTimeValue(immunity- System.currentTimeMillis());
 					Component immunityComp = Component.empty()
 							.append(Component.newline())
-							.append(Component.text(Translation.of("status_town_siege")))
+							.append(Component.text(translator.of("status_town_siege")))
 							.append(Component.newline())
-							.append(Component.text(Translation.of("status_town_siege_immunity_timer", time))); 
+							.append(Component.text(translator.of("status_town_siege_immunity_timer", time))); 
 					event.getStatusScreen().addComponentOf("siegeWar_siegeImmunity", immunityComp);
 	            }
 	        }

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -22,7 +22,9 @@ import com.palmergames.bukkit.towny.event.town.TownMapColourNationalCalculationE
 import com.palmergames.bukkit.towny.event.town.TownPreSetHomeBlockEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownToggleNeutralEvent;
 import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translation;
+import com.palmergames.bukkit.towny.object.Translator;
 import com.palmergames.util.TimeMgmt;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -125,19 +127,20 @@ public class SiegeWarTownEventListener implements Listener {
 	 */
 	@EventHandler
 	public void onTownUnclaim(TownPreUnclaimCmdEvent event) {
+		Translator translator = Translator.locale(event.getResident().getPlayer());
 		if (SiegeWarSettings.getWarCommonOccupiedTownUnClaimingDisabled() && SiegeWarTownOccupationUtil.isTownOccupied(event.getTown())) {
 			event.setCancelled(true);
-			event.setCancelMessage(Translation.of("siegewar_plugin_prefix") + Translation.of("msg_err_war_common_occupied_town_cannot_unclaim"));
+			event.setCancelMessage(translator.of("siegewar_plugin_prefix") + translator.of("msg_err_war_common_occupied_town_cannot_unclaim"));
 			return;
 		}
-			
+
 		if(SiegeWarSettings.getWarSiegeEnabled()
 			&& SiegeWarSettings.getWarSiegeBesiegedTownUnClaimingDisabled()) {
 
 			//Town besieged
 			if(SiegeController.hasActiveSiege(event.getTown())) {
 				event.setCancelled(true);
-				event.setCancelMessage(Translation.of("siegewar_plugin_prefix") + Translation.of("msg_err_siege_besieged_town_cannot_unclaim"));
+				event.setCancelMessage(translator.of("siegewar_plugin_prefix") + translator.of("msg_err_siege_besieged_town_cannot_unclaim"));
 				return;
 			}
 		}
@@ -151,20 +154,21 @@ public class SiegeWarTownEventListener implements Listener {
 	@EventHandler
 	public void on(TownPreSetHomeBlockEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
+			Translator translator = Translator.locale(event.getPlayer());
 			if(SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
 				&& SiegeWarTownPeacefulnessUtil.isTownPeaceful(event.getTown())) {
 				event.setCancelled(true);
-				event.setCancelMessage(Translation.of("siegewar_plugin_prefix") + Translation.of("msg_err_peaceful_town_cannot_move_homeblock"));
+				event.setCancelMessage(translator.of("siegewar_plugin_prefix") + translator.of("msg_err_peaceful_town_cannot_move_homeblock"));
 			}
 
 			if(SiegeController.hasActiveSiege(event.getTown())) {
 				event.setCancelled(true);
-				event.setCancelMessage(Translation.of("siegewar_plugin_prefix") + Translation.of("msg_err_besieged_town_cannot_move_homeblock"));
+				event.setCancelMessage(translator.of("siegewar_plugin_prefix") + translator.of("msg_err_besieged_town_cannot_move_homeblock"));
 			}
 
 			if(SiegeWarTownOccupationUtil.isTownOccupied(event.getTown())) {
 				event.setCancelled(true);
-				event.setCancelMessage(Translation.of("siegewar_plugin_prefix") + Translation.of("msg_err_occupied_town_cannot_move_homeblock"));
+				event.setCancelMessage(translator.of("siegewar_plugin_prefix") + translator.of("msg_err_occupied_town_cannot_move_homeblock"));
 			}
 		}
 	}
@@ -207,7 +211,7 @@ public class SiegeWarTownEventListener implements Listener {
 
 		if (event.getFutureState()) {
 			event.setCancelled(true);
-			event.setCancelMessage(Translation.of("msg_err_town_neutrality_not_supported"));
+			event.setCancelMessage(Translatable.of("msg_err_town_neutrality_not_supported").forLocale(event.getPlayer()));
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -11,10 +11,6 @@ import com.palmergames.bukkit.towny.object.metadata.LongDataField;
 import com.palmergames.bukkit.towny.object.metadata.StringDataField;
 import com.palmergames.bukkit.towny.utils.MetaDataUtil;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 /**
  * 
  * 

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
@@ -2,7 +2,6 @@ package com.gmail.goosius.siegewar.metadata;
 
 import com.gmail.goosius.siegewar.SiegeWar;
 import com.palmergames.bukkit.towny.object.Town;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.metadata.BooleanDataField;
 import com.palmergames.bukkit.towny.object.metadata.DecimalDataField;
 import com.palmergames.bukkit.towny.object.metadata.IntegerDataField;

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
@@ -11,7 +11,6 @@ import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.confirmations.Confirmation;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.util.TimeMgmt;
 import org.bukkit.entity.Player;
 
@@ -31,10 +30,10 @@ public class AbandonAttack {
 	 */
 	public static void processAbandonAttackRequest(Player player, Siege siege) throws TownyException {
 		if(!SiegeWarSettings.getWarSiegeAbandonEnabled())
-			throw new TownyException(Translation.of("msg_err_action_disable"));
+			throw new TownyException(Translatable.of("msg_err_action_disable"));
 
 		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.getPermissionNodeToAbandonAttack(siege.getSiegeType())))
-			throw new TownyException(Translation.of("msg_err_action_disable"));
+			throw new TownyException(Translatable.of("msg_err_action_disable"));
 
 		Confirmation
 			.runOnAccept(()-> abandonAttack(siege, siege.getTimeUntilAbandonConfirmationMillis()))

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/DestroyBlock.java
@@ -11,7 +11,6 @@ import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.event.actions.TownyDestroyEvent;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 
 import org.bukkit.block.Block;
@@ -36,7 +35,7 @@ public class DestroyBlock {
 		if (!TownyAPI.getInstance().getTownyWorld(block.getWorld()).isWarAllowed())
 			return;
 
-		final Translator translator = Translator.locale(Translation.getLocale(event.getPlayer()));
+		final Translator translator = Translator.locale(event.getPlayer());
 
 		//Get nearby siege
 		Siege nearbySiege = SiegeController.getActiveSiegeAtLocation(event.getLocation());

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -16,7 +16,6 @@ import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 
 import org.bukkit.Bukkit;
@@ -101,7 +100,7 @@ public class InvadeTown {
 	}
 
 	private static void allowInvasionOrThrow(Player player, Nation residentsNation, Town targetTown, Siege siege) throws TownyException {
-		final Translator translator = Translator.locale(Translation.getLocale(player));
+		final Translator translator = Translator.locale(player);
 		if(!SiegeWarSettings.getWarSiegeInvadeEnabled())
 			throw new TownyException(translator.of("msg_err_action_disable"));
 

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
@@ -14,7 +14,6 @@ import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 
 import org.bukkit.Bukkit;
@@ -84,7 +83,7 @@ public class PeacefullySubvertTown {
 	}
 
 	private static void allowSubversionOrThrow(Player player, Nation residentsNation, Town targetTown) throws TownyException {
-		final Translator translator =  Translator.locale(Translation.getLocale(player));
+		final Translator translator =  Translator.locale(player);
 		if(!SiegeWarSettings.isPeacefulTownsSubvertEnabled())
 			throw new TownyException(translator.of("msg_err_action_disable"));
 
@@ -121,12 +120,12 @@ public class PeacefullySubvertTown {
 		Map<Nation, Integer> townyInfluenceMap = SiegeWarTownPeacefulnessUtil.calculateTownyInfluenceMap(targetTown);
 		if(townyInfluenceMap.size() == 0)
 			//No nation has towny-influence in the local area
-			throw new TownyException(Translation.of("msg_err_cannot_subvert_town_zero_influence"));
+			throw new TownyException(Translatable.of("msg_err_cannot_subvert_town_zero_influence"));
 
 		Nation topNation = townyInfluenceMap.keySet().iterator().next();
 		if(topNation != nation)
 			//A different nation is top of the towny-influence map
-			throw new TownyException(Translation.of("msg_err_cannot_subvert_town_insufficient_influence", topNation.getName(),
+			throw new TownyException(Translatable.of("msg_err_cannot_subvert_town_insufficient_influence", topNation.getName(),
 					townyInfluenceMap.get(topNation),            // Top scorer. 
 					townyInfluenceMap.getOrDefault(nation, 0))); // The nation's score.
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -24,7 +24,6 @@ import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 
 import org.bukkit.Material;
@@ -57,7 +56,7 @@ public class PlaceBlock {
 	 * @param event The event object related to the block placement
 	 */
 	public static void evaluateSiegeWarPlaceBlockRequest(Player player, Block block, TownyBuildEvent event) {
-		final Translator translator = Translator.locale(Translation.getLocale(player));
+		final Translator translator = Translator.locale(player);
 		try {
 			//Ensure siege is enabled in this world
 			if (!TownyAPI.getInstance().getTownyWorld(block.getWorld()).isWarAllowed())
@@ -73,7 +72,7 @@ public class PlaceBlock {
 						return;  //Special banner placement
 					}
 				} catch (TownyException e1) {
-					Messaging.sendErrorMsg(player, e1.getMessage());
+					Messaging.sendErrorMsg(player, e1.getMessage(player));
 				}
 
 			} else if (mat == Material.CHEST || mat == Material.TRAPPED_CHEST) {
@@ -81,7 +80,7 @@ public class PlaceBlock {
 					//Chest placement
 					evaluatePlaceChest(player, block);
 				} catch (TownyException e) {
-					Messaging.sendErrorMsg(player, e.getMessage());
+					Messaging.sendErrorMsg(player, e.getMessage(player));
 				}
 			}
 
@@ -99,7 +98,7 @@ public class PlaceBlock {
 
 		} catch (TownyException e) {
 			event.setCancelled(true);
-			event.setCancelMessage(e.getMessage());
+			event.setCancelMessage(e.getMessage(player));
 		}
 	}
 
@@ -120,7 +119,7 @@ public class PlaceBlock {
 	 * @throws TownyException if the banner will not be allowed.
 	 */
 	private static boolean evaluatePlaceStandingBanner(Player player, Block block) throws TownyException {
-		final Translator translator = Translator.locale(Translation.getLocale(player));
+		final Translator translator = Translator.locale(player);
 		//Ensure the the banner is placed in wilderness
 		if (!TownyAPI.getInstance().isWilderness(block))
 			return false;
@@ -171,7 +170,7 @@ public class PlaceBlock {
 														 Town residentsTown,
 														 Nation residentsNation,
 														 Town nearbyTown) throws TownyException {
-		final Translator translator = Translator.locale(Translation.getLocale(player));
+		final Translator translator = Translator.locale(player);
 		//Ensure that there is a siege
 		if (!SiegeController.hasSiege(nearbyTown))
 			throw new TownyException(translator.of("msg_err_town_cannot_end_siege_as_no_siege"));
@@ -268,7 +267,7 @@ public class PlaceBlock {
 													 			  TownBlock nearbyTownBlock,
 													 			  Town nearbyTown,
 													 			  Block bannerBlock) throws TownyException {
-		final Translator translator = Translator.locale(Translation.getLocale(player));
+		final Translator translator = Translator.locale(player);
 		if (nearbyTown.isRuined())
 			throw new TownyException(translator.of("msg_err_cannot_start_siege_at_ruined_town"));
 
@@ -310,7 +309,7 @@ public class PlaceBlock {
 		if (!SiegeWarSettings.getWarSiegePlunderEnabled() || !TownyAPI.getInstance().isWilderness(block))
 			return;
 		
-		final Translator translator = Translator.locale(Translation.getLocale(player));
+		final Translator translator = Translator.locale(player);
 		
 		if(!TownyEconomyHandler.isActive())
 			throw new TownyException(translator.of("msg_err_siege_war_cannot_plunder_without_economy"));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
@@ -19,7 +19,6 @@ import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 import com.palmergames.bukkit.towny.utils.MoneyUtil;
 
@@ -48,7 +47,7 @@ public class PlunderTown {
 	private static Nation getPlunderingNationOrThrow(Player player, Siege siege) throws TownyException {
 		Town townToBePlundered = siege.getTown();
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
-		final Translator translator = Translator.locale(Translation.getLocale(player));
+		final Translator translator = Translator.locale(player);
 
 		if (!townyUniverse.getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_PLUNDER.getNode()))
 			throw new TownyException(translator.of("msg_err_command_disable"));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/StartConquestSiege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/StartConquestSiege.java
@@ -12,7 +12,6 @@ import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -56,7 +55,7 @@ public class StartConquestSiege {
 	}
 
 	private static void allowSiegeOrThrow(Player player, Nation nationOfSiegeStarter, Town targetTown) throws TownyException {
-		final Translator translator = Translator.locale(Translation.getLocale(player));
+		final Translator translator = Translator.locale(player);
 
 		if (!SiegeWarSettings.getConquestSiegesEnabled()
 		|| !TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.getPermissionNodeToStartSiege(SiegeType.CONQUEST)))

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/StartRevoltSiege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/StartRevoltSiege.java
@@ -12,7 +12,6 @@ import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 
 import org.bukkit.block.Block;
@@ -56,7 +55,7 @@ public class StartRevoltSiege {
 	}
 
 	private static void allowSiegeOrThrow(Player player, Town targetTown) throws TownyException {
-		final Translator translator = Translator.locale(Translation.getLocale(player));
+		final Translator translator = Translator.locale(player);
         if (!SiegeWarSettings.getRevoltSiegesEnabled()
         || !TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.getPermissionNodeToStartSiege(SiegeType.REVOLT)))
             throw new TownyException(translator.of("msg_err_action_disable"));

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -11,10 +11,8 @@ import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
-import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.util.TimeMgmt;
 import com.palmergames.util.TimeTools;
 import org.bukkit.Bukkit;
@@ -64,7 +62,7 @@ public class SiegeWarBannerControlUtil {
 
 				resident = universe.getResident(player.getUniqueId());
 	            if (resident == null)
-	            	throw new TownyException(Translation.of("msg_err_not_registered_1", player.getName()));
+	            	continue;
 
 				if(!doesPlayerMeetBasicSessionRequirements(siege, player, resident))
 					continue;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -14,7 +14,6 @@ import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.jail.UnJailReason;
 import com.palmergames.bukkit.towny.utils.JailUtil;
 import com.palmergames.util.StringMgmt;
@@ -239,30 +238,30 @@ public class SiegeWarBattleSessionUtil {
 	 * with a brief summary of who won any battles which were fought
 	 */
 	private static void sendBattleSessionEndedMessage(Map<Siege, Integer> battleResults) {
-		String header;
-		List<String> lines = new ArrayList<>();
+		Translatable header;
+		List<Translatable> lines = new ArrayList<>();
 
 		//Compile message
 		if(battleResults.size() == 0) {
-			header = Translation.of("msg_war_siege_battle_session_ended_without_battles");
+			header = Translatable.of("msg_war_siege_battle_session_ended_without_battles");
 		} else {
-			header = Translation.of("msg_war_siege_battle_session_ended_with_battles");
+			header = Translatable.of("msg_war_siege_battle_session_ended_with_battles");
 
-			String resultLine;
+			Translatable resultLine;
 			for (Map.Entry<Siege, Integer> battleResultEntry : battleResults.entrySet()) {
 				if (battleResultEntry.getValue() > 0) {
 					resultLine =
-							Translation.of("msg_war_siege_battle_session_ended_attacker_result",
+							Translatable.of("msg_war_siege_battle_session_ended_attacker_result",
 									battleResultEntry.getKey().getTown().getName(),
 									"+" + battleResultEntry.getValue());
 				} else if (battleResultEntry.getValue() < 0) {
 					resultLine =
-							Translation.of("msg_war_siege_battle_session_ended_defender_result",
+							Translatable.of("msg_war_siege_battle_session_ended_defender_result",
 									battleResultEntry.getKey().getTown().getName(),
 									"-" + Math.abs(battleResultEntry.getValue()));
 				} else {
 					resultLine =
-							Translation.of("msg_war_siege_battle_session_ended_draw_result",
+							Translatable.of("msg_war_siege_battle_session_ended_draw_result",
 									battleResultEntry.getKey().getTown().getName());
 				}
 				lines.add(resultLine);

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
@@ -15,7 +15,6 @@ import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.utils.MoneyUtil;
 
 import org.bukkit.entity.Player;
@@ -28,8 +27,8 @@ public class SiegeWarMoneyUtil {
 	public static void giveWarChestTo(Siege siege, Government government) {
 		if(TownyEconomyHandler.isActive()) {
 			government.getAccount().deposit(siege.getWarChestAmount(), "War Chest Captured");
-			String message =
-					Translation.of("msg_siege_war_attack_recover_war_chest",
+			Translatable message =
+					Translatable.of("msg_siege_war_attack_recover_war_chest",
 							government.getFormattedName(),
 							TownyEconomyHandler.getFormattedBalance(siege.getWarChestAmount()));
 
@@ -294,19 +293,19 @@ public class SiegeWarMoneyUtil {
 	public static void claimNationRefund(Player player) throws TownyException {
 		if (!TownySettings.isUsingEconomy()
 				|| SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete() == 0) {
-			throw new TownyException(Translation.of("msg_err_command_disable"));
+			throw new TownyException(Translatable.of("msg_err_command_disable"));
 		}
 		Resident formerKing = TownyUniverse.getInstance().getResident(player.getUniqueId());
 		if (formerKing == null)
-			throw new TownyException(Translation.of("msg_err_not_registered_1", player.getName()));
+			throw new TownyException(Translatable.of("msg_err_not_registered_1", player.getName()));
 
 		int refundAmount = ResidentMetaDataController.getNationRefundAmount(formerKing);
 		if(refundAmount != 0) {
 			formerKing.getAccount().deposit(refundAmount, "Nation Refund");
 			ResidentMetaDataController.setNationRefundAmount(formerKing, 0);
-			Messaging.sendMsg(player, Translation.of("msg_siege_war_nation_refund_claimed", TownyEconomyHandler.getFormattedBalance(refundAmount)));
+			Messaging.sendMsg(player, Translatable.of("msg_siege_war_nation_refund_claimed", TownyEconomyHandler.getFormattedBalance(refundAmount)));
 		} else {
-			throw new TownyException(Translation.of("msg_err_siege_war_nation_refund_unavailable"));
+			throw new TownyException(Translatable.of("msg_err_siege_war_nation_refund_unavailable"));
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
@@ -12,7 +12,8 @@ import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
-import com.palmergames.bukkit.towny.object.Translation;
+import com.palmergames.bukkit.towny.object.Translatable;
+import com.palmergames.bukkit.towny.object.Translator;
 import com.palmergames.util.TimeMgmt;
 import org.bukkit.entity.Player;
 
@@ -79,7 +80,7 @@ public class SiegeWarTownPeacefulnessUtil {
 	 * This method adjusts the peacefulness counter of a single town
 	 */
 	public static void updateTownPeacefulnessCounters(Town town) {
-		String message;
+		Translatable message;
 
 		int days = TownMetaDataController.getPeacefulnessChangeCountdownDays(town); 
 		if (days > 1) {
@@ -93,15 +94,15 @@ public class SiegeWarTownPeacefulnessUtil {
 
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			if (TownMetaDataController.getPeacefulness(town)) {
-				message = Translation.of("msg_town_became_peaceful", town.getFormattedName());
+				message = Translatable.of("msg_town_became_peaceful", town.getFormattedName());
 			} else {
-				message = Translation.of("msg_town_became_non_peaceful", town.getFormattedName());
+				message = Translatable.of("msg_town_became_non_peaceful", town.getFormattedName());
 			}
 		} else {
 			if (TownMetaDataController.getPeacefulness(town)) {
-				message = Translation.of("msg_town_became_peaceful", town.getFormattedName());
+				message = Translatable.of("msg_town_became_peaceful", town.getFormattedName());
 			} else {
-				message = Translation.of("msg_town_became_non_peaceful", town.getFormattedName());
+				message = Translatable.of("msg_town_became_non_peaceful", town.getFormattedName());
 			}
 		}
 		TownyMessaging.sendPrefixedTownMessage(town, message);
@@ -211,26 +212,27 @@ public class SiegeWarTownPeacefulnessUtil {
 	}
 
 	public static void toggleTownPeacefulness(Player player) {
+		Translator translator = Translator.locale(player);
 		if (!SiegeWarSettings.getWarSiegeEnabled()) {
-			player.sendMessage(Translation.of("msg_err_command_disable"));
+			player.sendMessage(translator.of("msg_err_command_disable"));
 			return;
 		}
 
 		if(!SiegeWarSettings.getWarCommonPeacefulTownsEnabled()) {
-			player.sendMessage(Translation.of("msg_err_command_disable"));
+			player.sendMessage(translator.of("msg_err_command_disable"));
 			return;
 		}
 
 		Resident resident = TownyAPI.getInstance().getResident(player.getUniqueId());
 		if(resident == null || !resident.hasTown()) {
-			player.sendMessage(Translation.of("msg_err_command_disable"));
+			player.sendMessage(translator.of("msg_err_command_disable"));
 			return;
 		}
 
 		//Capital towns cannot go peaceful.
 		Town town = resident.getTownOrNull();
 		if (town.isCapital() && !SiegeWarSettings.capitalsAllowedTownPeacefulness()) {
-			player.sendMessage(Translation.of("msg_err_capital_towns_cannot_go_peaceful"));
+			player.sendMessage(translator.of("msg_err_capital_towns_cannot_go_peaceful"));
 			return;
 		}
 
@@ -250,9 +252,9 @@ public class SiegeWarTownPeacefulnessUtil {
 
 			//Send message to town
 			if (TownMetaDataController.getDesiredPeacefulness(town))
-				TownyMessaging.sendPrefixedTownMessage(town, String.format(Translation.of("msg_war_common_town_declared_peaceful"), daysRequiredForStatusChange));
+				TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_war_common_town_declared_peaceful", daysRequiredForStatusChange));
 			else
-				TownyMessaging.sendPrefixedTownMessage(town, String.format(Translation.of("msg_war_common_town_declared_non_peaceful"), daysRequiredForStatusChange));
+				TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_war_common_town_declared_non_peaceful", daysRequiredForStatusChange));
 
 			//Remove any military nation ranks of residents
 			for(Resident peacefulTownResident: town.getResidents()) {
@@ -267,7 +269,7 @@ public class SiegeWarTownPeacefulnessUtil {
 			TownMetaDataController.setDesiredPeacefulness(town, SiegeWarTownPeacefulnessUtil.isTownPeaceful(town));
 			TownMetaDataController.setPeacefulnessChangeCountdownDays(town, 0);
 			//Send message to town
-			TownyMessaging.sendPrefixedTownMessage(town, String.format(Translation.of("msg_war_common_town_peacefulness_countdown_cancelled")));
+			TownyMessaging.sendPrefixedTownMessage(town, Translatable.of("msg_war_common_town_peacefulness_countdown_cancelled"));
 		}
 		//Save data
 		town.save();


### PR DESCRIPTION
PR largely removes the usage of Translation, which defaults to the server default locale, replacing it with Translatable where possible.

Exceptions:
- EventListeners do not always deliver a player that will be shown the cancel message.
- Dynmap/Bossbar/SiegeType areas where we actually do want things to be using the server default locale, for universal messages without individual readers.

Additionally, many areas where we caught TownyExceptions we were not choosing to show the message in the player's locale.

Fixes a thing in the BannerControlUtil that would cause an evaluation to fail before completion.

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
