### PR TITLE
Military ranks fix

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -3,6 +3,7 @@ package com.gmail.goosius.siegewar;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.DataCleanupUtil;
 
+import com.gmail.goosius.siegewar.utils.PermsCleanupUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -75,6 +76,7 @@ public class SiegeWar extends JavaPlugin {
         }
 
 		DataCleanupUtil.cleanupData(siegeWarPluginError);
+		PermsCleanupUtil.cleanupPerms(siegeWarPluginError);
 		registerPlayerCommands();
 		registerListeners();
 		checkIntegrations();

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -261,17 +261,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 				groupNodes.add("siegewar.command.siegewar.town.*");
 			file.set("towns.ranks.assistant", groupNodes);
 		}
-		
-		// Add nodes to the sheriff rank.
-		if (TownyPerms.mapHasGroup("towns.ranks.sheriff")) {
-			groupNodes = TownyPerms.getPermsOfGroup("towns.ranks.sheriff");
-			if (!groupNodes.contains(townpoints))
-				groupNodes.add(townpoints);
-			if (!groupNodes.contains("towny.command.town.rank.guard"))
-				groupNodes.add("towny.command.town.rank.guard");
-			file.set("towns.ranks.sheriff", groupNodes);
-		}
-		
+
 		// Create new ranks
 		file.createSection("towns.ranks.guard");
 		file.createSection("nations.ranks.private");
