### PR TITLE
Improved nation screen sw elements

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -95,29 +95,41 @@ public class SiegeWarStatusScreenListener implements Listener {
 				}
 			}
 
-			List<String> out = new ArrayList<>();
-
+			//[Sieges]
 			// Offensive Sieges [3]: TownA, TownB, TownC
-	        List<Town> siegeAttacks = new ArrayList<>(SiegeController.getActiveOffensiveSieges(nation).values());
-			if (siegeAttacks.size() > 0)
-				out.add(translator.of("status_nation_offensive_sieges", siegeAttacks.size())
-					+ getFormattedTownList(siegeAttacks));
-
-	        // Defensive Sieges [3]: TownX, TownY, TownZ
-	        List<Town> siegeDefences = new ArrayList<>(SiegeController.getActiveDefensiveSieges(nation).values());
-			if (siegeDefences.size() > 0)
-				out.add(translator.of("status_nation_defensive_sieges", siegeDefences.size())
-					+ getFormattedTownList(siegeDefences));
-
-			if (SiegeWarSettings.getWarSiegeNationStatisticsEnabled()) {
-				out.add(translator.of("status_nation_town_stats", NationMetaDataController.getTotalTownsGained(nation), NationMetaDataController.getTotalTownsLost(nation)));
-				out.add(translator.of("status_nation_plunder_stats", NationMetaDataController.getTotalPlunderGained(nation), NationMetaDataController.getTotalPlunderLost(nation)));
+			// Defensive Sieges [2]: TownX, TownY
+			List<Town> siegeAttacks = new ArrayList<>(SiegeController.getActiveOffensiveSieges(nation).values());
+			List<Town> siegeDefences = new ArrayList<>(SiegeController.getActiveDefensiveSieges(nation).values());
+			if(siegeAttacks.size() > 0 || siegeDefences.size() > 0) {
+				//Create the text inside the hover item
+				Component hoverText = Component.empty();
+				hoverText = hoverText.append(Component.text(translator.of("status_nation_offensive_sieges", siegeAttacks.size())
+						+ getFormattedTownList(siegeAttacks)));
+				hoverText = hoverText.append(Component.newline());
+				hoverText = hoverText.append(Component.text(translator.of("status_nation_defensive_sieges", siegeDefences.size())
+						+ getFormattedTownList(siegeDefences)));
+				//Add the hover item to the screen
+				event.getStatusScreen().addComponentOf("siegeWar_siegesHover",
+						Component.empty()
+							.append(Component.text(hoverFormat(translator.of("status_nation_hover_title_sieges")))
+							.hoverEvent(HoverEvent.showText(hoverText))));
 			}
-			
-			Component comp = Component.empty();
-			for (String line : out)
-				comp = comp.append(Component.newline()).append(Component.text(line));
-			event.getStatusScreen().addComponentOf("siegeWarNation", comp);
+
+			//[War History]
+			// Towny Captured ...
+			// Towns Plundered ...
+			if(siegeAttacks.size() > 0 || siegeDefences.size() > 0) {
+				//Create the text inside the hover item
+				Component hoverText = Component.empty();
+				hoverText = hoverText.append(Component.text(translator.of("status_nation_town_stats", NationMetaDataController.getTotalTownsGained(nation), NationMetaDataController.getTotalTownsLost(nation))));
+				hoverText = hoverText.append(Component.newline());
+				hoverText = hoverText.append(Component.text(translator.of("status_nation_plunder_stats", NationMetaDataController.getTotalPlunderGained(nation), NationMetaDataController.getTotalPlunderLost(nation))));
+				//Add the hover item to the screen
+				event.getStatusScreen().addComponentOf("siegeWar_warHistoryHover",
+						Component.empty()
+							.append(Component.text(hoverFormat(translator.of("status_nation_hover_title_war_history")))
+							.hoverEvent(HoverEvent.showText(hoverText))));
+			}
 		}
 	}
 	

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -272,8 +272,8 @@ msg_err_siege_war_plunder_not_possible_rebels_won: '&cPlunder not possible becau
 # Added in 0.16
 
 #Nation war history
-status_nation_town_stats: '&2Town Invasion History - Foreign/Home: &a%d&2/&a%d'
-status_nation_plunder_stats: '&2Town Plunder History - Gains/Losses: &a%d&2/&a%d'
+status_nation_town_stats: '&2Captures Foreign/Home: &a%d&2/&a%d'
+status_nation_plunder_stats: '&2Plunder Gains/Losses: &a%d&2/&a%d'
 
 #Siege effects
 msg_err_siege_war_cannot_spawn_into_siegezone_or_besieged_town: '&cOnly town residents can spawn into a besieged town or siege zone.'
@@ -559,6 +559,11 @@ status_town_hover_title_revolt_immunity: "%s[%sRevolt-Immunity%s]"
 status_town_hover_title_siege_immunity: "%s[%sSiege-Immunity%s]"
 status_town_standalone_siege_immunity_timer: '&2Siege Immunity Timer: &a%s'
 
+#Nation Screen
+    
+status_nation_hover_title_sieges: "%s[%sSieges%s]"
+status_nation_hover_title_war_history: "%s[%sWar-History%s]"
+    
 #Town Capture & Occupation
 
 msg_err_cannot_invade_without_victory: "&cYou cannot capture this town unless your nation is victorious in the siege."


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
- Tidied up the nation screen, by putting the siegewar elements (except occupation tax), into their own hover boxes

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
