### PR TITLE
Move peaceful-towns counter check to after newday event, not before

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -99,24 +99,20 @@ public class SiegeWarTownyEventListener implements Listener {
 	}
 
     @EventHandler
-    public void onPreNewDay(PreNewDayEvent event) {
+    public void onNewDay(NewDayEvent event) {
         if (SiegeWarSettings.getWarSiegeEnabled()) {
+            if (SiegeWarSettings.isPlunderPaidOutOverDays()) {
+                SiegeWarMoneyUtil.payDailyPlunderDebt();
+            }
             if(SiegeWarSettings.getWarCommonPeacefulTownsEnabled()) {
                 SiegeWarTownPeacefulnessUtil.updateTownPeacefulnessCounters();
+            }
+            if(SiegeWarSettings.getMaxOccupationTaxPerPlot() > 0) {
+                SiegeWarTownOccupationUtil.collectNationOccupationTax();
             }
         }
     }
 
-	@EventHandler
-	public void onNewDay(NewDayEvent event) {
-		if (SiegeWarSettings.getWarSiegeEnabled()) {
-			if (SiegeWarSettings.isPlunderPaidOutOverDays()) {
-				SiegeWarMoneyUtil.payDailyPlunderDebt();
-			}
-			SiegeWarTownOccupationUtil.collectNationOccupationTax();
-		}
-	}
-    
     /*
      * On NewHours SW makes some calculations.
      */


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- With current code, the peacefult-towns counter check and associated status messages .... occurs **before** the native Towny newday message, instead of **after** it, as would be expected.
- This seems needlessly confusing
- The only functional effect I can think of, is that in previous SW versions this would allow the towns to dodge the "Neutal Town Extra Upkeep" effect. However since SW no longer uses the "Neutral" town scheme, nor its associated extra upkeep cost, this effect no longer applies.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ NA too trivial ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
