### PR TITLE
Simplify Attacker/Defender logic

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -152,38 +152,18 @@ public class SiegeController {
 		else
 			siege.setSiegeType(SiegeType.parseString(siegeTypeString));
 
-		//Load Attacker
-		switch (siege.getSiegeType()) {
-			case CONQUEST:
-				String uuid = SiegeMetaDataController.getAttackerUUID(town);
-				if (uuid == null)
-					return false;
-				Nation nation = TownyAPI.getInstance().getNation(UUID.fromString(uuid));
-				if (nation == null)
-					return false;
-				siege.setAttacker(nation);
-				break;
-			case REVOLT:
-				siege.setAttacker(town);
-				break;
-		}
+		//Get nation
+		String nationUUID = SiegeMetaDataController.getAttackerUUID(town);
+		if (nationUUID == null)
+			return false;
+		Nation nation = TownyAPI.getInstance().getNation(UUID.fromString(nationUUID));
+		if (nation == null)
+			return false;
 
-		//Load defender
-		switch (siege.getSiegeType()) {
-			case CONQUEST:
-				siege.setDefender(town);
-				break;
-			case REVOLT:
-				String uuid = SiegeMetaDataController.getDefenderUUID(town);
-				if (uuid == null)
-					return false;
-				Nation nation = TownyAPI.getInstance().getNation(UUID.fromString(uuid));
-				if (nation == null)
-					return false;
-				siege.setDefender(nation);
-				break;
-		}
-
+		//Set attacker and defender
+		siege.setAttacker(nation);
+		siege.setDefender(town);
+		
 		//Load Status
 		if (SiegeMetaDataController.getSiegeStatus(town).isEmpty())
 			return false;
@@ -237,17 +217,17 @@ public class SiegeController {
 	}
 
 	//Remove a particular siege, and all associated data
-	public static void removeSiege(Siege siege, SiegeSide refundSideIfSiegeIsActive) {
-		//If siege is active, initiate siege immunity for town, and return war chest
+	public static void removeSiege(Siege siege, SiegeSide siegeSideToAwardWarchestTo) {
+		//If siege is active, initiate siege immunity for town, and award war chest
 		if(siege.getStatus().isActive()) {
 			siege.setActualEndTime(System.currentTimeMillis());
 			SiegeWarImmunityUtil.grantSiegeImmunityAfterEndedSiege(siege.getTown(), siege);
 
-			//Return warchest only if siege is not revolt
+			//Award warchest if siege is not revolt
 			if(!siege.isRevoltSiege()) {
-				if (refundSideIfSiegeIsActive == SiegeSide.ATTACKERS)
+				if (siegeSideToAwardWarchestTo == SiegeSide.ATTACKERS)
 					SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getAttacker());
-				else if (refundSideIfSiegeIsActive == SiegeSide.DEFENDERS)
+				else if (siegeSideToAwardWarchestTo == SiegeSide.DEFENDERS)
 					SiegeWarMoneyUtil.giveWarChestTo(siege, siege.getDefender());
 			}
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -163,7 +163,7 @@ public class SiegeController {
 		//Set attacker and defender
 		siege.setAttacker(nation);
 		siege.setDefender(town);
-		
+
 		//Load Status
 		if (SiegeMetaDataController.getSiegeStatus(town).isEmpty())
 			return false;

--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
@@ -92,34 +92,4 @@ public enum SiegeWarPermissionNodes {
 		return value.replace("*", replace + "");
 	}
 
-	public static String getPermissionNodeToStartSiege(SiegeType siegeType) {
-		switch (siegeType) {
-			case CONQUEST:
-				return SIEGEWAR_NATION_SIEGE_STARTCONQUESTSIEGE.getNode();
-			case REVOLT:
-				return SIEGEWAR_TOWN_SIEGE_STARTREVOLTSIEGE.getNode();
-			default:
-				throw new RuntimeException("Unknown siege type");
-		}
-	}
-
-	public static String getPermissionNodeToAbandonAttack(SiegeType siegeType) {
-		switch (siegeType) {
-			case CONQUEST:
-			case REVOLT:
-				return SIEGEWAR_NATION_SIEGE_ABANDON.getNode();
-			default:
-				throw new RuntimeException("Uknown siege type");
-		}
-	}
-
-	public static String getPermissionNodeToSurrenderDefence(SiegeType siegeType) {
-		switch (siegeType) {
-			case CONQUEST:
-			case REVOLT:
-				return SIEGEWAR_TOWN_SIEGE_SURRENDER.getNode();
-			default:
-				throw new RuntimeException("Unknown siege type.");
-		}
-	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
@@ -11,9 +11,8 @@ public enum SiegeWarPermissionNodes {
 	//Battle points
 	SIEGEWAR_NATION_SIEGE_BATTLE_POINTS("siegewar.nation.siege.battle.points"),
 	//Actions
-	SIEGEWAR_NATION_SIEGE_CONQUEST_SIEGE_START("siegewar.nation.siege.conquest.siege.start"),
-	SIEGEWAR_NATION_SIEGE_CONQUEST_SIEGE_ABANDON("siegewar.nation.siege.conquest.siege.abandon"),
-	SIEGEWAR_NATION_SIEGE_REVOLT_SIEGE_SURRENDER("siegewar.nation.siege.revolt.siege.surrender"),
+	SIEGEWAR_NATION_SIEGE_STARTCONQUESTSIEGE("siegewar.nation.siege.startconquestsiege"),
+	SIEGEWAR_NATION_SIEGE_ABANDON("siegewar.nation.siege.abandon"),
 	SIEGEWAR_NATION_SIEGE_INVADE("siegewar.nation.siege.invade"),
 	SIEGEWAR_NATION_SIEGE_PLUNDER("siegewar.nation.siege.plunder"),
 	SIEGEWAR_NATION_SIEGE_SUBVERTPEACEFULTOWN("siegewar.nation.siege.subvertpeacefultown"),
@@ -22,9 +21,8 @@ public enum SiegeWarPermissionNodes {
 	//Battle points
 	SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS("siegewar.town.siege.battle.points"),
 	//Actions
-	SIEGEWAR_TOWN_SIEGE_CONQUEST_SIEGE_SURRENDER("siegewar.town.siege.conquest.siege.surrender"),
-	SIEGEWAR_TOWN_SIEGE_REVOLT_SIEGE_START("siegewar.town.siege.revolt.siege.start"),
-	SIEGEWAR_TOWN_SIEGE_REVOLT_SIEGE_ABANDON("siegewar.town.siege.revolt.siege.abandon"),
+	SIEGEWAR_TOWN_SIEGE_SURRENDER("siegewar.town.siege.surrender"),
+	SIEGEWAR_TOWN_SIEGE_STARTREVOLTSIEGE("siegewar.town.siege.startrevoltsiege"),
 
 	// Siegewar related war sickness immunities
 	SIEGEWAR_IMMUNE_TO_WAR_NAUSEA("siegewar.immune.to.war.nausea"),
@@ -97,9 +95,9 @@ public enum SiegeWarPermissionNodes {
 	public static String getPermissionNodeToStartSiege(SiegeType siegeType) {
 		switch (siegeType) {
 			case CONQUEST:
-				return SIEGEWAR_NATION_SIEGE_CONQUEST_SIEGE_START.getNode();
+				return SIEGEWAR_NATION_SIEGE_STARTCONQUESTSIEGE.getNode();
 			case REVOLT:
-				return SIEGEWAR_TOWN_SIEGE_REVOLT_SIEGE_START.getNode();
+				return SIEGEWAR_TOWN_SIEGE_STARTREVOLTSIEGE.getNode();
 			default:
 				throw new RuntimeException("Unknown siege type");
 		}
@@ -108,9 +106,8 @@ public enum SiegeWarPermissionNodes {
 	public static String getPermissionNodeToAbandonAttack(SiegeType siegeType) {
 		switch (siegeType) {
 			case CONQUEST:
-				return SIEGEWAR_NATION_SIEGE_CONQUEST_SIEGE_ABANDON.getNode();
 			case REVOLT:
-				return SIEGEWAR_TOWN_SIEGE_REVOLT_SIEGE_ABANDON.getNode();
+				return SIEGEWAR_NATION_SIEGE_ABANDON.getNode();
 			default:
 				throw new RuntimeException("Uknown siege type");
 		}
@@ -119,9 +116,8 @@ public enum SiegeWarPermissionNodes {
 	public static String getPermissionNodeToSurrenderDefence(SiegeType siegeType) {
 		switch (siegeType) {
 			case CONQUEST:
-				return SIEGEWAR_TOWN_SIEGE_CONQUEST_SIEGE_SURRENDER.getNode();
 			case REVOLT:
-				return SIEGEWAR_NATION_SIEGE_REVOLT_SIEGE_SURRENDER.getNode();
+				return SIEGEWAR_TOWN_SIEGE_SURRENDER.getNode();
 			default:
 				throw new RuntimeException("Unknown siege type.");
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -77,27 +77,13 @@ public class SiegeWarNationEventListener implements Listener {
 		 * Adjust sieges if needed
 		 */
 		for (Siege siege : SiegeController.getSieges()) {
-			switch(siege.getSiegeType()) {
-				case CONQUEST:
-					/*
-					 * If attacker (which is a nation) disappears, we must delete the siege
-					 */
-					if(event.getNationUUID() == siege.getAttacker().getUUID()) {
-						SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);
-					}
-					break;
-				case REVOLT:
-					/*
-					 * Revolt
-					 * If defender (which is a nation) disappears, we must delete the siege
-					 */
-					if (event.getNationUUID() == siege.getDefender().getUUID()) {
-						SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);
-					}
-				break;
+			/*
+			 * If attacker (which is always a nation) disappears, we must delete the siege
+			 */
+			if (event.getNationUUID() == siege.getAttacker().getUUID()) {
+				SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);
 			}
 		}
-
 		//Award nation refund
 		event.getNationUUID();
 		Resident king = event.getLeader();

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -84,6 +84,7 @@ public class SiegeWarNationEventListener implements Listener {
 				SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);
 			}
 		}
+		
 		//Award nation refund
 		event.getNationUUID();
 		Resident king = event.getLeader();

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -84,7 +84,7 @@ public class SiegeWarNationEventListener implements Listener {
 				SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);
 			}
 		}
-		
+
 		//Award nation refund
 		event.getNationUUID();
 		Resident king = event.getLeader();

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -277,16 +277,16 @@ public class SiegeWarStatusScreenListener implements Listener {
 
 	                case ATTACKER_WIN:
 	                case DEFENDER_SURRENDER:
-					case DEFENDER_WIN:
-					case ATTACKER_ABANDON:
+
 	                    String invadedPlunderedStatus = getPlunderStatusLine(siege, translator) + getInvadeStatusLine(siege, translator);
-						if(!invadedPlunderedStatus.isEmpty())
-							out.add(invadedPlunderedStatus);
+						out.add(invadedPlunderedStatus);
 
 	                    String siegeImmunityTimer = translator.of("status_town_siege_immunity_timer", time);
 	                    out.add(siegeImmunityTimer);
 	                    break;
 
+					case DEFENDER_WIN:
+					case ATTACKER_ABANDON:
 	                case PENDING_DEFENDER_SURRENDER:
 	                case PENDING_ATTACKER_ABANDON:
 					case UNKNOWN:

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -279,7 +279,7 @@ public class SiegeWarStatusScreenListener implements Listener {
 	                case DEFENDER_SURRENDER:
 					case DEFENDER_WIN:
 					case ATTACKER_ABANDON:
-	                    String invadedPlunderedStatus = getInvadedPlunderedStatusLine(siege, translator);
+	                    String invadedPlunderedStatus = getPlunderStatusLine(siege, translator) + getInvadeStatusLine(siege, translator);
 						if(!invadedPlunderedStatus.isEmpty())
 							out.add(invadedPlunderedStatus);
 
@@ -345,30 +345,6 @@ public class SiegeWarStatusScreenListener implements Listener {
                 return "???";
         }
     }
-
-    private static String getInvadedPlunderedStatusLine(Siege siege, Translator translator) {
-		switch(siege.getSiegeType()) {
-			case CONQUEST:
-				switch (siege.getStatus()) {
-					case ATTACKER_WIN:
-					case DEFENDER_SURRENDER:
-						return getPlunderStatusLine(siege, translator) + getInvadeStatusLine(siege, translator);
-					default:
-						break;
-				}
-				break;
-			case REVOLT:
-				switch (siege.getStatus()) {
-					case DEFENDER_WIN:
-					case ATTACKER_ABANDON:
-						return getPlunderStatusLine(siege, translator) + getInvadeStatusLine(siege, translator);
-					default:
-						break;
-				}
-				break;
-		}
-		return "";
-	}
 
 	private static String getPlunderStatusLine(Siege siege, Translator translator) {
 		String plunderedYesNo = siege.isTownPlundered() ? translator.of("status_yes") : translator.of("status_no_green");

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -274,23 +274,19 @@ public class SiegeWarStatusScreenListener implements Listener {
 
 						// > Time Remaining: 22 minutes
 						out.add(translator.of("status_town_siege_battle_time_remaining", siege.getFormattedBattleTimeRemaining(translator)));
+						break;
 
 	                case ATTACKER_WIN:
 	                case DEFENDER_SURRENDER:
 
-	                    String invadedPlunderedStatus = getPlunderStatusLine(siege, translator) + getInvadeStatusLine(siege, translator);
-						out.add(invadedPlunderedStatus);
+						out.add(getPlunderStatusLine(siege, translator));
+						out.add(getInvadeStatusLine(siege, translator));
 
-	                    String siegeImmunityTimer = translator.of("status_town_siege_immunity_timer", time);
-	                    out.add(siegeImmunityTimer);
-	                    break;
-
-					case DEFENDER_WIN:
 					case ATTACKER_ABANDON:
-	                case PENDING_DEFENDER_SURRENDER:
-	                case PENDING_ATTACKER_ABANDON:
-					case UNKNOWN:
-						break;
+					case DEFENDER_WIN:
+
+						String siegeImmunityTimer = translator.of("status_town_siege_immunity_timer", time);
+						out.add(siegeImmunityTimer);
 	            }
 
 				Component hoverText = Component.empty();

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -393,7 +393,7 @@ public class SiegeWarTownyEventListener implements Listener {
      * @return SiegeSide of the player.
      */
     private SiegeSide getPlayerSiegeSide(Player player, Siege siege) {
-        return SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, TownyAPI.getInstance().getResident(player).getTownOrNull(), siege);
+        return SiegeWarAllegianceUtil.calculateSiegePlayerSide(player, TownyAPI.getInstance().getResident(player).getTownOrNull(), siege);
     }
 
     /**

--- a/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
@@ -43,8 +43,8 @@ import static com.palmergames.util.TimeMgmt.ONE_HOUR_IN_MILLIS;
 public class Siege {
 	private SiegeType siegeType;
 	private Town town;
-	private Government attacker;
-	private Government defender;
+	private Government attacker; //Always the attacking nation
+	private Government defender; //Always the besieged town
 	private String attackerName; //Only used in the siege-aftermath
 	private String defenderName; //Only used in the siege-aftermath
     private SiegeStatus status;

--- a/src/main/java/com/gmail/goosius/siegewar/objects/SiegeCamp.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/SiegeCamp.java
@@ -131,11 +131,9 @@ public class SiegeCamp {
 			TownyMessaging.sendPrefixedNationMessage((Nation)attacker, Translatable.of("msg_err_no_money"));
 			return;
 		}
-			
-		
-		Nation eventNation = siegeType.equals(SiegeType.REVOLT) ? (Nation) defender : (Nation) attacker;  
+
 		// Call event
-		PreSiegeWarStartEvent preSiegeWarStartEvent = new PreSiegeWarStartEvent(siegeType, targetTown, eventNation, townOfSiegeStarter, bannerBlock, townBlock);
+		PreSiegeWarStartEvent preSiegeWarStartEvent = new PreSiegeWarStartEvent(siegeType, targetTown, (Nation)attacker, townOfSiegeStarter, bannerBlock, townBlock);
 		Bukkit.getPluginManager().callEvent(preSiegeWarStartEvent);
 
 		// Setup attack

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
@@ -32,7 +32,7 @@ public class AbandonAttack {
 		if(!SiegeWarSettings.getWarSiegeAbandonEnabled())
 			throw new TownyException(Translatable.of("msg_err_action_disable"));
 
-		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.getPermissionNodeToAbandonAttack(siege.getSiegeType())))
+		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_ABANDON.getNode()))
 			throw new TownyException(Translatable.of("msg_err_action_disable"));
 
 		Confirmation

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
@@ -57,19 +57,9 @@ public class AbandonAttack {
 
 	private static Translatable getAbandonMessage(Siege siege, long timeUntilAbandonConfirmation) {
 		String key = String.format("msg_%s_siege_attacker_abandon", siege.getSiegeType().toLowerCase());
-		Translatable message = null;
-		switch (siege.getSiegeType()) {
-			case CONQUEST:
-				message = Translatable.of(key,
-						siege.getTown().getName(),
-						siege.getAttacker().getName());
-				break;
-			case REVOLT:
-				message = Translatable.of(key,
-						siege.getTown().getName(),
-						siege.getDefender().getName());
-				break;
-		}
+		Translatable message = Translatable.of(key,
+				siege.getTown().getName(),
+				siege.getAttacker().getName());
 
 		if (timeUntilAbandonConfirmation > 0) {
 			message.append(Translatable.of("msg_pending_defender_victory", TimeMgmt.getFormattedTimeValue(timeUntilAbandonConfirmation)));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -116,22 +116,11 @@ public class InvadeTown {
 		if(SiegeWarTownOccupationUtil.isTownOccupiedByNation(residentsNation, targetTown))
 			throw new TownyException(translator.of("msg_err_cannot_invade_town_already_occupied"));
 
-		switch(siege.getSiegeType()) {
-			case CONQUEST:
-				//In a conquest siege, only the attacker can invade
-				if(residentsNation != siege.getAttacker())
-					throw new TownyException(translator.of("msg_err_action_disable"));
-				if (siege.getStatus() != SiegeStatus.ATTACKER_WIN && siege.getStatus() != SiegeStatus.DEFENDER_SURRENDER)
-					throw new TownyException(translator.of("msg_err_cannot_invade_without_victory"));
-			break;
-			case REVOLT:
-				//In a revolt siege, only the defender can invade
-				if(residentsNation != siege.getDefender())
-					throw new TownyException(translator.of("msg_err_action_disable"));
-				if (siege.getStatus() != SiegeStatus.DEFENDER_WIN && siege.getStatus() != SiegeStatus.ATTACKER_ABANDON)
-					throw new TownyException(translator.of("msg_err_cannot_invade_without_victory"));
-				break;
-		}
+		if(residentsNation != siege.getAttacker())
+			throw new TownyException(translator.of("msg_err_action_disable"));
+
+		if (siege.getStatus() != SiegeStatus.ATTACKER_WIN && siege.getStatus() != SiegeStatus.DEFENDER_SURRENDER)
+			throw new TownyException(translator.of("msg_err_cannot_invade_without_victory"));
 
 		if (siege.isTownInvaded())
 			throw new TownyException(translator.of("msg_err_town_already_invaded"));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -184,29 +184,14 @@ public class PlaceBlock {
 		 * Check what type of action this qualifies as.
 		 * Depending on the scenario, it may be 'abandonAttack' or 'surrenderDefence'
 		 */
-		switch (siege.getSiegeType()) {
-			case CONQUEST:
-				if (residentsNation != null && residentsNation == siege.getAttacker()) {
-					//Attacking nation
-					AbandonAttack.processAbandonAttackRequest(player, siege);
-				} else if (residentsTown == nearbyTown) {
-					//Resident of town
-					SurrenderDefence.processSurrenderDefenceRequest(player, siege);
-				} else {
-					throw new TownyException(translator.of("msg_err_action_disable"));
-				}
-				break;
-			case REVOLT:
-				if (residentsTown == nearbyTown) {
-					//Resident of town
-					AbandonAttack.processAbandonAttackRequest(player, siege);
-				} else if (residentsNation != null && residentsNation == siege.getDefender()) {
-					//Defending former occupying nation
-					SurrenderDefence.processSurrenderDefenceRequest(player, siege);
-				} else {
-					throw new TownyException(translator.of("msg_err_action_disable"));
-				}
-				break;
+		if (residentsNation != null && residentsNation == siege.getAttacker()) {
+			//Member of attacking nation
+			AbandonAttack.processAbandonAttackRequest(player, siege);
+		} else if (residentsTown == nearbyTown) {
+			//Member of defending town
+			SurrenderDefence.processSurrenderDefenceRequest(player, siege);
+		} else {
+			throw new TownyException(translator.of("msg_err_action_disable"));
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -112,7 +112,7 @@ public class PlayerDeath {
 				continue;
 
 			//Is player an attacker or defender in this siege?
-			if(SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(deadPlayer, deadResidentTown, candidateSiege) == SiegeSide.NOBODY)
+			if(SiegeWarAllegianceUtil.calculateSiegePlayerSide(deadPlayer, deadResidentTown, candidateSiege) == SiegeSide.NOBODY)
 				continue;
 
 			//Set nearestSiege if it is 1st viable one OR closer than smallestDistanceToSiege.
@@ -149,7 +149,7 @@ public class PlayerDeath {
 		//No penalty points without an active battle session
 		if (BattleSession.getBattleSession().isActive()) {
 			SiegeWarScoringUtil.awardPenaltyPoints(
-					SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(deadPlayer, deadResidentTown, siege) == SiegeSide.ATTACKERS,
+					SiegeWarAllegianceUtil.calculateSiegePlayerSide(deadPlayer, deadResidentTown, siege) == SiegeSide.ATTACKERS,
 					deadPlayer,
 					siege);
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
@@ -67,37 +67,21 @@ public class PlunderTown {
 			throw new TownyException(translator.of("msg_err_siege_war_town_already_plundered", townToBePlundered.getName()));
 
 		if(siege.isRevoltSiege()) {
-			// A revolt siege means a town was rebelling against their Occupying nation.
-			
-			// Rebels do not plunder when they win or the occupying nation surrenders.
-			if(siege.getStatus() == SiegeStatus.ATTACKER_WIN || siege.getStatus() == SiegeStatus.DEFENDER_SURRENDER)
+			// If the rebels won, plunder is not possible
+			if (siege.getStatus() == SiegeStatus.DEFENDER_WIN || siege.getStatus() == SiegeStatus.ATTACKER_ABANDON)
 				throw new TownyException(translator.of("msg_err_siege_war_plunder_not_possible_rebels_won"));
-
-			// The Siege hasn't been won.
-			if(siege.getStatus() != SiegeStatus.DEFENDER_WIN && siege.getStatus() != SiegeStatus.ATTACKER_ABANDON)
-				throw new TownyException(translator.of("msg_err_siege_war_cannot_plunder_without_victory"));
-
-			// It is not the occupying nation trying to plunder this siege.
-			if(plunderingNation != siege.getDefender())
-				throw new TownyException(translator.of("msg_err_siege_war_cannot_plunder_without_victory"));
-
-			// Return the occupying nation of the sieged town, which has defeated the revolting town.
-			return (Nation)siege.getDefender();
-
-		} else {
-			// Any other type of Siege aside from Revolt.
-			
-			// The Siege hasn't been won.
-			if(siege.getStatus() != SiegeStatus.ATTACKER_WIN && siege.getStatus() != SiegeStatus.DEFENDER_SURRENDER)
-				throw new TownyException(translator.of("msg_err_siege_war_cannot_plunder_without_victory"));
-
-			// It is not the attacking Nation which is trying to plunder.
-			if(plunderingNation != siege.getAttacker())
-				throw new TownyException(translator.of("msg_err_siege_war_cannot_plunder_without_victory"));
-
-			// Return the Nation which started the Siege against the town.
-			return (Nation)siege.getAttacker();
 		}
+
+		// Ensure the attacking nation has completed the win
+		if(siege.getStatus() != SiegeStatus.ATTACKER_WIN && siege.getStatus() != SiegeStatus.DEFENDER_SURRENDER)
+			throw new TownyException(translator.of("msg_err_siege_war_cannot_plunder_without_victory"));
+
+		// Ensure tha attempted plunderer is from the victorious nation
+		if(plunderingNation != siege.getAttacker())
+			throw new TownyException(translator.of("msg_err_siege_war_cannot_plunder_without_victory"));
+
+		// Return the victorious nation, which has defeated the revolting town.
+		return (Nation)siege.getAttacker();
 	}
 
 	private static void plunderTown(Siege siege, Nation nation) {

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/StartConquestSiege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/StartConquestSiege.java
@@ -58,7 +58,7 @@ public class StartConquestSiege {
 		final Translator translator = Translator.locale(player);
 
 		if (!SiegeWarSettings.getConquestSiegesEnabled()
-		|| !TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.getPermissionNodeToStartSiege(SiegeType.CONQUEST)))
+		|| !TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_STARTCONQUESTSIEGE.getNode()))
 			throw new TownyException(translator.of("msg_err_action_disable"));
 
 		if (targetTown.hasNation()) {

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/StartRevoltSiege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/StartRevoltSiege.java
@@ -57,7 +57,7 @@ public class StartRevoltSiege {
 	private static void allowSiegeOrThrow(Player player, Town targetTown) throws TownyException {
 		final Translator translator = Translator.locale(player);
         if (!SiegeWarSettings.getRevoltSiegesEnabled()
-        || !TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.getPermissionNodeToStartSiege(SiegeType.REVOLT)))
+        || !TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_STARTREVOLTSIEGE.getNode()))
             throw new TownyException(translator.of("msg_err_action_disable"));
 
         if(SiegeWarTownPeacefulnessUtil.isTownPeaceful(targetTown))

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/StartRevoltSiege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/StartRevoltSiege.java
@@ -51,7 +51,7 @@ public class StartRevoltSiege {
 		allowSiegeOrThrow(player, targetTown);
 
 		// Start a SiegeCamp that will kick off the Siege (or if SiegeAssemblies are disabled, start the Siege immediately.)
-		SiegeController.startSiegeCampProcess(player, bannerBlock, SiegeType.REVOLT, targetTown, targetTown, targetTown.getNationOrNull(), townOfSiegeStarter, townBlock);
+		SiegeController.startSiegeCampProcess(player, bannerBlock, SiegeType.REVOLT, targetTown, targetTown.getNationOrNull(), targetTown, townOfSiegeStarter, townBlock);
 	}
 
 	private static void allowSiegeOrThrow(Player player, Town targetTown) throws TownyException {

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderDefence.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderDefence.java
@@ -50,19 +50,9 @@ public class SurrenderDefence {
 
 	private static Translatable getSurrenderMessage(Siege siege, long timeUntilSurrenderConfirmation) {
 		String key = String.format("msg_%s_siege_defender_surrender", siege.getSiegeType().toLowerCase());
-		Translatable message = null;
-		switch(siege.getSiegeType()) {
-			case CONQUEST:
-				message = Translatable.of(key,
+		Translatable message = Translatable.of(key,
 						siege.getTown().getName(),
 						siege.getAttacker().getName());
-				break;
-			case REVOLT:
-				message = Translatable.of(key,
-						siege.getTown().getName(),
-						siege.getDefender().getName());
-				break;
-		}
 
 		if(timeUntilSurrenderConfirmation > 0) {
 			message.append(Translatable.of("msg_pending_attacker_victory", TimeMgmt.getFormattedTimeValue(timeUntilSurrenderConfirmation)));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderDefence.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderDefence.java
@@ -11,6 +11,7 @@ import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.confirmations.Confirmation;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Translatable;
+import com.palmergames.bukkit.towny.permissions.PermissionNodes;
 import com.palmergames.util.TimeMgmt;
 import org.bukkit.entity.Player;
 
@@ -25,7 +26,7 @@ public class SurrenderDefence {
 		if(!SiegeWarSettings.getWarSiegeSurrenderEnabled())
 			throw new TownyException(Translatable.of("msg_err_action_disable").forLocale(player));
 
-		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.getPermissionNodeToSurrenderDefence(siege.getSiegeType())))
+		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_SURRENDER.getNode()))
 			throw new TownyException(Translatable.of("msg_err_action_disable").forLocale(player));
 		
 		Confirmation

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerTimedWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerTimedWin.java
@@ -30,7 +30,7 @@ public class AttackerTimedWin {
                 break;
             case REVOLT:
                 message = Translatable.of(key,
-                        siege.getTown().getName(),           
+                        siege.getTown().getName(),
                         siege.getAttacker().getName());
                 break;
         }

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerTimedWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerTimedWin.java
@@ -30,8 +30,8 @@ public class AttackerTimedWin {
                 break;
             case REVOLT:
                 message = Translatable.of(key,
-                        siege.getTown().getName(),
-                        siege.getDefender().getName());
+                        siege.getTown().getName(),           
+                        siege.getAttacker().getName());
                 break;
         }
         String key2 = String.format("msg_%s_siege_attacker_win_result", siege.getSiegeType().toLowerCase());

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderTimedWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderTimedWin.java
@@ -31,7 +31,7 @@ public class DefenderTimedWin {
             case REVOLT:
                 message = Translatable.of(key,
                         siege.getTown().getName(),
-                        siege.getDefender().getName());
+                        siege.getAttacker().getName());
                 break;
         }
         String key2 = String.format("msg_%s_siege_defender_win_result", siege.getSiegeType().toLowerCase());

--- a/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
@@ -109,7 +109,7 @@ public class CosmeticUtil {
 
 		SiegeSide siegeSide = SiegeSide.NOBODY;
 		if(resident.hasTown())
-			siegeSide = SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, TownyAPI.getInstance().getResidentTownOrNull(resident), siege);
+			siegeSide = SiegeWarAllegianceUtil.calculateSiegePlayerSide(player, TownyAPI.getInstance().getResidentTownOrNull(resident), siege);
 
 
 		if (siegeSide == SiegeSide.NOBODY || siege.getBannerControllingSide() == SiegeSide.NOBODY)

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
@@ -21,13 +21,13 @@ public class SiegeWarAllegianceUtil {
             || isNationSoldierOrAlliedSoldier(player, playerTown, besiegedTown)) {
             return SiegeSide.DEFENDERS;
         }
-        
+
         //Look for attacker
         Government attackingNation = siege.getAttacker();
         if (isNationSoldierOrAlliedSoldier(player, playerTown, attackingNation)) {
             return SiegeSide.ATTACKERS;
         }
-        
+
         return SiegeSide.NOBODY;
     }
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
@@ -27,7 +27,6 @@ public class SiegeWarAllegianceUtil {
         if (isNationSoldierOrAlliedSoldier(player, playerTown, attackingNation)) {
             return SiegeSide.ATTACKERS;
         }
-
         return SiegeSide.NOBODY;
     }
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarAllegianceUtil.java
@@ -13,33 +13,21 @@ import org.bukkit.entity.Player;
 
 public class SiegeWarAllegianceUtil {
 
-    public static SiegeSide calculateCandidateSiegePlayerSide(Player deadPlayer, Town deadResidentTown, Siege candidateSiege) {
+    public static SiegeSide calculateSiegePlayerSide(Player player, Town playerTown, Siege siege) {
 
         //Look for defender
-        Government defendingGovernment = candidateSiege.getDefender();
-        switch (candidateSiege.getSiegeType()) {
-            case CONQUEST:
-                //In the above sieges, defenders can be town guards
-                if (isTownGuard(deadPlayer, deadResidentTown, defendingGovernment))
-                    return SiegeSide.DEFENDERS;
-            case REVOLT:
-                //In the above sieges, defenders can be nation/allied soldiers
-                if (isNationSoldierOrAlliedSoldier(deadPlayer, deadResidentTown, defendingGovernment))
-                    return SiegeSide.DEFENDERS;
+        Government besiegedTown = siege.getDefender();
+        if (isTownGuard(player, playerTown, besiegedTown)
+            || isNationSoldierOrAlliedSoldier(player, playerTown, besiegedTown)) {
+            return SiegeSide.DEFENDERS;
         }
-
+        
         //Look for attacker
-        Government attackingGovernment = candidateSiege.getAttacker();
-        switch (candidateSiege.getSiegeType()) {
-            case REVOLT:
-                //In the above sieges, attackers can be town guards
-                if (isTownGuard(deadPlayer, deadResidentTown, attackingGovernment))
-                    return SiegeSide.ATTACKERS;
-            case CONQUEST:
-                //In the above sieges, attackers can be nation/allied soldiers
-                if (isNationSoldierOrAlliedSoldier(deadPlayer, deadResidentTown, attackingGovernment))
-                    return SiegeSide.ATTACKERS;
+        Government attackingNation = siege.getAttacker();
+        if (isNationSoldierOrAlliedSoldier(player, playerTown, attackingNation)) {
+            return SiegeSide.ATTACKERS;
         }
+        
         return SiegeSide.NOBODY;
     }
 
@@ -86,7 +74,7 @@ public class SiegeWarAllegianceUtil {
      */
     public static boolean isPlayerOnTownFriendlySide(Player player, Resident resident, Siege siege) {
         Town gunnerResidentTown = resident.getTownOrNull();
-        SiegeSide playerSiegeSide = calculateCandidateSiegePlayerSide(player, gunnerResidentTown, siege);
+        SiegeSide playerSiegeSide = calculateSiegePlayerSide(player, gunnerResidentTown, siege);
         switch(playerSiegeSide) {
             case DEFENDERS:
                 return siege.isConquestSiege();
@@ -102,7 +90,7 @@ public class SiegeWarAllegianceUtil {
      */
     public static boolean isPlayerOnTownHostileSide(Player player, Resident resident, Siege siege) {
         Town gunnerResidentTown = resident.getTownOrNull();
-        SiegeSide playerSiegeSide = calculateCandidateSiegePlayerSide(player, gunnerResidentTown, siege);
+        SiegeSide playerSiegeSide = calculateSiegePlayerSide(player, gunnerResidentTown, siege);
         switch(playerSiegeSide) {
             case ATTACKERS:
                 return siege.isConquestSiege();

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -80,7 +80,7 @@ public class SiegeWarBannerControlUtil {
 				if(siege.getBannerControllingResidents().contains(resident))
 					continue;  // Player already on the BC list
 
-				SiegeSide siegeSide = SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, resident.getTown(), siege);
+				SiegeSide siegeSide = SiegeWarAllegianceUtil.calculateSiegePlayerSide(player, resident.getTown(), siege);
 
 				switch(siegeSide) {
 					case ATTACKERS:

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarSicknessUtil.java
@@ -145,7 +145,7 @@ public class SiegeWarSicknessUtil {
         if (!resident.hasTown())
             return false;
 
-        SiegeSide siegeSide = SiegeWarAllegianceUtil.calculateCandidateSiegePlayerSide(player, TownyAPI.getInstance().getResidentTownOrNull(resident), siege);
+        SiegeSide siegeSide = SiegeWarAllegianceUtil.calculateSiegePlayerSide(player, TownyAPI.getInstance().getResidentTownOrNull(resident), siege);
 
         return siegeSide != SiegeSide.NOBODY;
     }

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -498,6 +498,7 @@ msg_err_cannot_subvert_town_already_occupied: "&cThere is no need to subvert thi
 msg_revolt_siege_started: '&bThe townspeople of %s have risen up against the occupying nation of %s, and declared themselves free to choose their own destiny. A REVOLT SIEGE has begun!'
 
 #war sickness
+
 msg_you_will_get_sickness: '&cYou are not an official participant of this siege and cannot be in the Siege Zone. Please leave or you will receive war sickness in %s seconds.'
 msg_you_received_war_sickness: '&cYou are not an official participant of this siege and cannot be in the Siege Zone. Please leave to remove the war sickness. Common causes of war sickness: Not having a military rank or not being allied to either side.'
 
@@ -532,26 +533,26 @@ msg_err_command_not_allowed_on_active_siege: "You cannot run this command unless
 #Timed wins
 
 msg_conquest_siege_timed_attacker_win: '&bCONQUEST SIEGE at %s > The attacking army of %s has defeated the defending army of %s!.'
-msg_revolt_siege_timed_attacker_win: '&bREVOLT SIEGE at %s > The rebellion has succeeded!. The attacking rebels have successfully driven off the defending army of %s, which previously occupied the town.'
 msg_conquest_siege_timed_defender_win: '&bCONQUEST SIEGE at %s > The defending army of %s has defeated the attacking army of %s!.'
-msg_revolt_siege_timed_defender_win: '&bREVOLT SIEGE at %s > The defending army of %s, which previously occupied the town, has successfully crushed the rebellion!.'
+msg_revolt_siege_timed_attacker_win: '&bREVOLT SIEGE at %s > The attacking army of %s, which previously occupied the town, has successfully crushed the rebellion!.'
+msg_revolt_siege_timed_defender_win: '&bREVOLT SIEGE at %s > The rebellion has succeeded!. The attacking rebels have successfully driven off the attacking army of %s.'
 
 #Abandoning Attacks
 
 msg_conquest_siege_attacker_abandon: '&bCONQUEST SIEGE at %s > The attacking army of %s has abandoned its attack on the town!.'
-msg_revolt_siege_attacker_abandon: '&bREVOLT SIEGE at %s > The attacking rebel army has abandoned its revolt against %s!.'
+msg_revolt_siege_attacker_abandon: '&bREVOLT SIEGE at %s > The attacking army of %s, which previously occupied the town, has admitted defeat and retreated!.'
 
 #Surrendering Defence
 
 msg_conquest_siege_defender_surrender: '&bCONQUEST SIEGE at %s > The town has surrendered to the attacking army of %s!.'
-msg_revolt_siege_defender_surrender: '&bREVOLT SIEGE at %s > The defending army of %s, which previously occupied the town, has admitted defeat and retreated!.'
+msg_revolt_siege_defender_surrender: '&bREVOLT SIEGE at %s > The rebels have admitted defeat and surrendered to the attacking army of %s!.'
 
 #Siege Results
 
 msg_conquest_siege_attacker_win_result: ' The town now stands open for invasion and/or plunder.'
 msg_conquest_siege_defender_win_result: ' The town has been saved!'
-msg_revolt_siege_attacker_win_result: ' The town has won its freedom!'
-msg_revolt_siege_defender_win_result: ' The town now stands open for invasion and/or plunder.'
+msg_revolt_siege_attacker_win_result: ' The town now stands open for invasion and/or plunder.'
+msg_revolt_siege_defender_win_result: ' The town has won its freedom!'
 
 #Town Screen
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -498,7 +498,6 @@ msg_err_cannot_subvert_town_already_occupied: "&cThere is no need to subvert thi
 msg_revolt_siege_started: '&bThe townspeople of %s have risen up against the occupying nation of %s, and declared themselves free to choose their own destiny. A REVOLT SIEGE has begun!'
 
 #war sickness
-
 msg_you_will_get_sickness: '&cYou are not an official participant of this siege and cannot be in the Siege Zone. Please leave or you will receive war sickness in %s seconds.'
 msg_you_received_war_sickness: '&cYou are not an official participant of this siege and cannot be in the Siege Zone. Please leave to remove the war sickness. Common causes of war sickness: Not having a military rank or not being allied to either side.'
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -556,7 +556,7 @@ msg_revolt_siege_defender_win_result: ' The town has won its freedom!'
 
 #Town Screen
 
-status_town_siege_status_invaded: '   &2Town Captured: %s'
+status_town_siege_status_invaded: '&2 > Town Captured: %s'
 status_town_peacefulness_flag: '&b(Peaceful)'
 
 #Town Capture & Occupation

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -78,13 +78,10 @@ permissions:
         default: false
         children:
             siegewar.nation.siege.battle.points: true
-            siegewar.nation.siege.attack: true
+            siegewar.nation.siege.startconquestsiege: true
             siegewar.nation.siege.abandon: true
             siegewar.nation.siege.invade: true
             siegewar.nation.siege.plunder: true
-            siegewar.nation.siege.conquest.siege.start: true
-            siegewar.nation.siege.conquest.siege.abandon: true
-            siegewar.nation.siege.revolt.siege.surrender: true
             siegewar.nation.siege.subvertpeacefultown: true
 
     siegewar.town.siege.*:
@@ -92,10 +89,9 @@ permissions:
         default: false
         children:
             siegewar.town.siege.battle.points: true
-            siegewar.town.siege.conquest.siege.surrender: true
-            siegewar.town.siege.revolt.siege.start: true
-            siegewar.town.siege.revolt.siege.abandon: true
-            
+            siegewar.town.siege.startrevoltsiege: true
+            siegewar.town.siege.surrender: true
+    
     siegewar.command.siegewar.collect:
         description: User is able to do the /siegewar collect command.
         default: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -91,7 +91,7 @@ permissions:
             siegewar.town.siege.battle.points: true
             siegewar.town.siege.startrevoltsiege: true
             siegewar.town.siege.surrender: true
-    
+
     siegewar.command.siegewar.collect:
         description: User is able to do the /siegewar collect command.
         default: true


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
- With current code, sometimes the town is the attacker (revolt), and sometimes the town is the defender (conquest)
  - I think this is more complicated for users to understand, compared to the "attacker = nation, defender = town" logic which SW had in early versions.
  - This is also a problem for siege balancing by server owners. Because typically a server might want to give a straight points advantage to the "town side", but this is not possible.
- This PR changes the logic to be simpler so that:
  - Attacker = attacking nation
  - Defender = defending town 
- As part of the above change, this PR makes some related changes to the perms in **plugin.yml**. However because the affected perms are not expected or required to be specified outside of plugin.yml,  I deem this low risk compared to the alterative of maintaining a perms naming scheme which no longer makes sense.  For servers who have deliberately specified the perms outside of the plugin.yml,  they probably are technical enough anyway to quickly resolve any potential issues.
- Note: This PR also does a very small / low risk UI fix to split the "Plundered" and "Invaded" stats on siege popup, into 2 lines.


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
```
Test 
Revolt siege attacker timed victory PASS
Revolt siege defender timed victory PASS
Revolt siege attacker abandon PASS
Revolt siege defender surrender PASS
Revolt siege plunder PASS
Revolt siege invade PASS

Conquest siege attacker timed victory PASS
Conquest siege attacker timed defeat  PASS
Conquest siege attacker abandon PASS
Conquest siege defender surrender PASS
Conquest siege invade PASS
Conquest siege plunder PASS
```

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
