### PR TITLE
Siege migration

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -158,7 +158,7 @@ public class SiegeController {
 			siege.setSiegeType(SiegeType.parseString(siegeTypeString));
 
 		//Get nation
-		UUID nationUUID = SiegeMetaDataController.getAttackerUUID(town);
+		UUID nationUUID = UUID.fromString(SiegeMetaDataController.getAttackerUUID(town));
 		if (nationUUID == null)
 			return false;
 		Nation nation = TownyAPI.getInstance().getNation(nationUUID);

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -127,7 +127,7 @@ public class SiegeController {
 				SiegeWar.info("Siege List Data: Found siege in Town " + town.getName());
 
 				//Migration support. Only if this method returns true, do we load.
-				if (!DataCleanupUtil.handleLegacySiegeDataAndCheckForLoad(town)) {
+				if (DataCleanupUtil.handleLegacySiegeDataAndCheckForLoad(town)) {
 					newSiege(town);
 					setSiege(town, true);
 				}

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -158,10 +158,10 @@ public class SiegeController {
 			siege.setSiegeType(SiegeType.parseString(siegeTypeString));
 
 		//Get nation
-		String nationUUID = SiegeMetaDataController.getAttackerUUID(town);
+		UUID nationUUID = SiegeMetaDataController.getAttackerUUID(town);
 		if (nationUUID == null)
 			return false;
-		Nation nation = TownyAPI.getInstance().getNation(UUID.fromString(nationUUID));
+		Nation nation = TownyAPI.getInstance().getNation(nationUUID);
 		if (nation == null)
 			return false;
 

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -18,6 +18,7 @@ import com.gmail.goosius.siegewar.events.PreSiegeCampEvent;
 import com.gmail.goosius.siegewar.events.SiegeWarStartEvent;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.CosmeticUtil;
+import com.gmail.goosius.siegewar.utils.DataCleanupUtil;
 import com.gmail.goosius.siegewar.utils.SiegeCampUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
@@ -120,14 +121,17 @@ public class SiegeController {
 	}
 
 	public static void loadSiegeList() {
-		for (Town town : TownyUniverse.getInstance().getTowns())
+		for (Town town : TownyUniverse.getInstance().getTowns()) {
 			if (SiegeMetaDataController.hasSiege(town)) {
 				SiegeWar.info("Siege List Data: Found siege in Town " + town.getName());
-				newSiege(town);
 
-				setSiege(town, true);
-
+				//Migration support. Only if this method returns true, do we load.
+				if (!DataCleanupUtil.handleLegacySiegeAndCheckForLoad(town)) {
+					newSiege(town);
+					setSiege(town, true);
+				}
 			}
+		}
 	}
 
 	public static boolean loadSieges() {

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -126,7 +126,7 @@ public class SiegeController {
 				SiegeWar.info("Siege List Data: Found siege in Town " + town.getName());
 
 				//Migration support. Only if this method returns true, do we load.
-				if (!DataCleanupUtil.handleLegacySiegeAndCheckForLoad(town)) {
+				if (!DataCleanupUtil.handleLegacySiegeDataAndCheckForLoad(town)) {
 					newSiege(town);
 					setSiege(town, true);
 				}

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -112,7 +112,7 @@ public class SiegeWar extends JavaPlugin {
     public void onDisable() {
     	info("Shutting down...");
     }
-    	
+
 	private boolean loadAll() {
 		return !Towny.getPlugin().isError()
 				&& Settings.loadSettingsAndLang()

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -71,8 +71,11 @@ public class SiegeWar extends JavaPlugin {
         
         registerAdminCommands();
         handleLegacyConfigs();
-		siegeWarPluginError = loadData();
-		siegeWarPluginError = loadSettingsAndLang();
+
+		if (!loadAll()) {
+			siegeWarPluginError = true;
+		}
+
 		listenersRegistered = registerListeners();
 		registerPlayerCommands();
 		checkIntegrations();
@@ -109,25 +112,11 @@ public class SiegeWar extends JavaPlugin {
     public void onDisable() {
     	info("Shutting down...");
     }
-    
-    private boolean loadData() {
-		if(Towny.getPlugin().isError()) {
-			SiegeWar.severe("Towny is in safe mode. SiegeWar data load not attempted.");
-			return true;
-		}
-		if(siegeWarPluginError) {
-			SiegeWar.severe("SiegeWar is in safe mode. SiegeWar data load not attempted.");
-			return true;
-		}
-		return SiegeController.loadAll();
-    }
 
-	public boolean loadSettingsAndLang() {
-		if(siegeWarPluginError) {
-			SiegeWar.severe("SiegeWar is in safe mode. SiegeWar settings-and-lang-load not attempted.");
-			return true;
-		}
-		return Settings.loadSettingsAndLang();
+ 	private boolean loadAll() {
+		return !Towny.getPlugin().isError()
+				&& Settings.loadSettingsAndLang()
+				&& SiegeController.loadAll();
 	}
 
 	public String getVersion() {

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -114,9 +114,9 @@ public class SiegeWar extends JavaPlugin {
     }
 
     private boolean loadAll() {
-	    return !Towny.getPlugin().isError()
-		    	&& Settings.loadSettingsAndLang()
-			    && SiegeController.loadAll();
+    	return !Towny.getPlugin().isError()
+				&& Settings.loadSettingsAndLang()
+				&& SiegeController.loadAll();
     }
 
 	public String getVersion() {

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -112,8 +112,8 @@ public class SiegeWar extends JavaPlugin {
     public void onDisable() {
     	info("Shutting down...");
     }
-
- 	private boolean loadAll() {
+    	
+	private boolean loadAll() {
 		return !Towny.getPlugin().isError()
 				&& Settings.loadSettingsAndLang()
 				&& SiegeController.loadAll();
@@ -146,7 +146,6 @@ public class SiegeWar extends JavaPlugin {
 	
 	private boolean registerListeners() {
 		PluginManager pm = getServer().getPluginManager();
-
 		if (siegeWarPluginError) {
 			pm.registerEvents(new SiegeWarSafeModeListener(this), this);
 			return false;

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -75,11 +75,12 @@ public class SiegeWar extends JavaPlugin {
 	        siegeWarPluginError = true;
         }
 
+		registerListeners(); //Ensure listeners are registered before data cleanup, to listen for nation disband
+		registerPlayerCommands();
+		checkIntegrations();
+
 		DataCleanupUtil.cleanupData(siegeWarPluginError);
 		PermsCleanupUtil.cleanupPerms(siegeWarPluginError);
-		registerPlayerCommands();
-		registerListeners();
-		checkIntegrations();
 
 		if(siegeWarPluginError) {
 			severe("SiegeWar did not load successfully, and is now in safe mode!");

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -113,11 +113,11 @@ public class SiegeWar extends JavaPlugin {
     	info("Shutting down...");
     }
 
-	private boolean loadAll() {
-		return !Towny.getPlugin().isError()
-				&& Settings.loadSettingsAndLang()
-				&& SiegeController.loadAll();
-	}
+    private boolean loadAll() {
+	    return !Towny.getPlugin().isError()
+		    	&& Settings.loadSettingsAndLang()
+			    && SiegeController.loadAll();
+    }
 
 	public String getVersion() {
 		return getDescription().getVersion();

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -112,7 +112,7 @@ public class SiegeWar extends JavaPlugin {
     public void onDisable() {
     	info("Shutting down...");
     }
-
+	
     private boolean loadAll() {
     	return !Towny.getPlugin().isError()
 				&& Settings.loadSettingsAndLang()

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -112,7 +112,7 @@ public class SiegeWar extends JavaPlugin {
     public void onDisable() {
     	info("Shutting down...");
     }
-	
+    
     private boolean loadAll() {
     	return !Towny.getPlugin().isError()
 				&& Settings.loadSettingsAndLang()

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -99,6 +99,14 @@ public class SiegeMetaDataController {
 			town.addMetaData(new StringDataField("siegewar_attackerName", name));
 	}
 
+	@Nullable
+	public static String getDefenderUUID(Town town) {
+		StringDataField sdf = (StringDataField) siegeDefenderUUID.clone();
+		if (town.hasMeta(sdf.getKey()))
+			return MetaDataUtil.getString(town, sdf);
+		return null;
+	}
+
 	public static void setDefenderUUID(Town town, String uuid) {
 		StringDataField sdf = (StringDataField) siegeDefenderUUID.clone();
 		if (town.hasMeta(sdf.getKey()))

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -70,10 +70,10 @@ public class SiegeMetaDataController {
 	}
 
 	@Nullable
-	public static UUID getAttackerUUID(Town town) {
+	public static String getAttackerUUID(Town town) {
 		StringDataField sdf = (StringDataField) siegeAttackerUUID.clone();
 		if (town.hasMeta(sdf.getKey()))
-			return UUID.fromString(MetaDataUtil.getString(town, sdf));
+			return MetaDataUtil.getString(town, sdf);
 		return null;
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -11,7 +11,6 @@ import com.palmergames.bukkit.towny.object.metadata.LongDataField;
 import com.palmergames.bukkit.towny.object.metadata.StringDataField;
 import com.palmergames.bukkit.towny.utils.MetaDataUtil;
 
-
 /**
  * 
  * 

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -11,7 +11,6 @@ import com.palmergames.bukkit.towny.object.metadata.LongDataField;
 import com.palmergames.bukkit.towny.object.metadata.StringDataField;
 import com.palmergames.bukkit.towny.utils.MetaDataUtil;
 
-import java.util.UUID;
 
 /**
  * 

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -101,14 +101,6 @@ public class SiegeMetaDataController {
 			town.addMetaData(new StringDataField("siegewar_attackerName", name));
 	}
 
-	@Nullable
-	public static String getDefenderUUID(Town town) {
-		StringDataField sdf = (StringDataField) siegeDefenderUUID.clone();
-		if (town.hasMeta(sdf.getKey()))
-			return MetaDataUtil.getString(town, sdf);
-		return null;
-	}
-
 	public static void setDefenderUUID(Town town, String uuid) {
 		StringDataField sdf = (StringDataField) siegeDefenderUUID.clone();
 		if (town.hasMeta(sdf.getKey()))

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/SiegeMetaDataController.java
@@ -11,6 +11,8 @@ import com.palmergames.bukkit.towny.object.metadata.LongDataField;
 import com.palmergames.bukkit.towny.object.metadata.StringDataField;
 import com.palmergames.bukkit.towny.utils.MetaDataUtil;
 
+import java.util.UUID;
+
 /**
  * 
  * 
@@ -68,10 +70,10 @@ public class SiegeMetaDataController {
 	}
 
 	@Nullable
-	public static String getAttackerUUID(Town town) {
+	public static UUID getAttackerUUID(Town town) {
 		StringDataField sdf = (StringDataField) siegeAttackerUUID.clone();
 		if (town.hasMeta(sdf.getKey()))
-			return MetaDataUtil.getString(town, sdf);
+			return UUID.fromString(MetaDataUtil.getString(town, sdf));
 		return null;
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
@@ -1,5 +1,6 @@
 package com.gmail.goosius.siegewar.metadata;
 
+import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.metadata.BooleanDataField;
@@ -207,5 +208,7 @@ public class TownMetaDataController {
 		if (town.hasMeta(sdf.getKey())) {
 			town.removeMetaData(sdf);
 		}
+		//Completely delete sieges of types suppression, liberation, and revolt
+		SiegeMetaDataController.removeSiegeMeta(town);
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
@@ -1,6 +1,5 @@
 package com.gmail.goosius.siegewar.metadata;
 
-import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.metadata.BooleanDataField;

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
@@ -11,6 +11,8 @@ import com.palmergames.bukkit.towny.object.metadata.StringDataField;
 import com.palmergames.bukkit.towny.utils.MetaDataUtil;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.UUID;
+
 /**
  * 
  * @author LlmDl
@@ -187,8 +189,8 @@ public class TownMetaDataController {
 		return MetaDataUtil.hasMeta(town, legacyDataOccupyingNationUUID);
 	}
 
-	public static String getLegacyOccupierUUID(Town town) {
-		return MetaDataUtil.getString(town, legacyDataOccupyingNationUUID);
+	public static UUID getLegacyOccupierUUID(Town town) {
+		return UUID.fromString(MetaDataUtil.getString(town, legacyDataOccupyingNationUUID));
 	}
 
 	public static void deleteLegacyMetadata(Town town) {

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
@@ -208,7 +208,6 @@ public class TownMetaDataController {
 		if (town.hasMeta(sdf.getKey())) {
 			town.removeMetaData(sdf);
 		}
-		//Completely delete sieges of types suppression, liberation, and revolt
-		SiegeMetaDataController.removeSiegeMeta(town);
+		//Note that legacy sieges will already have been removed by SiegeController.loadSiegeList()
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/TownMetaDataController.java
@@ -11,8 +11,6 @@ import com.palmergames.bukkit.towny.object.metadata.StringDataField;
 import com.palmergames.bukkit.towny.utils.MetaDataUtil;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.UUID;
-
 /**
  * 
  * @author LlmDl
@@ -189,8 +187,8 @@ public class TownMetaDataController {
 		return MetaDataUtil.hasMeta(town, legacyDataOccupyingNationUUID);
 	}
 
-	public static UUID getLegacyOccupierUUID(Town town) {
-		return UUID.fromString(MetaDataUtil.getString(town, legacyDataOccupyingNationUUID));
+	public static String getLegacyOccupierUUID(Town town) {
+		return MetaDataUtil.getString(town, legacyDataOccupyingNationUUID);
 	}
 
 	public static void deleteLegacyMetadata(Town town) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
@@ -33,7 +33,7 @@ public class DataCleanupUtil {
             return;
         }
         if(!listenersRegistered) {
-            SiegeWar.severe("Listeners are not registered. Ensure listeners are registered before cleanup up data (e.g. to ensure enation refunds).");
+            SiegeWar.severe("Listeners are not registered. Ensure listeners are registered before cleanup up data (e.g. to ensure nation refunds).");
             return;
         }
         //Cleanup battle session data
@@ -43,7 +43,7 @@ public class DataCleanupUtil {
         migrateTownNeutralityData();
         migrateTownOccupationData();
         
-        //Only after all migration is complete, delete legacy data;
+        //Only after all migration is complete, delete legacy data.
         deleteLegacyResidentMetadata();
         deleteLegacyTownMetadata();
         deleteLegacyNationMetadata();

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
@@ -148,7 +148,7 @@ public class DataCleanupUtil {
      *             
      * @return true if we should load the given siege
      */
-    public static boolean handleLegacySiegeAndCheckForLoad(Town town) {
+    public static boolean handleLegacySiegeDataAndCheckForLoad(Town town) {
         try {
             String siegeType = SiegeMetaDataController.getSiegeType(town);
             switch (siegeType.toLowerCase()) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
@@ -158,7 +158,8 @@ public class DataCleanupUtil {
                 case "liberation":
                 case "suppression":
                     if (TownyEconomyHandler.isActive()) {
-                        Nation attacker = TownyAPI.getInstance().getNation(SiegeMetaDataController.getAttackerUUID(town));
+                        UUID attackerUUID = UUID.fromString(SiegeMetaDataController.getAttackerUUID(town));
+                        Nation attacker = TownyAPI.getInstance().getNation(attackerUUID);
                         double warChestAmount = SiegeMetaDataController.getWarChestAmount(town);
                         attacker.getAccount().deposit(warChestAmount, "Warchest Returned by data migration");
                         SiegeWar.info("Data Migration: Siege on " + town.getName() + " had warchest returned to attacker, because the siege will not be loaded.");
@@ -166,7 +167,7 @@ public class DataCleanupUtil {
                     SiegeWar.info("Data Migration: Not loading siege on " + town.getName() + ", because its type was legacy: " + siegeType + ".");
                     return false;
                 case "revolt":
-                    UUID attackerUUID = SiegeMetaDataController.getAttackerUUID(town);
+                    UUID attackerUUID = UUID.fromString(SiegeMetaDataController.getAttackerUUID(town));
                     UUID townUUID = town.getUUID();
                     if(attackerUUID.equals(townUUID)) {
                         SiegeWar.info("Data Migration: Not loading siege on " + town.getName() + ", because its format was a legacy revolt siege.");

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
@@ -27,9 +27,14 @@ import java.util.UUID;
  */
 public class DataCleanupUtil {
 
-    public static void cleanupData(boolean siegeWarPluginError) {
+    public static void cleanupData(boolean siegeWarPluginError, boolean listenersRegistered) {
         if(siegeWarPluginError) {
             SiegeWar.severe("SiegeWar is in safe mode. Data cleanup not attempted.");
+            return;
+        }
+        if(!listenersRegistered) {
+            SiegeWar.severe("Listeners are not registered. Ensure listeners are registered before cleanup up data (e.g. to ensure enation refunds).");
+            return;
         }
         //Cleanup battle session data
         cleanupBattleSession();

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
@@ -178,6 +178,8 @@ public class DataCleanupUtil {
             }
         } catch (Exception e) {
             SiegeWar.severe("Problem Migrating Siege on " + town.getName());
+            SiegeWar.severe("Now deleting Siege on " + town.getName());
+            SiegeMetaDataController.removeSiegeMeta(town);
             e.printStackTrace();
             return false;
         }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
@@ -87,7 +87,7 @@ public class DataCleanupUtil {
         boolean success = false;
         for(Town town: new ArrayList<>(TownyAPI.getInstance().getTowns())) {
             if(TownMetaDataController.hasLegacyOccupierUUID(town)) {
-                Nation occupyingNation = TownyAPI.getInstance().getNation(TownMetaDataController.getLegacyOccupierUUID(town));
+                Nation occupyingNation = TownyAPI.getInstance().getNation(UUID.fromString(TownMetaDataController.getLegacyOccupierUUID(town)));
                 if(occupyingNation != null) {
                     SiegeWarTownOccupationUtil.setTownOccupation(town, occupyingNation);
                     success = true;

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
@@ -18,6 +18,7 @@ import com.palmergames.bukkit.towny.object.Translation;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * This class deals with everything related to data cleanup, including:
@@ -165,9 +166,9 @@ public class DataCleanupUtil {
                     SiegeWar.info("Data Migration: Not loading siege on " + town.getName() + ", because its type was legacy: " + siegeType + ".");
                     return false;
                 case "revolt":
-                    String attackerUUID = SiegeMetaDataController.getAttackerUUID(town);
-                    String townUUID = town.getUUID().toString();
-                    if(attackerUUID.equalsIgnoreCase(townUUID)) {
+                    UUID attackerUUID = SiegeMetaDataController.getAttackerUUID(town);
+                    UUID townUUID = town.getUUID();
+                    if(attackerUUID.equals(townUUID)) {
                         SiegeWar.info("Data Migration: Not loading siege on " + town.getName() + ", because its format was a legacy revolt siege.");
                         return false;
                     } else {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DataCleanupUtil.java
@@ -177,10 +177,9 @@ public class DataCleanupUtil {
                     return false; //Unknown siege type
             }
         } catch (Exception e) {
-            SiegeWar.severe("Problem Migrating Siege on " + town.getName());
-            SiegeWar.severe("Now deleting Siege on " + town.getName());
+            SiegeWar.info("Problem Migrating Siege on " + town.getName());
+            SiegeWar.info("Now deleting Siege on " + town.getName());
             SiegeMetaDataController.removeSiegeMeta(town);
-            e.printStackTrace();
             return false;
         }
     }


### PR DESCRIPTION
#### Description: 
- With current code, sieges do not get migrate from the legacy to the new format (and indeed bad things happen if you load up with legacy sieges.
- When upgrading to SW2.0.0, Servers will be recommended to first let all current sieges be completed, including invade/plunder, so that players might have some time to study the new mechanics before sieges restart.
- This PR supports those servers who choose to go against recommendations and migrate while there are active or recently ended sieges. The migration is deliberately robust to carefully avoid any data corruption issues: Legacy conquest sieges are automatically kept, the rest are automatically deleted. 
- The PR also fixes a bug with occupation migration, where the natural nation was getting the town after migration.
- This PR also fixes a bug where nations deleted during occupation would not get refunds.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
