### PR TITLE
Fix invade/plunder/subvert block placement messaging

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -108,7 +108,7 @@ public class InvadeTown {
 			throw new TownyException(translator.of("msg_err_cannot_invade_not_enough_permissions"));
 
 		if(residentsNation == null)
-			throw new TownyException(translator.of("msg_err_cannot_invade_not_enough_permissions"));  //Can't invade if nationless
+			throw new TownyException(translator.of("msg_err_siege_war_action_not_a_nation_member"));  //Can't invade if nationless
 
 		if(siege.getStatus().isActive())
 			throw new TownyException(translator.of("msg_err_cannot_invade_siege_still_in_progress"));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -105,10 +105,10 @@ public class InvadeTown {
 			throw new TownyException(translator.of("msg_err_action_disable"));
 
 		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_INVADE.getNode()))
-			throw new TownyException(translator.of("msg_err_action_disable"));
+			throw new TownyException(translator.of("msg_err_cannot_invade_not_enough_permissions"));
 
 		if(residentsNation == null)
-			throw new TownyException(translator.of("msg_err_action_disable"));  //Can't invade if nationless
+			throw new TownyException(translator.of("msg_err_cannot_invade_not_enough_permissions"));  //Can't invade if nationless
 
 		if(siege.getStatus().isActive())
 			throw new TownyException(translator.of("msg_err_cannot_invade_siege_still_in_progress"));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -104,11 +104,11 @@ public class InvadeTown {
 		if(!SiegeWarSettings.getWarSiegeInvadeEnabled())
 			throw new TownyException(translator.of("msg_err_action_disable"));
 
-		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_INVADE.getNode()))
-			throw new TownyException(translator.of("msg_err_cannot_invade_not_enough_permissions"));
-
 		if(residentsNation == null)
 			throw new TownyException(translator.of("msg_err_siege_war_action_not_a_nation_member"));  //Can't invade if nationless
+
+		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_INVADE.getNode()))
+			throw new TownyException(translator.of("msg_err_cannot_invade_not_enough_permissions"));
 
 		if(siege.getStatus().isActive())
 			throw new TownyException(translator.of("msg_err_cannot_invade_siege_still_in_progress"));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
@@ -91,7 +91,7 @@ public class PeacefullySubvertTown {
 			throw new TownyException(translator.of("msg_err_cannot_subvert_not_enough_permissions"));
 
 		if(residentsNation == null)
-			throw new TownyException(translator.of("msg_err_cannot_subvert_not_enough_permissions"));  //Can't subvert if nationless
+			throw new TownyException(translator.of("msg_err_siege_war_action_not_a_nation_member"));  //Can't subvert if nationless
 
 		if(SiegeController.hasActiveSiege(targetTown))
 			throw new TownyException(translator.of("msg_err_cannot_change_occupation_of_besieged_town"));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
@@ -87,11 +87,11 @@ public class PeacefullySubvertTown {
 		if(!SiegeWarSettings.isPeacefulTownsSubvertEnabled())
 			throw new TownyException(translator.of("msg_err_action_disable"));
 
-		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_SUBVERTPEACEFULTOWN.getNode()))
-			throw new TownyException(translator.of("msg_err_cannot_subvert_not_enough_permissions"));
-
 		if(residentsNation == null)
 			throw new TownyException(translator.of("msg_err_siege_war_action_not_a_nation_member"));  //Can't subvert if nationless
+
+		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_SUBVERTPEACEFULTOWN.getNode()))
+			throw new TownyException(translator.of("msg_err_cannot_subvert_not_enough_permissions"));
 
 		if(SiegeController.hasActiveSiege(targetTown))
 			throw new TownyException(translator.of("msg_err_cannot_change_occupation_of_besieged_town"));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
@@ -88,10 +88,10 @@ public class PeacefullySubvertTown {
 			throw new TownyException(translator.of("msg_err_action_disable"));
 
 		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_SUBVERTPEACEFULTOWN.getNode()))
-			throw new TownyException(translator.of("msg_err_action_disable"));
+			throw new TownyException(translator.of("msg_err_cannot_subvert_not_enough_permissions"));
 
 		if(residentsNation == null)
