### PR TITLE
Messaging improvements and fixes

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -516,7 +516,7 @@ public class SiegeController {
 				Messaging.sendGlobalMessage(
 						Translatable.of("msg_revolt_siege_started",
 						siege.getTown().getName(),
-						siege.getDefender().getName()
+						siege.getAttacker().getName()
 				));
 				break;
 		}

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
@@ -56,16 +56,16 @@ public class AbandonAttack {
 	}
 
 	private static Translatable getAbandonMessage(Siege siege) {
-		String key = String.format("msg_%s_siege_attacker_abandon", siege.getSiegeType().toLowerCase());
-		Translatable message = Translatable.of(key,
-				siege.getTown().getName(),
-				siege.getAttacker().getName());
-
+		Translatable message;
+		String key;
 		if (siege.getNumBattleSessionsCompleted() < SiegeWarSettings.getSiegeDurationBattleSessions()) {
-			message.append(Translatable.of("msg_pending_defender_victory"));
+			key = String.format("msg_%s_siege_attacker_abandon", siege.getSiegeType().toLowerCase());
+			message = Translatable.of(key, siege.getTown().getName(), siege.getAttacker().getName());
 		} else {
-			String key2 = String.format("msg_%s_siege_defender_win_result", siege.getSiegeType().toLowerCase());
-			message.append(Translatable.of(key2));
+			key = String.format("msg_%s_siege_attacker_abandon_confirmed", siege.getSiegeType().toLowerCase());
+			message = Translatable.of(key, siege.getTown().getName());
+			key= String.format("msg_%s_siege_defender_win_result", siege.getSiegeType().toLowerCase());
+			message.append(Translatable.of(key));
 		}
 
 		return message;

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderDefence.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/SurrenderDefence.java
@@ -54,18 +54,17 @@ public class SurrenderDefence {
 	}
 
 	private static Translatable getSurrenderMessage(Siege siege) {
-		String key = String.format("msg_%s_siege_defender_surrender", siege.getSiegeType().toLowerCase());
-		Translatable message = Translatable.of(key,
-						siege.getTown().getName(),
-						siege.getAttacker().getName());
-
-		if(siege.getNumBattleSessionsCompleted() < SiegeWarSettings.getSiegeDurationBattleSessions()) {
-			message.append(Translatable.of("msg_pending_attacker_victory"));
+		Translatable message;
+		String key;
+		if (siege.getNumBattleSessionsCompleted() < SiegeWarSettings.getSiegeDurationBattleSessions()) {
+			key = String.format("msg_%s_siege_defender_surrender", siege.getSiegeType().toLowerCase());
+			message = Translatable.of(key, siege.getTown().getName(), siege.getAttacker().getName());
 		} else {
-			String key2 = String.format("msg_%s_siege_attacker_win_result", siege.getSiegeType().toLowerCase());
-			message.append(Translatable.of(key2));
+			key = String.format("msg_%s_siege_defender_surrender_confirmed", siege.getSiegeType().toLowerCase());
+			message = Translatable.of(key, siege.getTown().getName());
+			key = String.format("msg_%s_siege_attacker_win_result", siege.getSiegeType().toLowerCase());
+			message.append(Translatable.of(key));
 		}
-
 		return message;
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -138,6 +138,11 @@ public class SiegeWarBattleSessionUtil {
 
 				//Save siege to database
 				SiegeController.saveSiege(siege);
+
+			} else if (siege.getStatus() == SiegeStatus.PENDING_ATTACKER_ABANDON
+				|| siege.getStatus() == SiegeStatus.PENDING_DEFENDER_SURRENDER) {
+				//Adjust numBattleSessionsCompleted
+				siege.setNumBattleSessionsCompleted(siege.getNumBattleSessionsCompleted()+1);
 			}
 		} catch (Throwable t) {
 			try {

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -256,8 +256,8 @@ status_town_siege_status_plundered: '&2 > Town Plundered: %s'
 # Siege statuses
 siege_status_attacker_abandon: 'Attacker Abandon'
 siege_status_defender_surrender: 'Defender Surrender'
-siege_status_pending_attacker_abandon: 'Pending Attacker Abandon'
-siege_status_pending_defender_surrender: 'Pending Defender Surrender'
+siege_status_pending_attacker_abandon: 'Attacker Abandon Pending'
+siege_status_pending_defender_surrender: 'Defender Surrender Pending'
 
 # Nation screen
 status_nation_offensive_sieges: '&2Offensive Sieges &a[%s]&2: &f'
@@ -265,12 +265,6 @@ status_nation_defensive_sieges: '&2Defensive Sieges &a[%s]&2: &f'
 
 msg_err_town_cannot_end_siege_as_no_siege: '&cThe nearby town has no siege. Abandon/Surrender not possible.'
 msg_err_town_cannot_end_siege_as_finished: '&cThe siege is finished or scheduled to finish. Abandon/Surrender not possible.'
-
-# Generic Victory messages
-msg_immediate_attacker_victory: " The attackers are victorious!"
-msg_pending_attacker_victory: " Attacker victory will be confirmed when siege progress is complete."
-msg_immediate_defender_victory: " The defenders are victorious!"
-msg_pending_defender_victory: " Defender victory will be confirmed when siege progress is complete."
 
 # Plunder
 msg_err_siege_war_plunder_not_possible_rebels_won: '&cPlunder not possible because the town rebels won the siege.'
@@ -535,13 +529,18 @@ msg_revolt_siege_timed_defender_win: '&bREVOLT SIEGE at %s > The rebellion has s
 
 #Abandoning Attacks
 
-msg_conquest_siege_attacker_abandon: '&bCONQUEST SIEGE at %s > The attacking army of %s has abandoned its attack on the town!.'
-msg_revolt_siege_attacker_abandon: '&bREVOLT SIEGE at %s > The attacking army of %s, which previously occupied the town, has admitted defeat and retreated!.'
+msg_conquest_siege_attacker_abandon: '&bCONQUEST SIEGE at %s > The attacking army of %s has admitted defeat and retreated!. This action will be confirmed when siege progress is complete.'
+msg_revolt_siege_attacker_abandon: '&bREVOLT SIEGE at %s > The attacking army of %s, which previously occupied the town, has admitted defeat and retreated!. This action will be confirmed when siege progress is complete.'
+msg_conquest_siege_attacker_abandon_confirmed: '&bCONQUEST SIEGE at %s > Attacker Abandon Confirmed!'
+msg_revolt_siege_attacker_abandon_confirmed: '&bREVOLT SIEGE at %s > Attacker Abandon Confirmed!'
+
 
 #Surrendering Defence
 
-msg_conquest_siege_defender_surrender: '&bCONQUEST SIEGE at %s > The town has surrendered to the attacking army of %s!.'
-msg_revolt_siege_defender_surrender: '&bREVOLT SIEGE at %s > The rebels have admitted defeat and surrendered to the attacking army of %s!.'
+msg_conquest_siege_defender_surrender: '&bCONQUEST SIEGE at %s > The town has surrendered to the attacking army of %s!. This action will be confirmed when siege progress is complete.'
+msg_revolt_siege_defender_surrender: '&bREVOLT SIEGE at %s > The rebels have admitted defeat and surrendered to the attacking army of %s!. This action will be confirmed when siege progress is complete.'
+msg_conquest_siege_defender_surrender_confirmed: '&bCONQUEST SIEGE at %s > Defender Surrender Confirmed!.'
+msg_revolt_siege_defender_surrender_confirmed: '&bREVOLT SIEGE at %s > Defender Surrender Confirmed!.'
 msg_err_siege_occupied_towns_cannot_surrender_in_conquest_sieges: '&cIn CONQUEST sieges, occupied towns cannot surrender.'
 
 #Siege Results


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- This PR fixes the revolt siege start message to give the nation name.
- The messages for "abandon/surrender initiated" and "abandon/surrender confirmed" contained a lot of duplication. The PR removes the duplication.
- This PR changes the siege status names of "Pending X" to "X Pending" for consistency

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
