### PR TITLE
Set occupation tax to be double

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarNationSetOccupationTaxAddonCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarNationSetOccupationTaxAddonCommand.java
@@ -57,14 +57,14 @@ public class SiegeWarNationSetOccupationTaxAddonCommand extends BaseCommand impl
 		Player player = catchConsole(sender);
 		Nation nation = getNationFromPlayerOrThrow(player);
 
-		int maxTaxPerPlot = SiegeWarSettings.getMaxOccupationTaxPerPlot();
-		int taxPerPlot;
+		double maxTaxPerPlot = SiegeWarSettings.getMaxOccupationTaxPerPlot();
+		double taxPerPlot;
 		if (args[0].equalsIgnoreCase("max")) {
 			NationMetaDataController.setNationOccupationTaxPerPlot(nation, -1);
 			taxPerPlot = maxTaxPerPlot;
 			TownyMessaging.sendMsg(player, Translatable.of("msg_occupation_tax_set_max", getMoney(taxPerPlot)));
 		} else {
-			taxPerPlot = MathUtil.getPositiveIntOrThrow(args[0]);
+			taxPerPlot = getPositiveDoubleOrThrow(args[0]);
 			if (taxPerPlot > maxTaxPerPlot)
 				Messaging.sendMsg(player, Translatable.of("msg_err_occupation_tax_cannot_be_more_than", maxTaxPerPlot));
 			taxPerPlot = Math.min(maxTaxPerPlot, taxPerPlot);
@@ -73,7 +73,19 @@ public class SiegeWarNationSetOccupationTaxAddonCommand extends BaseCommand impl
 		}
 	}
 
-	private String getMoney(int tax) {
+	private double getPositiveDoubleOrThrow(String input) throws TownyException {
+		try {
+			double d = Double.parseDouble(input);
+			if(d < 0) {
+				throw new TownyException(Translatable.of("msg_err_negative"));
+			}
+			return d;
+		} catch (NumberFormatException var3) {
+			throw new TownyException(Translatable.of("msg_error_must_be_num"));
+		}
+	}
+
+	private String getMoney(double tax) {
 		return TownyEconomyHandler.isActive() ? TownyEconomyHandler.getFormattedBalance(tax) : String.valueOf(tax);
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/metadata/NationMetaDataController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/metadata/NationMetaDataController.java
@@ -3,6 +3,7 @@ package com.gmail.goosius.siegewar.metadata;
 import com.gmail.goosius.siegewar.SiegeWar;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.metadata.CustomDataField;
+import com.palmergames.bukkit.towny.object.metadata.DecimalDataField;
 import com.palmergames.bukkit.towny.object.metadata.IntegerDataField;
 import com.palmergames.bukkit.towny.object.metadata.LongDataField;
 import com.palmergames.bukkit.towny.object.metadata.StringDataField;
@@ -22,7 +23,7 @@ public class NationMetaDataController {
     private static final IntegerDataField legacyFieldNationPeacefulOccupationTax = new IntegerDataField("siegeWar_nationPeacefulOccupationTax", 0);
     
     //Occupation tax per plot. A value of -1 causes the applied value to be the "max" set in the config file.
-    private static final IntegerDataField nationOccupationTaxPerPlot = new IntegerDataField("siegeWar_nationOccupationTaxPerPlot", -1);
+    private static final DecimalDataField nationOccupationTaxPerPlot = new DecimalDataField("siegeWar_nationOccupationTaxPerPlot", -1.0);
  
     public NationMetaDataController(SiegeWar plugin) {
         this.plugin = plugin;
@@ -94,14 +95,14 @@ public class NationMetaDataController {
         setIdf(nation, townsLost, num);
     }
 
-	public static void setNationOccupationTaxPerPlot(Nation nation, int tax) {
-		MetaDataUtil.setInt(nation, nationOccupationTaxPerPlot, tax, true);
+	public static void setNationOccupationTaxPerPlot(Nation nation, double tax) {
+		MetaDataUtil.setDouble(nation, nationOccupationTaxPerPlot, tax, true);
 	}
 
-	public static int getNationOccupationTaxPerPlot(Nation nation) {
+	public static double getNationOccupationTaxPerPlot(Nation nation) {
         if (!MetaDataUtil.hasMeta(nation, nationOccupationTaxPerPlot))
             return -1;
-        return MetaDataUtil.getInt(nation, nationOccupationTaxPerPlot);
+        return MetaDataUtil.getDouble(nation, nationOccupationTaxPerPlot);
 	}
 
     public static void deleteLegacyMetadata(Nation nation) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -207,7 +207,7 @@ public enum ConfigNodes {
 			"# If the value is 0, then money amounts are not modified."),
 	WAR_SIEGE_MAX_OCCUPATION_TAX_PER_PLOT(
 			"war.siege.money.max_occupation_tax_per_plot",
-			"2",
+			"2.0",
 			"",
 			"# The maximum that a nation can set for its occupation-tax, using /n set occupationtax.",
 			"# Each nation's occupation tax will always track the above value, unless they use the above command.",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -173,8 +173,8 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_EXTRA_MONEY_PERCENTAGE_PER_TOWN_LEVEL);
 	}
 
-	public static int getMaxOccupationTaxPerPlot() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_MAX_OCCUPATION_TAX_PER_PLOT);
+	public static double getMaxOccupationTaxPerPlot() {
+		return Settings.getDouble(ConfigNodes.WAR_SIEGE_MAX_OCCUPATION_TAX_PER_PLOT);
 	}
 
 	public static int getWarSiegeBannerControlSessionDurationMinutes() {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- With current code the default occupation tax is very small e.g. 2
- Small differences in this could be important e.g 2.5, 1.5
- Thus this PR turns the value into a decimal

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