-			throw new TownyException(translator.of("msg_err_action_disable"));  //Can't subvert if nationless
+			throw new TownyException(translator.of("msg_err_cannot_subvert_not_enough_permissions"));  //Can't subvert if nationless
 
 		if(SiegeController.hasActiveSiege(targetTown))
 			throw new TownyException(translator.of("msg_err_cannot_change_occupation_of_besieged_town"));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -269,7 +269,7 @@ public class PlaceBlock {
 			SiegeWarTownOccupationUtil.removeTownOccupation(nearbyTown);
 		} else {
 			if (residentsNation == null)
-				throw new TownyException(translator.of("msg_err_dont_belong_nation"));
+				throw new TownyException(translator.of("msg_err_siege_war_action_not_a_nation_member"));
 
 			if (SiegeWarImmunityUtil.isTownSiegeImmune(nearbyTown))
 				throw new TownyException(translator.of("msg_err_cannot_start_siege_due_to_siege_immunity"));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
@@ -50,18 +50,18 @@ public class PlunderTown {
 		final Translator translator = Translator.locale(player);
 
 		if (!townyUniverse.getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_PLUNDER.getNode()))
-			throw new TownyException(translator.of("msg_err_command_disable"));
+			throw new TownyException(translator.of("msg_err_cannot_plunder_not_enough_permissions"));
 
 		Resident resident = townyUniverse.getResident(player.getUniqueId());
 		if (resident == null)
 			throw new TownyException(translator.of("msg_err_not_registered_1", player.getName()));
 
 		if(!resident.hasTown())
-			throw new TownyException(translator.of("msg_err_siege_war_action_not_a_town_member"));
+			throw new TownyException(translator.of("msg_err_cannot_plunder_not_enough_permissions"));
 
 		Nation plunderingNation = resident.getNationOrNull();
 		if(plunderingNation == null)
-			throw new TownyException(translator.of("msg_err_siege_war_action_not_a_nation_member"));
+			throw new TownyException(translator.of("msg_err_cannot_plunder_not_enough_permissions"));
 
 		if(siege.isTownPlundered())
 			throw new TownyException(translator.of("msg_err_siege_war_town_already_plundered", townToBePlundered.getName()));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
@@ -49,9 +49,6 @@ public class PlunderTown {
 		TownyUniverse townyUniverse = TownyUniverse.getInstance();
 		final Translator translator = Translator.locale(player);
 
-		if (!townyUniverse.getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_PLUNDER.getNode()))
-			throw new TownyException(translator.of("msg_err_cannot_plunder_not_enough_permissions"));
-
 		Resident resident = townyUniverse.getResident(player.getUniqueId());
 		if (resident == null)
 			throw new TownyException(translator.of("msg_err_not_registered_1", player.getName()));
@@ -62,6 +59,9 @@ public class PlunderTown {
 		Nation plunderingNation = resident.getNationOrNull();
 		if(plunderingNation == null)
 			throw new TownyException(translator.of("msg_err_siege_war_action_not_a_nation_member"));
+
+		if (!townyUniverse.getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_PLUNDER.getNode()))
+			throw new TownyException(translator.of("msg_err_cannot_plunder_not_enough_permissions"));
 
 		if(siege.isTownPlundered())
 			throw new TownyException(translator.of("msg_err_siege_war_town_already_plundered", townToBePlundered.getName()));

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
@@ -57,11 +57,11 @@ public class PlunderTown {
 			throw new TownyException(translator.of("msg_err_not_registered_1", player.getName()));
 
 		if(!resident.hasTown())
-			throw new TownyException(translator.of("msg_err_cannot_plunder_not_enough_permissions"));
+			throw new TownyException(translator.of("msg_err_siege_war_action_not_a_town_member"));
 
 		Nation plunderingNation = resident.getNationOrNull();
 		if(plunderingNation == null)
-			throw new TownyException(translator.of("msg_err_cannot_plunder_not_enough_permissions"));
+			throw new TownyException(translator.of("msg_err_siege_war_action_not_a_nation_member"));
 
 		if(siege.isTownPlundered())
 			throw new TownyException(translator.of("msg_err_siege_war_town_already_plundered", townToBePlundered.getName()));

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -55,7 +55,6 @@ msg_err_siege_war_revolt_immunity_active: "&cYour town has revolt immunity. It c
 #Attack
 msg_err_siege_war_banner_must_be_placed_above_ground: '&cThe siege banner must be placed above ground.'
 msg_err_siege_war_action_not_a_town_member: '&cYou must be a member of a town to do this action.'
-NUKE ???? msg_err_siege_war_action_not_a_nation_member: '&cYou must be a member of a nation to do this action.'
 msg_err_siege_war_cannot_attack_own_town: '&cYou cannot attack your own town.'
 msg_err_siege_war_cannot_attack_town_in_own_nation: '&cYou cannot attack a town in your own nation.'
 msg_err_siege_war_cannot_attack_non_enemy_nation: '&cYou cannot attack a town unless the nation of that town is an enemy of your nation.'
@@ -561,7 +560,12 @@ msg_err_cannot_invade_siege_still_in_progress: '&cYou cannot capture this town w
 msg_err_cannot_invade_town_already_occupied: '&cThere is no need to capture this town, because your nation already owns and occupies it.'
 msg_war_siege_cannot_add_military_rank_to_occupied_resident: '&cUnable to add military rank to resident, because they belong to an Occupied town.'
 msg_err_cannot_set_occupation_without_nation: '&cTown %s has no nation. You must set the nation first before you can set the town to Occupied.'
+msg_err_cannot_invade_not_enough_permissions: "&cYou do not have enough permissions to capture the town."
 
 #Siegezone proximity warning
 
 msg_siege_zone_proximity_warning: "&cWARNING: You are in a Siege-Zone!."
+
+#Plunder
+
+msg_err_cannot_plunder_not_enough_permissions: "&cYou do not have enough permissions to plunder the town."

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -54,7 +54,6 @@ msg_err_siege_war_town_voluntary_leave_impossible: "&cTowns cannot leave nations
 msg_err_siege_war_revolt_immunity_active: "&cYour town has revolt immunity. It cannot revolt until the revolt immunity expires."
 #Attack
 msg_err_siege_war_banner_must_be_placed_above_ground: '&cThe siege banner must be placed above ground.'
-msg_err_siege_war_action_not_a_town_member: '&cYou must be a member of a town to do this action.'
 msg_err_siege_war_cannot_attack_own_town: '&cYou cannot attack your own town.'
 msg_err_siege_war_cannot_attack_town_in_own_nation: '&cYou cannot attack a town in your own nation.'
 msg_err_siege_war_cannot_attack_non_enemy_nation: '&cYou cannot attack a town unless the nation of that town is an enemy of your nation.'
@@ -570,3 +569,8 @@ msg_siege_zone_proximity_warning: "&cWARNING: You are in a Siege-Zone!."
 #Plunder
 
 msg_err_cannot_plunder_not_enough_permissions: "&cYou do not have enough permissions to plunder the town."
+
+#Not a town/nation member
+
+msg_err_siege_war_action_not_a_nation_member: '&cYou must be a member of a nation to do this action.'
+msg_err_siege_war_action_not_a_town_member: '&cYou must be a member of a town to do this action.'

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -512,6 +512,7 @@ msg_war_siege_cannot_add_military_rank_to_peaceful_resident: '&cUnable to add mi
 sg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their homeblocks. If you wish to move your homeblock, first toggle peacefulness off."
 msg_err_peaceful_towns_cannot_revolt: '&cPeaceful towns cannot revolt.'
 msg_err_capital_towns_cannot_go_peaceful: '&cCapital towns cannot go peaceful.'
+msg_err_cannot_subvert_not_enough_permissions: "&cYou do not have enough permissions to subvert the town."
 
 # Town neutrality
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- Wth current code, in an active revolt siege, when a chest is placed by the town, a string missing error is shown.
- With current code, in an active resolve siege, when a coloured flag is placed by the town, the error message is not very informative e.g. "No permission".
- This PR fixes issue 1, and improves the messaging in issue 2
- The PR also improves the messaging around subvert when the player hasn't permissions

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
