### PR TITLE
Added restriction - in con sieges, occupied towns cannot surrender

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderDefence.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderDefence.java
@@ -3,15 +3,16 @@ package com.gmail.goosius.siegewar.playeractions;
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
+import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.timeractions.AttackerWin;
+import com.gmail.goosius.siegewar.utils.SiegeWarTownOccupationUtil;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.confirmations.Confirmation;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Translatable;
-import com.palmergames.bukkit.towny.permissions.PermissionNodes;
 import com.palmergames.util.TimeMgmt;
 import org.bukkit.entity.Player;
 
@@ -28,7 +29,10 @@ public class SurrenderDefence {
 
 		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_SURRENDER.getNode()))
 			throw new TownyException(Translatable.of("msg_err_action_disable").forLocale(player));
-		
+
+		if (siege.getSiegeType() == SiegeType.CONQUEST && SiegeWarTownOccupationUtil.isTownOccupied(siege.getTown()))
+			throw new TownyException(Translatable.of("msg_err_siege_occupied_towns_cannot_surrender_in_conquest_sieges").forLocale(player));
+
 		Confirmation
 			.runOnAccept(()-> surrenderDefence(siege, siege.getTimeUntilSurrenderConfirmationMillis()))
 			.runOnCancel(()-> Messaging.sendMsg(player, Translatable.of("msg_surrender_action_cancelled")))

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -541,6 +541,7 @@ msg_revolt_siege_attacker_abandon: '&bREVOLT SIEGE at %s > The attacking army of
 
 msg_conquest_siege_defender_surrender: '&bCONQUEST SIEGE at %s > The town has surrendered to the attacking army of %s!.'
 msg_revolt_siege_defender_surrender: '&bREVOLT SIEGE at %s > The rebels have admitted defeat and surrendered to the attacking army of %s!.'
+msg_err_siege_occupied_towns_cannot_surrender_in_conquest_sieges: '&cIn CONQUEST sieges, occupied towns cannot surrender.'
 
 #Siege Results
 


### PR DESCRIPTION
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- With the new occ system, its important that occupied towns cannot surrender conquest sieges ... otherwise they could quickly surrender to a friendly nation and get the occupation removed.
- The PR adds the required restriction

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ N/A too trivial ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
