### PR TITLE
Fix to "remove siege" command

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -636,7 +636,6 @@ public class SiegeWarAdminCommand implements TabExecutor {
 				case "end":
 					SiegeController.endSiegeWithTimedWin(siege);
 					return;
-
 				case "setplundered":
 					boolean plundered = Boolean.parseBoolean(args[2]);
 					siege.setTownPlundered(plundered);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -1,7 +1,6 @@
 package com.gmail.goosius.siegewar.listeners;
 
 import com.gmail.goosius.siegewar.SiegeController;
-import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
@@ -81,7 +80,7 @@ public class SiegeWarNationEventListener implements Listener {
 			 * If attacker (which is always a nation) disappears, we must delete the siege
 			 */
 			if (event.getNationUUID() == siege.getAttacker().getUUID()) {
-				SiegeController.removeSiege(siege, SiegeSide.DEFENDERS);
+				SiegeController.removeSiege(siege);
 			}
 		}
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -5,7 +5,6 @@ import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.utils.PermissionUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarTownOccupationUtil;
-import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
@@ -18,7 +17,6 @@ import com.palmergames.bukkit.towny.event.NewTownEvent;
 import com.palmergames.bukkit.towny.event.TownAddResidentRankEvent;
 import com.palmergames.bukkit.towny.event.TownPreAddResidentEvent;
 import com.palmergames.bukkit.towny.event.TownPreClaimEvent;
-import com.palmergames.bukkit.towny.event.nation.NationRankAddEvent;
 import com.palmergames.bukkit.towny.event.time.dailytaxes.PreTownPaysNationTaxEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreMergeEvent;
 import com.palmergames.bukkit.towny.event.town.TownPreUnclaimCmdEvent;
@@ -53,7 +51,7 @@ public class SiegeWarTownEventListener implements Listener {
 	public void onTownGoesToRuin(TownRuinedEvent event) {
 		//Remove siege if town has one
 		if (SiegeController.hasSiege(event.getTown()))
-			SiegeController.removeSiege(SiegeController.getSiege(event.getTown()), SiegeSide.ATTACKERS);
+			SiegeController.removeSiege(SiegeController.getSiege(event.getTown()));
 		//Remove occupier if town has one
 		if (SiegeWarTownOccupationUtil.isTownOccupied(event.getTown()))
 			SiegeWarTownOccupationUtil.removeTownOccupation(event.getTown());
@@ -184,7 +182,7 @@ public class SiegeWarTownEventListener implements Listener {
 	@EventHandler
 	public void onDeleteTown(DeleteTownEvent event) {
 		if (SiegeController.hasSiege(event.getTownUUID()))
-			SiegeController.removeSiege(SiegeController.getSiegeByTownUUID(event.getTownUUID()), SiegeSide.ATTACKERS);
+			SiegeController.removeSiege(SiegeController.getSiegeByTownUUID(event.getTownUUID()));
 	}
 
 	@EventHandler

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
@@ -1,14 +1,11 @@
 package com.gmail.goosius.siegewar.tasks;
 
 import com.gmail.goosius.siegewar.SiegeController;
-import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.playeractions.AbandonAttack;
 import com.gmail.goosius.siegewar.playeractions.SurrenderDefence;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
-import com.gmail.goosius.siegewar.timeractions.AttackerTimedWin;
-import com.gmail.goosius.siegewar.timeractions.DefenderTimedWin;
 import com.gmail.goosius.siegewar.utils.SiegeWarBannerControlUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarBattleSessionUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarSicknessUtil;
@@ -40,13 +37,9 @@ public class SiegeWarTimerTaskController {
 	private static void evaluateTimedSiegeOutcome(Siege siege) {
 		switch(siege.getStatus()) {
 			case IN_PROGRESS:
-				//If scheduled end time has arrived, choose winner
+				//If scheduled end time has arrived, end siege and choose winner
 				if (System.currentTimeMillis() > siege.getScheduledEndTime()) {
-					if (siege.getSiegeBalance() > 0) {
-						AttackerTimedWin.attackerTimedWin(siege);
-					} else {
-						DefenderTimedWin.defenderTimedWin(siege);
-					}
+					SiegeController.endSiegeWithTimedWin(siege);
 				}
 				break;
 
@@ -64,7 +57,7 @@ public class SiegeWarTimerTaskController {
 				//Siege is inactive i.e. in the 'aftermath' phase
 				//Wait for siege immunity timer to end then delete siege
 				if (System.currentTimeMillis() > TownMetaDataController.getSiegeImmunityEndTime(siege.getTown())) {
-					SiegeController.removeSiege(siege, SiegeSide.NOBODY);
+					SiegeController.removeSiege(siege);
 				}
 		}
 	}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- With current code:
  - The "remove siege" command leaves the bossbars and glowing in place
  - Also, when the sieges is removed the warchest always goes to the attacker, regardless of the points, which might not be intended by the command runner.
- This PR changes the removeSiege method to do just this:
  - First it makes a call to a dedicated end-siege method, which ends the siege via the normal way, and based on the points.
  - Then it makes a call to a dedicated remove-siege-from-system method

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ N/A low risk ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