@@ -326,8 +316,6 @@ public class SiegeWarAdminCommand implements TabExecutor {
 		groupNodes.add("towny.command.nation.rank.captain");
 		groupNodes.add("towny.command.nation.rank.major");
 		groupNodes.add("towny.command.nation.rank.colonel");
-		groupNodes.add("towny.command.nation.rank.engineer");
-		groupNodes.add("towny.command.nation.rank.gunner");
 		groupNodes.add("towny.nation.siege.pay.grade.500");
 		file.set("nations.ranks.general", groupNodes);
 	
@@ -354,8 +342,6 @@ public class SiegeWarAdminCommand implements TabExecutor {
 
 	private void setupTownyConfigFile(CommandSender sender) {
 		CommentedConfiguration file = TownySettings.getConfig();
-		file.set("economy.price_town_neutrality", "0");
-		file.set("economy.price_nation_neutrality", "0");
 		file.set("economy.bankruptcy.enabled", "true");
 		file.set("town_ruining.town_ruins.enabled", "true");
 		file.set("town_ruining.town_ruins.min_duration_hours", "24");

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -689,13 +689,12 @@ public class SiegeWarAdminCommand implements TabExecutor {
 					Messaging.sendMsg(sender, Translatable.of("msg_swa_town_peacefulness_change_success", town.getName(), Boolean.toString(peaceful)));
 					break;
 				case "setoccupied":
-					//set occupied flag
-					boolean occupied = Boolean.parseBoolean(args[2]);
-					town.setConquered(occupied);
-					//Save data
-					town.save();
-					//Send message
-					Messaging.sendMsg(sender, Translatable.of("msg_swa_town_occupation_change_success", town.getName(), Boolean.toString(occupied)));
+					if(town.hasNation()) {
+						SiegeWarTownOccupationUtil.setTownOccupation(town, town.getNationOrNull());
+						Messaging.sendMsg(sender, Translatable.of("msg_swa_town_occupation_change_success", town.getName()));
+					} else {
+						Messaging.sendErrorMsg(sender, Translatable.of("msg_err_cannot_set_occupation_without_nation", town.getName()));
+					}
 					break;
 				default:
 					showSiegeHelp(sender);

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -702,6 +702,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 					} else {
 						SiegeWarTownOccupationUtil.removeTownOccupation(town);
 						Messaging.sendMsg(sender, Translatable.of("msg_swa_town_occupation_change_success", town.getName(), occupied));
+						break;
 					}
 				default:
 					showSiegeHelp(sender);

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -689,16 +689,22 @@ public class SiegeWarAdminCommand implements TabExecutor {
 					Messaging.sendMsg(sender, Translatable.of("msg_swa_town_peacefulness_change_success", town.getName(), Boolean.toString(peaceful)));
 					break;
 				case "setoccupied":
-					if(town.hasNation()) {
-						SiegeWarTownOccupationUtil.setTownOccupation(town, town.getNationOrNull());
-						Messaging.sendMsg(sender, Translatable.of("msg_swa_town_occupation_change_success", town.getName()));
+					boolean occupied = Boolean.parseBoolean(args[2]);
+					if(occupied) {
+						if(town.hasNation()) {
+							SiegeWarTownOccupationUtil.setTownOccupation(town, town.getNationOrNull());
+							Messaging.sendMsg(sender, Translatable.of("msg_swa_town_occupation_change_success", town.getName(), occupied));
+							break;
+						} else {
+							Messaging.sendErrorMsg(sender, Translatable.of("msg_err_cannot_set_occupation_without_nation", town.getName()));
+							break;
+						}
 					} else {
-						Messaging.sendErrorMsg(sender, Translatable.of("msg_err_cannot_set_occupation_without_nation", town.getName()));
+						SiegeWarTownOccupationUtil.removeTownOccupation(town);
+						Messaging.sendMsg(sender, Translatable.of("msg_swa_town_occupation_change_success", town.getName(), occupied));
 					}
-					break;
 				default:
 					showSiegeHelp(sender);
-					return;
 			}
 		} else
 			showTownHelp(sender);

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -255,8 +255,6 @@ public class SiegeWarAdminCommand implements TabExecutor {
 		// Add nodes to the town assistant rank.
 		if (TownyPerms.mapHasGroup("towns.ranks.assistant")) {
 			groupNodes = TownyPerms.getPermsOfGroup("towns.ranks.assistant");
-			if (!groupNodes.contains("siegewar.town.siege.*"))
-				groupNodes.add("siegewar.town.siege.*");
 			if (!groupNodes.contains("siegewar.command.siegewar.town.*"))
 				groupNodes.add("siegewar.command.siegewar.town.*");
 			file.set("towns.ranks.assistant", groupNodes);
@@ -330,8 +328,6 @@ public class SiegeWarAdminCommand implements TabExecutor {
 		// Add nodes to the nation assistant rank.
 		if (TownyPerms.mapHasGroup("nations.ranks.assistant")) {
 			groupNodes = TownyPerms.getPermsOfGroup("nations.ranks.assistant");
-			if (!groupNodes.contains("siegewar.nation.siege.*"))
-				groupNodes.add("siegewar.nation.siege.*");
 			if (!groupNodes.contains("siegewar.command.siegewar.nation.*"))
 				groupNodes.add("siegewar.command.siegewar.nation.*");
 			file.set("nations.ranks.assistant", groupNodes);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -35,7 +35,7 @@ public class SiegeWarNationEventListener implements Listener {
 	public void onNationRankGivenToPlayer(NationRankAddEvent event) {
 		//In Siegewar, if target town is peaceful or occupied, can't add military rank
 		if(SiegeWarSettings.getWarSiegeEnabled()
-				&& PermissionUtil.doesTownRankAllowPermissionNode(event.getRank(), SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS)) {
+				&& PermissionUtil.doesNationRankAllowPermissionNode(event.getRank(), SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS)) {
 
 			//Get residents town
 			Town town = TownyAPI.getInstance().getResidentTownOrNull(event.getResident());

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -7,6 +7,7 @@ import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.PermissionUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarTownOccupationUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarTownPeacefulnessUtil;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.event.NationPreRemoveEnemyEvent;
@@ -32,15 +33,22 @@ public class SiegeWarNationEventListener implements Listener {
 
 	@EventHandler
 	public void onNationRankGivenToPlayer(NationRankAddEvent event) {
-		//In Siegewar, if target town is peaceful, can't add military rank
+		//In Siegewar, if target town is peaceful or occupied, can't add military rank
 		if(SiegeWarSettings.getWarSiegeEnabled()
-			&& SiegeWarSettings.getWarCommonPeacefulTownsEnabled()
-			&& PermissionUtil.doesNationRankAllowPermissionNode(event.getRank(), SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS)
-			&& SiegeWarTownPeacefulnessUtil.isTownPeaceful(TownyAPI.getInstance().getResidentTownOrNull(event.getResident()))) { // We know that the resident's town will not be null based on the tests already done.
-			event.setCancelled(true);
-			event.setCancelMessage(Translation.of("siegewar_plugin_prefix") + Translation.of("msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident"));
+				&& PermissionUtil.doesTownRankAllowPermissionNode(event.getRank(), SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS)) {
+
+			//Get residents town
+			Town town = TownyAPI.getInstance().getResidentTownOrNull(event.getResident());
+			if(town != null) {
+				if(SiegeWarTownPeacefulnessUtil.isTownPeaceful(town)) {
+					event.setCancelled(true);
+					event.setCancelMessage(Translation.of("siegewar_plugin_prefix") + Translation.of("msg_war_siege_cannot_add_military_rank_to_peaceful_resident"));
+				} else if (SiegeWarTownOccupationUtil.isTownOccupied(town)) {
+					event.setCancelled(true);
+					event.setCancelMessage(Translation.of("siegewar_plugin_prefix") + Translation.of("msg_war_siege_cannot_add_military_rank_to_occupied_resident"));
+				}
+			}
 		}
-		
 	}
 	
 	/*

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -49,7 +49,7 @@ public class SiegeWarNationEventListener implements Listener {
 				}
 			}
 		}
-
+		
 	}
 	
 	/*

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -49,6 +49,7 @@ public class SiegeWarNationEventListener implements Listener {
 				}
 			}
 		}
+
 	}
 	
 	/*

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -236,7 +236,7 @@ public class SiegeWarTownEventListener implements Listener {
 	public void onTownRankGivenToPlayer(TownAddResidentRankEvent event) {
 		//In Siegewar, if target town is peaceful or occupied, can't add military rank
 		if(SiegeWarSettings.getWarSiegeEnabled()
-				&& PermissionUtil.doesNationRankAllowPermissionNode(event.getRank(), SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS)) {
+				&& PermissionUtil.doesTownRankAllowPermissionNode(event.getRank(), SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS)) {
 
 			//Get residents town
 			Town town = TownyAPI.getInstance().getResidentTownOrNull(event.getResident());

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
@@ -122,7 +122,7 @@ public class DataCleanupUtil {
             SiegeWar.info("Old Town Neutrality Data migrated...");
     }
 
-    public static void deleteLegacyResidentMetadata() {
+    private static void deleteLegacyResidentMetadata() {
         for(Resident resident: TownyUniverse.getInstance().getResidents()) {
             ResidentMetaDataController.deleteLegacyMetadata(resident);
         }
@@ -139,5 +139,4 @@ public class DataCleanupUtil {
             NationMetaDataController.deleteLegacyMetadata(nation);
         }
     }
-
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
@@ -139,4 +139,5 @@ public class DataCleanupUtil {
             NationMetaDataController.deleteLegacyMetadata(nation);
         }
     }
+
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
@@ -1,0 +1,44 @@
+package com.gmail.goosius.siegewar.utils;
+
+import com.gmail.goosius.siegewar.SiegeWar;
+import com.palmergames.bukkit.config.CommentedConfiguration;
+import com.palmergames.bukkit.towny.permissions.TownyPerms;
+
+import java.util.List;
+
+public class PermsCleanupUtil {
+
+    public static void cleanupPerms(boolean siegeWarPluginError) {
+        if(siegeWarPluginError) {
+            SiegeWar.severe("SiegeWar is in safe mode. Data cleanup not attempted.");
+        }
+        CommentedConfiguration townyPermsFile = TownyPerms.getTownyPermsFile();
+        boolean success = deleteMilitaryPermsFromSheriffRank(townyPermsFile);
+        if(success) {
+            townyPermsFile.save();
+            SiegeWar.info("Perms Cleanup Complete");
+        }
+    }
+    
+    private static boolean deleteMilitaryPermsFromSheriffRank(CommentedConfiguration townyPermsFile) {
+        boolean success = false;
+        List<String> groupNodes;
+        String townpoints = "siegewar.town.siege.battle.points";
+        // Add nodes to the sheriff rank.
+        if (TownyPerms.mapHasGroup("towns.ranks.sheriff")) {
+            groupNodes = TownyPerms.getPermsOfGroup("towns.ranks.sheriff");
+            if (groupNodes.contains(townpoints)) {
+                groupNodes.remove(townpoints);
+                success = true;
+            }
+            if (groupNodes.contains("towny.command.town.rank.guard")) {
+                groupNodes.remove("towny.command.town.rank.guard");
+                success = true;
+            }
+            if(success) {
+                townyPermsFile.set("towns.ranks.sheriff", groupNodes);
+            }
+        }
+        return success;
+    }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
@@ -15,7 +15,9 @@ public class PermsCleanupUtil {
         CommentedConfiguration townyPermsFile = TownyPerms.getTownyPermsFile();
         boolean success = false;
         success = deleteMilitaryPermsFromSheriffRank(townyPermsFile, success);
+        success = deleteFireCannonPermFromGuardRank(townyPermsFile, success);
         success = deleteGunnerAndEngineerRanks(townyPermsFile, success);
+
         if(success) {
             townyPermsFile.save();
             SiegeWar.info("Perms Cleanup Complete");
@@ -24,12 +26,15 @@ public class PermsCleanupUtil {
     
     private static boolean deleteMilitaryPermsFromSheriffRank(CommentedConfiguration townyPermsFile, boolean success) {
         List<String> groupNodes;
-        String townpoints = "siegewar.town.siege.battle.points";
         // Add nodes to the sheriff rank.
         if (TownyPerms.mapHasGroup("towns.ranks.sheriff")) {
             groupNodes = TownyPerms.getPermsOfGroup("towns.ranks.sheriff");
-            if (groupNodes.contains(townpoints)) {
-                groupNodes.remove(townpoints);
+            if (groupNodes.contains("siegewar.town.siege.battle.points")) {
+                groupNodes.remove("siegewar.town.siege.battle.points");
+                success = true;
+            }
+            if (groupNodes.contains("siegewar.town.siege.fire.cannon.in.siegezone")) {
+                groupNodes.remove("siegewar.town.siege.fire.cannon.in.siegezone");
                 success = true;
             }
             if (groupNodes.contains("towny.command.town.rank.guard")) {
@@ -43,13 +48,34 @@ public class PermsCleanupUtil {
         return success;
     }
 
+    private static boolean deleteFireCannonPermFromGuardRank(CommentedConfiguration townyPermsFile, boolean success) {
+        List<String> groupNodes;
+        // Add nodes to the sheriff rank.
+        if (TownyPerms.mapHasGroup("towns.ranks.guard")) {
+            groupNodes = TownyPerms.getPermsOfGroup("towns.ranks.guard");
+            if (groupNodes.contains("siegewar.town.siege.fire.cannon.in.siegezone")) {
+                groupNodes.remove("siegewar.town.siege.fire.cannon.in.siegezone");
+                townyPermsFile.set("towns.ranks.guard", groupNodes);
+                success = true;
+            }
+        }
+        return success;
+    }
+    
     private static boolean deleteGunnerAndEngineerRanks(CommentedConfiguration townyPermsFile, boolean success) {
-        if (TownyPerms.mapHasGroup("nation.ranks.gunner")) {
-            townyPermsFile.set("nation.ranks.gunner", null);
+        if (TownyPerms.mapHasGroup("nations.ranks.gunner")) {
+            townyPermsFile.set("nations.ranks.gunner", null);
             success = true;
         }
-        if (TownyPerms.mapHasGroup("nation.ranks.engineer")) {
-            townyPermsFile.set("nation.ranks.engineer", null);
+        if (TownyPerms.mapHasGroup("nations.ranks.engineer")) {
+            townyPermsFile.set("nations.ranks.engineer", null);
+            success = true;
+        }
+        if (TownyPerms.mapHasGroup("nations.ranks.general")) {
+            List<String> groupNodes = TownyPerms.getPermsOfGroup("nations.ranks.general");
+            groupNodes.remove("towny.command.nation.rank.engineer");
+            groupNodes.remove("towny.command.nation.rank.gunner");
+            townyPermsFile.set("nations.ranks.general", groupNodes);
             success = true;
         }
         return success;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
@@ -10,7 +10,8 @@ public class PermsCleanupUtil {
 
     public static void cleanupPerms(boolean siegeWarPluginError) {
         if(siegeWarPluginError) {
-            SiegeWar.severe("SiegeWar is in safe mode. Data cleanup not attempted.");
+            SiegeWar.severe("SiegeWar is in safe mode. Perms cleanup not attempted.");
+            return;
         }
         CommentedConfiguration townyPermsFile = TownyPerms.getTownyPermsFile();
         boolean success = false;
@@ -26,20 +27,17 @@ public class PermsCleanupUtil {
     
     private static boolean deleteMilitaryPermsFromSheriffRank(CommentedConfiguration townyPermsFile, boolean success) {
         List<String> groupNodes;
-        // Add nodes to the sheriff rank.
+        // Deleted nodes from the sheriff rank.
         if (TownyPerms.mapHasGroup("towns.ranks.sheriff")) {
             groupNodes = TownyPerms.getPermsOfGroup("towns.ranks.sheriff");
             if (groupNodes.contains("siegewar.town.siege.battle.points")) {
-                groupNodes.remove("siegewar.town.siege.battle.points");
-                success = true;
+                success = groupNodes.remove("siegewar.town.siege.battle.points");
             }
             if (groupNodes.contains("siegewar.town.siege.fire.cannon.in.siegezone")) {
-                groupNodes.remove("siegewar.town.siege.fire.cannon.in.siegezone");
-                success = true;
+                success = groupNodes.remove("siegewar.town.siege.fire.cannon.in.siegezone");
             }
             if (groupNodes.contains("towny.command.town.rank.guard")) {
-                groupNodes.remove("towny.command.town.rank.guard");
-                success = true;
+                success = groupNodes.remove("towny.command.town.rank.guard");
             }
             if(success) {
                 townyPermsFile.set("towns.ranks.sheriff", groupNodes);
@@ -50,13 +48,14 @@ public class PermsCleanupUtil {
 
     private static boolean deleteFireCannonPermFromGuardRank(CommentedConfiguration townyPermsFile, boolean success) {
         List<String> groupNodes;
-        // Add nodes to the sheriff rank.
+        // Delete nodes from the guard rank.
         if (TownyPerms.mapHasGroup("towns.ranks.guard")) {
             groupNodes = TownyPerms.getPermsOfGroup("towns.ranks.guard");
             if (groupNodes.contains("siegewar.town.siege.fire.cannon.in.siegezone")) {
-                groupNodes.remove("siegewar.town.siege.fire.cannon.in.siegezone");
+                success = groupNodes.remove("siegewar.town.siege.fire.cannon.in.siegezone");
+            }
+            if (success) {
                 townyPermsFile.set("towns.ranks.guard", groupNodes);
-                success = true;
             }
         }
         return success;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
@@ -16,6 +16,7 @@ public class PermsCleanupUtil {
         CommentedConfiguration townyPermsFile = TownyPerms.getTownyPermsFile();
         boolean success = false;
         success = deleteMilitaryPermsFromSheriffRank(townyPermsFile, success);
+        success = deleteMilitaryPermsFromAssistantRanks(townyPermsFile, success);
         success = deleteFireCannonPermFromGuardRank(townyPermsFile, success);
         success = deleteGunnerAndEngineerRanks(townyPermsFile, success);
 
@@ -25,6 +26,9 @@ public class PermsCleanupUtil {
         }
     }
     
+    /**
+     * Delete military perms from sheriff rank. So that peaceful and occupied towns can still have sheriffs
+     */
     private static boolean deleteMilitaryPermsFromSheriffRank(CommentedConfiguration townyPermsFile, boolean success) {
         List<String> groupNodes;
         // Deleted nodes from the sheriff rank.
@@ -45,7 +49,30 @@ public class PermsCleanupUtil {
         }
         return success;
     }
-
+    
+    /**
+     * Delete military perms from assistant rank. So that peaceful and occupied towns can still have assistants
+     */
+    private static boolean deleteMilitaryPermsFromAssistantRanks(CommentedConfiguration townyPermsFile, boolean success) {
+        List<String> groupNodes = null;
+        if (TownyPerms.mapHasGroup("towns.ranks.assistant")) {
+            groupNodes = TownyPerms.getPermsOfGroup("towns.ranks.assistant");
+            if (groupNodes.contains("siegewar.town.siege.*")) {
+                success = groupNodes.remove("siegewar.town.siege.*");
+            }
+        }
+        if (TownyPerms.mapHasGroup("nations.ranks.assistant")) {
+            groupNodes = TownyPerms.getPermsOfGroup("nations.ranks.assistant");
+            if (groupNodes.contains("siegewar.nation.siege.*")) {
+                success = groupNodes.remove("siegewar.nation.siege.*");
+            }
+        }
+        if(success) {
+            townyPermsFile.set("towns.ranks.sheriff", groupNodes);
+        }
+        return success;
+    }
+    
     private static boolean deleteFireCannonPermFromGuardRank(CommentedConfiguration townyPermsFile, boolean success) {
         List<String> groupNodes;
         // Delete nodes from the guard rank.

--- a/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
@@ -72,10 +72,15 @@ public class PermsCleanupUtil {
         }
         if (TownyPerms.mapHasGroup("nations.ranks.general")) {
             List<String> groupNodes = TownyPerms.getPermsOfGroup("nations.ranks.general");
-            groupNodes.remove("towny.command.nation.rank.engineer");
-            groupNodes.remove("towny.command.nation.rank.gunner");
-            townyPermsFile.set("nations.ranks.general", groupNodes);
-            success = true;
+            if (groupNodes.contains("towny.command.nation.rank.engineer")) {
+                success = groupNodes.remove("towny.command.nation.rank.engineer");
+            }
+            if (groupNodes.contains("towny.command.nation.rank.gunner")) {
+                success = groupNodes.remove("towny.command.nation.rank.gunner");
+            }
+            if(success) {
+                townyPermsFile.set("nations.ranks.general", groupNodes);      
+            }
         }
         return success;
     }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/PermsCleanupUtil.java
@@ -13,15 +13,16 @@ public class PermsCleanupUtil {
             SiegeWar.severe("SiegeWar is in safe mode. Data cleanup not attempted.");
         }
         CommentedConfiguration townyPermsFile = TownyPerms.getTownyPermsFile();
-        boolean success = deleteMilitaryPermsFromSheriffRank(townyPermsFile);
+        boolean success = false;
+        success = deleteMilitaryPermsFromSheriffRank(townyPermsFile, success);
+        success = deleteGunnerAndEngineerRanks(townyPermsFile, success);
         if(success) {
             townyPermsFile.save();
             SiegeWar.info("Perms Cleanup Complete");
         }
     }
     
-    private static boolean deleteMilitaryPermsFromSheriffRank(CommentedConfiguration townyPermsFile) {
-        boolean success = false;
+    private static boolean deleteMilitaryPermsFromSheriffRank(CommentedConfiguration townyPermsFile, boolean success) {
         List<String> groupNodes;
         String townpoints = "siegewar.town.siege.battle.points";
         // Add nodes to the sheriff rank.
@@ -38,6 +39,18 @@ public class PermsCleanupUtil {
             if(success) {
                 townyPermsFile.set("towns.ranks.sheriff", groupNodes);
             }
+        }
+        return success;
+    }
+
+    private static boolean deleteGunnerAndEngineerRanks(CommentedConfiguration townyPermsFile, boolean success) {
+        if (TownyPerms.mapHasGroup("nation.ranks.gunner")) {
+            townyPermsFile.set("nation.ranks.gunner", null);
+            success = true;
+        }
+        if (TownyPerms.mapHasGroup("nation.ranks.engineer")) {
+            townyPermsFile.set("nation.ranks.engineer", null);
+            success = true;
         }
         return success;
     }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMilitaryRanksUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMilitaryRanksUtil.java
@@ -1,0 +1,27 @@
+package com.gmail.goosius.siegewar.utils;
+
+import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
+
+import java.util.ArrayList;
+
+public class SiegeWarMilitaryRanksUtil {
+    
+    public static void removeMilitaryRanksFromTownResidents(Town town) {
+        for(Resident townResident: town.getResidents()) {
+            //Remove town ranks
+            for (String townRank : new ArrayList<>(townResident.getTownRanks())) {
+                if (PermissionUtil.doesTownRankAllowPermissionNode(townRank, SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS)) {
+                    townResident.removeTownRank(townRank);
+                }
+            }
+            //Remove nation ranks
+            for (String nationRank : new ArrayList<>(townResident.getNationRanks())) {
+                if (PermissionUtil.doesNationRankAllowPermissionNode(nationRank, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS)) {
+                    townResident.removeNationRank(nationRank);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownOccupationUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownOccupationUtil.java
@@ -51,10 +51,9 @@ public class SiegeWarTownOccupationUtil {
     }
 
     public static void setTownOccupation(Town targetTown, @NotNull Nation occupyingNation) {
-        //Remove the town from its existing nation, if it has one
-		Nation existingNation = null;
-		if(targetTown.hasNation()) {
-			existingNation = targetTown.getNationOrNull();
+        //If the town has a nation which is different than the incoming one, remove town from nation
+		Nation existingNation = targetTown.getNationOrNull();
+		if(existingNation != null && existingNation != occupyingNation) {
 			targetTown.removeNation();
 		}
 
@@ -76,7 +75,7 @@ public class SiegeWarTownOccupationUtil {
 		//Save data
 		targetTown.save();
 		occupyingNation.save();
-		if(existingNation != null) {
+		if(existingNation != null && existingNation != occupyingNation) {
 			existingNation.save();
 		}
     }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownOccupationUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownOccupationUtil.java
@@ -70,6 +70,9 @@ public class SiegeWarTownOccupationUtil {
 		//Set town occupied flag
 		targetTown.setConquered(true);
 
+		//Remove military ranks
+		SiegeWarMilitaryRanksUtil.removeMilitaryRanksFromTownResidents(targetTown);
+		
 		//Save data
 		targetTown.save();
 		occupyingNation.save();

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
@@ -27,7 +27,7 @@ import java.util.LinkedHashMap;
 public class SiegeWarTownPeacefulnessUtil {
 
 	public static boolean isTownPeaceful(Town town) {
-		return TownMetaDataController.getPeacefulness(town);
+		return SiegeWarSettings.getWarCommonPeacefulTownsEnabled() && TownMetaDataController.getPeacefulness(town);
 	}
 	
 	public static void setTownPeacefulness(Town town, boolean bool) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
@@ -90,19 +90,14 @@ public class SiegeWarTownPeacefulnessUtil {
 		//Reverse the town peacefulness setting
 		TownMetaDataController.setPeacefulness(town, !TownMetaDataController.getPeacefulness(town));
 
-		if (SiegeWarSettings.getWarSiegeEnabled()) {
-			if (TownMetaDataController.getPeacefulness(town)) {
-				message = Translation.of("msg_town_became_peaceful", town.getFormattedName());
-			} else {
-				message = Translation.of("msg_town_became_non_peaceful", town.getFormattedName());
-			}
+		if (TownMetaDataController.getPeacefulness(town)) {
+			//Remove military ranks
+			SiegeWarMilitaryRanksUtil.removeMilitaryRanksFromTownResidents(town);
+			message = Translation.of("msg_town_became_peaceful", town.getFormattedName());
 		} else {
-			if (TownMetaDataController.getPeacefulness(town)) {
-				message = Translation.of("msg_town_became_peaceful", town.getFormattedName());
-			} else {
-				message = Translation.of("msg_town_became_non_peaceful", town.getFormattedName());
-			}
+			message = Translation.of("msg_town_became_non_peaceful", town.getFormattedName());
 		}
+
 		TownyMessaging.sendPrefixedTownMessage(town, message);
 		town.save();
 	}
@@ -252,9 +247,6 @@ public class SiegeWarTownPeacefulnessUtil {
 				TownyMessaging.sendPrefixedTownMessage(town, String.format(Translation.of("msg_war_common_town_declared_peaceful"), daysRequiredForStatusChange));
 			else
 				TownyMessaging.sendPrefixedTownMessage(town, String.format(Translation.of("msg_war_common_town_declared_non_peaceful"), daysRequiredForStatusChange));
-
-			//Remove military ranks
-			SiegeWarMilitaryRanksUtil.removeMilitaryRanksFromTownResidents(town);
 		} else {
 			//Countdown in progress. Cancel the countdown
 			TownMetaDataController.setDesiredPeacefulness(town, SiegeWarTownPeacefulnessUtil.isTownPeaceful(town));

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
@@ -2,7 +2,6 @@ package com.gmail.goosius.siegewar.utils;
 
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
-import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.TownyAPI;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
@@ -254,14 +254,8 @@ public class SiegeWarTownPeacefulnessUtil {
 			else
 				TownyMessaging.sendPrefixedTownMessage(town, String.format(Translation.of("msg_war_common_town_declared_non_peaceful"), daysRequiredForStatusChange));
 
-			//Remove any military nation ranks of residents
-			for(Resident peacefulTownResident: town.getResidents()) {
-				for (String nationRank : new ArrayList<>(peacefulTownResident.getNationRanks())) {
-					if (PermissionUtil.doesNationRankAllowPermissionNode(nationRank, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS)) {
-						peacefulTownResident.removeNationRank(nationRank);
-					}
-				}
-			}
+			//Remove military ranks
+			SiegeWarMilitaryRanksUtil.removeMilitaryRanksFromTownResidents(town);
 		} else {
 			//Countdown in progress. Cancel the countdown
 			TownMetaDataController.setDesiredPeacefulness(town, SiegeWarTownPeacefulnessUtil.isTownPeaceful(town));

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -564,6 +564,7 @@ msg_err_cannot_invade_without_victory: "&cYou cannot capture this town unless yo
 msg_err_cannot_invade_siege_still_in_progress: '&cYou cannot capture this town while the siege is still in progress.'
 msg_err_cannot_invade_town_already_occupied: '&cThere is no need to capture this town, because your nation already owns and occupies it.'
 msg_war_siege_cannot_add_military_rank_to_occupied_resident: '&cUnable to add military rank to resident, because they belong to an Occupied town.'
+msg_err_cannot_set_occupation_without_nation: '&cTown %s has no nation. You must set the nation first before you can set the town to Occupied.'
 
 #Siegezone proximity warning
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -513,7 +513,7 @@ msg_war_common_town_declared_non_peaceful: '&bNon-Peacefulness Declared! The tow
 msg_town_became_peaceful: '&b%s has been confirmed as Peaceful. The town is now immune to siege attacks, but vulnerable to getting subverted by nearby nations. Residents cannot gain nation-military ranks.'
 msg_town_became_non_peaceful: '&b%s has been confirmed as Non-Peaceful. The town is no longer immune to siege attacks, and no longer vulnerable to getting subverted by nearby nations. Residents can now gain nation-military ranks.'
 msg_war_common_town_peacefulness_countdown_cancelled: '&bThe Peaceful status change countdown was cancelled.'
-msg_war_siege_cannot_add_nation_military_rank_to_peaceful_resident: '&cUnable to add nation military rank to resident, because they belong to a Peaceful town.'
+msg_war_siege_cannot_add_military_rank_to_peaceful_resident: '&cUnable to add military rank to resident, because they belong to a Peaceful town.'
 sg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."
 msg_err_peaceful_towns_cannot_revolt: '&cPeaceful towns cannot revolt.'
 msg_err_capital_towns_cannot_go_peaceful: '&cCapital towns cannot go peaceful.'
@@ -558,11 +558,12 @@ msg_revolt_siege_defender_win_result: ' The town now stands open for invasion an
 status_town_siege_status_invaded: '   &2Town Captured: %s'
 status_town_peacefulness_flag: '&b(Peaceful)'
 
-#Capture
+#Town Capture & Occupation
 
 msg_err_cannot_invade_without_victory: "&cYou cannot capture this town unless your nation is victorious in the siege."
 msg_err_cannot_invade_siege_still_in_progress: '&cYou cannot capture this town while the siege is still in progress.'
 msg_err_cannot_invade_town_already_occupied: '&cThere is no need to capture this town, because your nation already owns and occupies it.'
+msg_war_siege_cannot_add_military_rank_to_occupied_resident: '&cUnable to add military rank to resident, because they belong to an Occupied town.'
 
 #Siegezone proximity warning
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- For the new occupation system to work, occupied towns can no longer have use of military ranks.
- This PR fixes it so that both Peaceful & Occupied towns cannot get any military ranks
- On capture/peacefulness, all ranks are stripped
- Sheriff is no longer a military rank (migration util added to fix that)

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server.   .... I will before merging though
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
