### PR TITLE
Banner Altitude Checker Fix

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -172,8 +172,15 @@ public class SiegeWarBannerControlUtil {
 			return false; //player is not in the timed point zone
 
 		if(SiegeWarSettings.isTrapWarfareMitigationEnabled()
-			&& player.getLocation().getY() < siege.getFlagLocation().getY())
-			return false; //Player is below the siege banner
+				&& player.getLocation().getY() < siege.getFlagLocation().getY() - 1) {
+			/*
+			 * Player is below the siege banner block
+			 * We look at the support-block-altitude rather than the banner altitude,
+			 * Because otherwise, dirt path's can cause confusion,
+			 * because their altitude is very slightly lower than a regular dirt block.
+			 */
+			return false;
+		}
 
 		return true;
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -172,12 +172,13 @@ public class SiegeWarBannerControlUtil {
 			return false; //player is not in the timed point zone
 
 		if(SiegeWarSettings.isTrapWarfareMitigationEnabled()
-				&& player.getLocation().getY() < siege.getFlagLocation().getY() - 1) {
+				&& player.getLocation().getY() < siege.getFlagLocation().getY() - 0.5) {
 			/*
 			 * Player is below the siege banner block
-			 * We look at the support-block-altitude rather than the banner altitude,
-			 * Because otherwise, dirt path's can cause confusion,
-			 * because their altitude is very slightly lower than a regular dirt block.
+			 * We allow 0.5 blocks of leniency here,
+			 * Because otherwise, half-blocks and dirt paths can cause confusion,
+			 * because although players might think they are at the banner altitude,
+			 * they are actually below it.
 			 */
 			return false;
 		}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- With current code, if a player is standing on a dirt block, apparently at the banner altitude, they will fail the banner control session, because a dirt block is actually very slightly under banner altitude.
- The PR adds a fix by adding a little leniency.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
