### PR TITLE
Moved nation refund to be trigger on /sw collect

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -40,7 +40,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 
 	private static final List<String> siegewarTownTabCompletes = Arrays.asList("togglepeaceful");
 	
-	private static final List<String> siegewarNationTabCompletes = Arrays.asList("paysoldiers", "claimrefund");
+	private static final List<String> siegewarNationTabCompletes = Arrays.asList("paysoldiers");
 
 	private static final List<String> siegewarPreferenceTabCompletes = Arrays.asList("beacons", "bossbars");
 	
@@ -78,7 +78,6 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw hud", "[town]", ""));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw collect", "", Translatable.of("nation_help_11").forLocale(sender)));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw nation", "paysoldiers [amount]", Translatable.of("nation_help_12").forLocale(sender)));
-		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw nation", "claimrefund [amount]", Translatable.of("nation_help_refund").forLocale(sender)));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw town", "togglepeaceful", Translatable.of("town_help_toggle_peaceful").forLocale(sender)));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw preference", "beacons [on/off]", ""));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw nextsession", "", ""));
@@ -88,7 +87,6 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 	private void showNationHelp(CommandSender sender) {
 		TownyMessaging.sendMessage(sender, ChatTools.formatTitle("/siegewar nation"));
 		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw nation", "paysoldiers [amount]", Translatable.of("nation_help_12").forLocale(sender)));
-		TownyMessaging.sendMessage(sender, ChatTools.formatCommand("Eg", "/sw nation", "claimrefund [amount]", Translatable.of("nation_help_refund").forLocale(sender)));
 	}
 
 	private void showTownHelp(CommandSender sender) {
@@ -174,6 +172,14 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 
 		try {
 			if(SiegeWarMoneyUtil.collectMilitarySalary(player))
+				incomeTypesCollected++;
+		} catch (Exception e) {
+			error = true;
+			player.sendMessage(e.getMessage());
+		}
+
+		try {
+			if(SiegeWarMoneyUtil.claimNationRefund(player))
 				incomeTypesCollected++;
 		} catch (Exception e) {
 			error = true;

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -290,18 +290,6 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 				}
 				break;
 
-			case "claimrefund":
-				try {
-					if (args.length != 1) {
-						showNationHelp(player);
-						return;
-					}
-					SiegeWarMoneyUtil.claimNationRefund(player);
-				} catch (TownyException te) {
-					Messaging.sendErrorMsg(player, te.getMessage(player));
-				}
-				break;
-
 			default:
 				showNationHelp(player);
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
@@ -38,7 +38,6 @@ public enum SiegeWarPermissionNodes {
 		SIEGEWAR_COMMAND_SIEGEWAR_TOWN_TOGGLEPEACEFUL("siegewar.command.siegewar.town.togglepeaceful"),
 	SIEGEWAR_COMMAND_SIEGEWAR_NATION("siegewar.command.siegewar.nation.*"),
 		SIEGEWAR_COMMAND_SIEGEWAR_NATION_PAYSOLDIERS("siegewar.command.siegewar.nation.paysoldiers"),
-		SIEGEWAR_COMMAND_SIEGEWAR_NATION_CLAIMREFUND("siegewar.command.siegewar.nation.claimrefund"),
 	SIEGEWAR_COMMAND_SIEGEWAR_COLLECT("siegewar.command.siegewar.collect"),
 	SIEGEWAR_COMMAND_SIEGEWAR_HUD("siegewar.command.siegewar.hud"),
 	SIEGEWAR_COMMAND_SIEGEWAR_PREFERENCE("siegewar.command.siegewar.preference"),

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
@@ -290,7 +290,7 @@ public class SiegeWarMoneyUtil {
 	 * @param player claiming the nation refund.
 	 * @throws TownyException when payment cannot be made for various reasons.
 	 */
-	public static void claimNationRefund(Player player) throws TownyException {
+	public static boolean claimNationRefund(Player player) throws TownyException {
 		if (!TownySettings.isUsingEconomy()
 				|| SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete() == 0) {
 			throw new TownyException(Translatable.of("msg_err_command_disable"));
@@ -304,6 +304,7 @@ public class SiegeWarMoneyUtil {
 			formerKing.getAccount().deposit(refundAmount, "Nation Refund");
 			ResidentMetaDataController.setNationRefundAmount(formerKing, 0);
 			Messaging.sendMsg(player, Translatable.of("msg_siege_war_nation_refund_claimed", TownyEconomyHandler.getFormattedBalance(refundAmount)));
+			return true;
 		} else {
 			throw new TownyException(Translatable.of("msg_err_siege_war_nation_refund_unavailable"));
 		}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- Moved nation refund to be trigger on /sw collect, instead of /sw nation claimrefund.
- This is simpler, plus it ensures that even if the former king is now townless, they can still claim without issue.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [N/A too trivial ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
