### PR TITLE
Revert "TownyInfluence" to "Guardian Towns"

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -161,7 +161,8 @@ public class SiegeWarTownEventListener implements Listener {
 	 * used by players as an easy exploit to escape occupation.
 	 * 
 	 * If a guardian town moves its homeblock, all peaceful towns it was guarding, are released.
-	 * NOTE: As per the "simplicity" theme of SW.2.0.0, this is preferred over a more complex scheme of keeping some towns and releasing others.
+	 * NOTE: As per the "simplicity" theme of SW.2.0.0, 
+	 * this is preferred over the alternative scheme of keeping the qualified towns and releasing the disqualified towns.
 	 * 
 	 */
 	@EventHandler
@@ -271,5 +272,4 @@ public class SiegeWarTownEventListener implements Listener {
 			}
 		}
 	}
-
 }

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
@@ -117,10 +117,10 @@ public class PeacefullySubvertTown {
 			return;  //There is no guardian town. Subversion allowed
 
 		if(!guardianTown.hasNation())
-			throw new TownyException(translator.of("msg_err_cannot_subvert_dont_own_guardian_town", targetPeacefulTown.getName()));
+			throw new TownyException(translator.of("msg_err_cannot_subvert_dont_own_guardian_town", guardianTown.getName()));
 
 		if(guardianTown.getNationOrNull() != subvertingNation)
-			throw new TownyException(translator.of("msg_err_cannot_subvert_dont_own_guardian_town", targetPeacefulTown.getName()));
+			throw new TownyException(translator.of("msg_err_cannot_subvert_dont_own_guardian_town", guardianTown.getName()));
 	}
 
 }

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
@@ -5,19 +5,23 @@ import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.TownOccupationController;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.events.PreSubvertTownEvent;
+import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.SiegeWarNationUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarTownPeacefulnessUtil;
+import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownyInventory;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translator;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
@@ -35,22 +39,22 @@ public class PeacefullySubvertTown {
 	 *
 	 * @param player the player attempting the subvert.
 	 * @param residentsNation the nation of the player (can be null)
-	 * @param targetTown the target town. We know the player is not a resident.
+	 * @param targetPeacefulTown the target peaceful town. We know the town is peaceful, and the player is not a resident.
 	 *
 	 * @throws TownyException if subvert is not allowed
 	 */
-	public static void processActionRequest(Player player, Nation residentsNation, Town targetTown) throws TownyException {
+	public static void processActionRequest(Player player, Nation residentsNation, Town targetPeacefulTown) throws TownyException {
 		// Throws an exception if the peaceful subversion of this town would not be allowed.
-		allowSubversionOrThrow(player, residentsNation, targetTown);
+		allowSubversionOrThrow(player, residentsNation, targetPeacefulTown);
 
-		PreSubvertTownEvent preEvent = new PreSubvertTownEvent(player, residentsNation, targetTown);
+		PreSubvertTownEvent preEvent = new PreSubvertTownEvent(player, residentsNation, targetPeacefulTown);
 		Bukkit.getPluginManager().callEvent(preEvent);
 		if (preEvent.isCancelled()) {
 			if (!preEvent.getCancellationMsg().isEmpty())
 				Messaging.sendErrorMsg(player, preEvent.getCancellationMsg());
 		} else {
 			//Subvert town now
-			subvertTown(residentsNation, targetTown);
+			subvertTown(residentsNation, targetPeacefulTown);
 		}
 	}
 	
@@ -82,8 +86,12 @@ public class PeacefullySubvertTown {
 		TownOccupationController.setTownOccupation(targetTown, subvertingNation);
 	}
 
-	private static void allowSubversionOrThrow(Player player, Nation residentsNation, Town targetTown) throws TownyException {
+	private static void allowSubversionOrThrow(Player player, Nation residentsNation, Town targetPeacefulTown) throws TownyException {
+		if(!targetPeacefulTown.hasHomeBlock())
+			return;  //If you don't have a homeblock, insta-subvert, otherwise we cannot check distance to any guardian towns
+
 		final Translator translator =  Translator.locale(player);
+
 		if(!SiegeWarSettings.isPeacefulTownsSubvertEnabled())
 			throw new TownyException(translator.of("msg_err_action_disable"));
 
@@ -93,21 +101,101 @@ public class PeacefullySubvertTown {
 		if (!TownyUniverse.getInstance().getPermissionSource().testPermission(player, SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_SUBVERTPEACEFULTOWN.getNode()))
 			throw new TownyException(translator.of("msg_err_cannot_subvert_not_enough_permissions"));
 
-		if(SiegeController.hasActiveSiege(targetTown))
+		if(SiegeController.hasActiveSiege(targetPeacefulTown))
 			throw new TownyException(translator.of("msg_err_cannot_change_occupation_of_besieged_town"));
 
-		if(TownOccupationController.isTownOccupiedByNation(residentsNation, targetTown))
+		if(TownOccupationController.isTownOccupiedByNation(residentsNation, targetPeacefulTown))
 			throw new TownyException(translator.of("msg_err_cannot_subvert_town_already_occupied"));
 
-		SiegeWarDistanceUtil.throwIfTownIsTooFarFromNationCapitalByWorld(residentsNation, targetTown);
+		SiegeWarDistanceUtil.throwIfTownIsTooFarFromNationCapitalByWorld(residentsNation, targetPeacefulTown);
 
-		SiegeWarDistanceUtil.throwIfTownIsTooFarFromNationCapitalByDistance(residentsNation, targetTown);
+		SiegeWarDistanceUtil.throwIfTownIsTooFarFromNationCapitalByDistance(residentsNation, targetPeacefulTown);
 
 		SiegeWarNationUtil.throwIfNationHasTooManyTowns(residentsNation);
 		
-		verifyThatNationHasEnoughTownyInfluenceToSubvertTown(residentsNation, targetTown);
+		SiegeWarNationUtil.throwIfNationHasTooManyTowns(residentsNation);
+
+		throwIfGuardianTownExistsAndSubverterDoesNotOwnIt(targetPeacefulTown, residentsNation);
 	}
 
+	/**
+	 * Throw if the given nation does not own the guardian town of the target peaceful town.
+	 * 
+	 * @param subvertingNation the nation attempting the subversion
+	 */
+	public static void throwIfGuardianTownExistsAndSubverterDoesNotOwnIt(Town targetPeacefulTown, Nation subvertingNation) throws TownyException {
+		Town guardianTown = calculateGuardianTown(targetPeacefulTown);
+		
+		if(guardianTown == null)
+			return;  //There is no guardian town. Subversion allowed
+		
+		if(!guardianTown.hasNation())
+			throw new TownyException("Cannot subvert because your nation does not own the guardian town of this peaceful town. The guardian town is: %s.");
+	
+		if(guardianTown.getNationOrNull() != subvertingNation)
+			throw new TownyException("Cannot subvert because your nation does not own the guardian town of this peaceful town. The guardian town is: %s");
+	}
+	
+	private static @Nullable Town calculateGuardianTown(Town peacefulTown) {
+		int guardianTownPlotsRequirement = SiegeWarSettings.getPeacefulTownsGuardianTownPlotsRequirement();
+		
+		Town guardianTown = null;
+		int winningDistanceInTownBlocks = SiegeWarSettings.getPeacefulTownsGuardianTownMinDistanceRequirement() + 1;  //A candidate guardian town must beat this distance (be less) to become leading candidate
+		for(Town candidateGuardianTown: TownyAPI.getInstance().getTowns()) {
+			if(!candidateGuardianTown.isRuined()
+				&& candidateGuardianTown.hasHomeBlock()
+				&& !SiegeWarTownPeacefulnessUtil.isTownPeaceful(candidateGuardianTown)
+				&& !SiegeController.hasActiveSiege(candidateGuardianTown) 
+				&& SiegeWarDistanceUtil.areTownsClose(peacefulTown, candidateGuardianTown, winningDistanceInTownBlocks)) {
+
+				guardianTown = candidateGuardianTown;
+				winningDistanceInTownBlocks = getDistanceInTownBlocks(peacefulTown, candidateGuardianTown);
+				distanceToCandidateGuardianTownInTownBlocks = 
+			}
+			{
+				
+				distanceToCandidateGuardianTown = SiegeWarDistanceUtil.areLocationsCloseHorizontally()
+				
+			}
+					&& town.getNumTownBlocks() >= guardianTownPlotsRequirement
+		}
+		
+		return guardianTown;
+	}
+
+
+	public static Set<Town> getValidGuardianTowns(Town peacefulTown) {
+		Set<Town> validGuardianTowns = new HashSet<>();
+		TownyUniverse townyUniverse = TownyUniverse.getInstance();
+
+		try {
+			int guardianTownPlotsRequirement = SiegeWarSettings.getPeacefulTownsGuardianTownPlotsRequirement();
+			int guardianTownMaxDistanceRequirementTownblocks = SiegeWarSettings.getPeacefulTownsGuardianTownMinDistanceRequirement();
+
+			//Find valid guardian towns
+			List<Town> candidateTowns = new ArrayList<>(townyUniverse.getDataSource().getTowns());
+			for(Town candidateTown: candidateTowns) {
+				if(!candidateTown.isNeutral()
+						&& candidateTown.hasNation()
+						&& candidateTown.getNation().isOpen()
+						&& candidateTown.getTownBlocks().size() >= guardianTownPlotsRequirement
+						&& SiegeWarDistanceUtil.areTownsClose(peacefulTown, candidateTown, guardianTownMaxDistanceRequirementTownblocks)) {
+					validGuardianTowns.add(candidateTown);
+				}
+			}
+		} catch (Exception e) {
+			try {
+				System.err.println("Problem getting valid guardian towns for - " + peacefulTown.getName());
+			} catch (Exception e2) {
+				System.err.println("Problem getting valid guardian towns (could not read peaceful town name)");
+			}
+			e.printStackTrace();
+		}
+
+		//Return result
+		return validGuardianTowns;
+	}
+	
 	/**
 	 * Verify if the given nation has enough Towny-Influence to subvert the given town
 	 *

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
@@ -15,6 +15,7 @@ import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translator;
+
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -81,7 +82,6 @@ public class PeacefullySubvertTown {
 
 	private static void allowSubversionOrThrow(Player player, Nation residentsNation, Town targetPeacefulTown) throws TownyException {
 		final Translator translator =  Translator.locale(player);
-
 		if(!SiegeWarSettings.isPeacefulTownsSubvertEnabled())
 			throw new TownyException(translator.of("msg_err_action_disable"));
 

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PeacefullySubvertTown.java
@@ -5,25 +5,18 @@ import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.TownOccupationController;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.events.PreSubvertTownEvent;
-import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
-import com.gmail.goosius.siegewar.utils.SiegeWarNationUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarNationUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarTownPeacefulnessUtil;
-import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
-import com.palmergames.bukkit.towny.object.TownyInventory;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translator;
-
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.Map;
 
 /**
  * This class is responsible for processing requests by nations to peacefully 'subvert' towns.
@@ -119,7 +112,7 @@ public class PeacefullySubvertTown {
 	 * @param subvertingNation the nation attempting the subversion
 	 */
 	public static void throwIfGuardianTownExistsAndSubverterDoesNotOwnIt(Translator translator, Town targetPeacefulTown, Nation subvertingNation) throws TownyException {
-		Town guardianTown = calculateGuardianTown(targetPeacefulTown);
+		Town guardianTown = SiegeWarTownPeacefulnessUtil.calculateGuardianTown(targetPeacefulTown);
 		if(guardianTown == null)
 			return;  //There is no guardian town. Subversion allowed
 
@@ -128,30 +121,6 @@ public class PeacefullySubvertTown {
 
 		if(guardianTown.getNationOrNull() != subvertingNation)
 			throw new TownyException(translator.of("msg_err_cannot_subvert_dont_own_guardian_town", targetPeacefulTown.getName()));
-	}
-	
-	private static @Nullable Town calculateGuardianTown(Town peacefulTown) {
-		if(!peacefulTown.hasHomeBlock())  //The peaceful town can't have a guardian town if it has no homeblock
-			return null;
-		Town guardianTown = null;
-		int candidateDistanceInTownBlocks;
-		int winningDistanceInTownBlocks = SiegeWarSettings.getPeacefulTownsGuardianTownSearchRadius() + 1;  //A candidate guardian town must beat this distance (be less) to become the leading candidate
-		for(Town candidateGuardianTown: TownyAPI.getInstance().getTowns()) {
-			if (!candidateGuardianTown.isRuined()
-					&& candidateGuardianTown.hasHomeBlock()
-					&& candidateGuardianTown.getHomeBlockOrNull().getWorld() == peacefulTown.getHomeBlockOrNull().getWorld()
-					&& !SiegeWarTownPeacefulnessUtil.isTownPeaceful(candidateGuardianTown)
-					&& !SiegeController.hasActiveSiege(candidateGuardianTown)) {
-
-				//Check distance
-				candidateDistanceInTownBlocks = SiegeWarDistanceUtil.getDistanceInTownBlocks(peacefulTown, candidateGuardianTown);
-				if (candidateDistanceInTownBlocks < winningDistanceInTownBlocks) {
-					guardianTown = candidateGuardianTown;
-					winningDistanceInTownBlocks = candidateDistanceInTownBlocks;
-				}
-			}
-		}
-		return guardianTown;
 	}
 
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -581,14 +581,12 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# If this setting is true, then subversion (instant capture and occupation) of peaceful towns is enabled."),
-	PEACEFUL_TOWNS_TOWNY_INFLUENCE_RADIUS(
-			"peaceful_towns.towny_influence_radius",
+	PEACEFUL_TOWNS_GUARDIAN_TOWN_SEARCH_RADIUS(
+			"peaceful_towns.guardian_town_search_radius",
 			"1200",
 			"",
-			"# This setting describes a circular area surrounding each peaceful town.",
-			"# The town feels the effect of all 'Towny-Influence' in that area.",
-			"# Each non-peaceful, non-sieged town, generates Towny Influence. The power of the influence is determined by num-townblocks.",
-			"# The nation with the highest Towny-Influence in the area can subvert (instantly capture and occupy) the peaceful town, if it wishes to do so."),
+			"# Given any peaceful town, the largest-by-townblock, non-peaceful, non-sieged town, in this radius around the homeblock, is considered to be the guardian town.",
+			"# If a nation owns the guardian town of a peaceful town, that nation can subvert (instantly capture and occupy) the peaceful town"),
 	OCCUPIED_TOWNS(
 			"occupied_towns",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -586,7 +586,7 @@ public enum ConfigNodes {
 			"1200",
 			"",
 			"# Given any peaceful town, the largest-by-townblock, non-peaceful, non-sieged town, in this radius around the homeblock, is considered to be the guardian town.",
-			"# If a nation owns the guardian town of a peaceful town, that nation can subvert (instantly capture and occupy) the peaceful town"),
+			"# If a nation owns the guardian town, that nation can instantly subvert & occupy the peaceful town"),
 	OCCUPIED_TOWNS(
 			"occupied_towns",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -236,8 +236,8 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.PEACEFUL_TOWNS_SUBVERT_ENABLED);
 	}
 
-	public static int getPeacefulTownsTownyInfluenceRadius() {
-		return Settings.getInt(ConfigNodes.PEACEFUL_TOWNS_TOWNY_INFLUENCE_RADIUS);
+	public static int getPeacefulTownsGuardianTownSearchRadius() {
+		return Settings.getInt(ConfigNodes.PEACEFUL_TOWNS_GUARDIAN_TOWN_SEARCH_RADIUS);
 	}
 
 	public static int getWarCommonPeacefulTownsNewTownConfirmationRequirementDays() {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -21,7 +21,10 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -150,6 +153,16 @@ public class SiegeWarDistanceUtil {
 		} catch(TownyException te) {
 			return false;
 		}
+	}
+
+
+	public static boolean areTownBlocksClose(@NotNull TownBlock townBlock1, @NotNull TownBlock townBlock2, int radiusTownblocks) {
+		return areCoordsClose(
+			townBlock1.getWorld(),
+			townBlock1.getCoord(),
+			townBlock2.getWorld(), 
+			townBlock2.getCoord(),
+			radiusTownblocks);
 	}
 
 	private static boolean areCoordsClose(TownyWorld world1, Coord coord1, TownyWorld world2, Coord coord2, int radiusTownblocks) {
@@ -299,5 +312,18 @@ public class SiegeWarDistanceUtil {
 		Coord coord1 = townA.getHomeBlockOrNull().getCoord();
 		Coord coord2= townB.getHomeBlockOrNull().getCoord();
 		return (int)(Math.sqrt(Math.pow(coord1.getX() - coord2.getX(), 2) + Math.pow(coord1.getZ() - coord2.getZ(), 2)));
+	}
+
+	public static List<Town> getNearbyTownsPeacefulTowns(@NotNull TownBlock townBlock, int radius) {
+		List<Town> result = new ArrayList<>();
+		int radiusInTownBlocks = radius / TownySettings.getTownBlockSize();
+		for(Town town: TownyAPI.getInstance().getTowns()) {
+			if(SiegeWarTownPeacefulnessUtil.isTownPeaceful(town)
+					&& town.hasHomeBlock() 
+					&& areTownBlocksClose(town.getHomeBlockOrNull(), townBlock, radiusInTownBlocks)) {
+				result.add(town);
+			}
+		}
+		return result;
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -335,4 +335,10 @@ public class SiegeWarDistanceUtil {
 			return false;
 		}
 	}
+
+	public static int getDistanceInTownBlocks(Town townA, Town townB) {
+		Coord coord1 = townA.getHomeBlockOrNull().getCoord();
+		Coord coord2= townB.getHomeBlockOrNull().getCoord();
+		return (int)(Math.sqrt(Math.pow(coord1.getX() - coord2.getX(), 2) + Math.pow(coord1.getZ() - coord2.getZ(), 2)));
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
@@ -1,29 +1,21 @@
 package com.gmail.goosius.siegewar.utils;
 
 import com.gmail.goosius.siegewar.SiegeController;
-import com.gmail.goosius.siegewar.SiegeWar;
-import com.gmail.goosius.siegewar.TownOccupationController;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyMessaging;
-import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
-import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.Translator;
 import com.palmergames.util.TimeMgmt;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Map;
-import java.util.Comparator;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 
 public class SiegeWarTownPeacefulnessUtil {
 
@@ -104,108 +96,6 @@ public class SiegeWarTownPeacefulnessUtil {
 		town.save();
 	}
 
-	/**
-     * Calculates the Towny-Influence map for the target town
-     *
-     * @param targetTown targetTown
-     *
-     * @return Towny-Influence map ....in the form: NationX:Amt, NationY:Amt, NationZ:Amt ....etc.
-     *         The map is sorted in descending order, with the highest influence nation being first
-     */
-    public static Map<Nation,Integer> calculateTownyInfluenceMap(Town targetTown) {
-		Map<Nation,Integer> result = new LinkedHashMap<>();
-		List<Town> allTowns = TownyAPI.getInstance().getTowns();
-		ListIterator<Town> allTownsItr = allTowns.listIterator();
-		Town town;
-		Nation nation;
-
-		//Cycle all towns
-		while (allTownsItr.hasNext()) {
-			town = allTownsItr.next();
-
-			try {
-				//Skip if town is ruined
-				if (town.isRuined())
-					continue;
-
-				//Skip if town is peaceful
-				if(TownMetaDataController.getPeacefulness(town))
-					continue;
-
-				//Skip if town has no natural or occupying nation
-				if(!town.hasNation() && !TownOccupationController.isTownOccupied(town))
-					continue;
-
-				//Skip if town is besieged
-				if(SiegeController.hasActiveSiege(town))
-					continue;
-
-				//Skip if town is too far from target town
-				int townyInfluenceRadiusInTownBlocks = SiegeWarSettings.getPeacefulTownsTownyInfluenceRadius() / TownySettings.getTownBlockSize();
-				if(!SiegeWarDistanceUtil.areTownsClose(town, targetTown, townyInfluenceRadiusInTownBlocks))
-					continue;
-
-				//Update towny-influence map
-				nation = TownOccupationController.isTownOccupied(town) ? TownOccupationController.getTownOccupier(town) : town.getNation();
-				if(result.containsKey(nation)) {
-					result.put(nation, result.get(nation) + town.getTownBlocks().size());
-				} else {
-					result.put(nation, town.getTownBlocks().size());
-				}
-			} catch (Exception e) {
-				try {
-					SiegeWar.severe("Problem evaluating towny-influence map generation for town: " + targetTown.getName());
-				} catch (Exception e2) {
-					SiegeWar.severe("Problem evaluating towny-influence map generation for town (could not read town name)");
-				}
-				e.printStackTrace();
-			}
-		}
-		//Sort result, highest result first
-		result = sortTownyInfluenceMap(result);
-		//Return result
-		return result;
-    }
-
-	/**
-	 * Sort the influence map in descending order, so that the nation with the highest value,
-	 * is first in the map.
-	 *
-	 * @param unsortedTownyInfluenceMap the given unsorted map
-	 * @return sorted towny-influence map
-	 */
-	private static Map<Nation,Integer> sortTownyInfluenceMap(Map<Nation,Integer> unsortedTownyInfluenceMap) {
-		// Now, getting all entries from map and
-        // convert it to a list using entrySet() method
-        List<Map.Entry<Nation, Integer>> list = new ArrayList<>(unsortedTownyInfluenceMap.entrySet());
-
-        // Using collections class sort method
-        // and inside which we are using
-        // custom comparator to compare value of map
-        Collections.sort(
-            list,
-            new Comparator<Map.Entry<Nation, Integer> >() {
-                // Comparing two entries by value
-                public int compare(
-                    Map.Entry<Nation, Integer> entry1,
-                    Map.Entry<Nation, Integer> entry2)
-                {
-                    // Subtracting the entries
-                    return entry2.getValue()
-                        - entry1.getValue();
-                }
-            });
-
-		// Iterating over the sorted map
-		// using the for each method
-		Map<Nation, Integer> result = new LinkedHashMap<>();
-		for (Map.Entry<Nation, Integer> mapEntry : list) {
-			result.put(mapEntry.getKey(), mapEntry.getValue());
-		}
-
-		return result;
-	}
-
 	public static void toggleTownPeacefulness(Player player) {
 		Translator translator = Translator.locale(player);
 		if (!SiegeWarSettings.getWarSiegeEnabled()) {
@@ -260,4 +150,32 @@ public class SiegeWarTownPeacefulnessUtil {
 		//Save data
 		town.save();
 	}
+
+	/**
+	 * Calculate the guardian town of a given peaceful town
+	 * 
+	 * @param peacefulTown given peaceful town
+	 * @return guardian town
+	 */
+	public static @Nullable Town calculateGuardianTown(Town peacefulTown) {
+		if(!peacefulTown.hasHomeBlock())  //The peaceful town can't have a guardian town if it has no homeblock
+			return null;
+		Town guardianTown = null;
+		int winningNumTownBlocks = 0;
+		for(Town candidateGuardianTown: TownyAPI.getInstance().getTowns()) {
+			//Search all towns to find the guardian town
+			if (!candidateGuardianTown.isRuined()
+					&& candidateGuardianTown.hasHomeBlock()
+					&& !SiegeWarTownPeacefulnessUtil.isTownPeaceful(candidateGuardianTown)
+					&& !SiegeController.hasActiveSiege(candidateGuardianTown)
+					&& SiegeWarDistanceUtil.areTownsClose(peacefulTown, candidateGuardianTown, SiegeWarSettings.getPeacefulTownsGuardianTownSearchRadius())
+					&& candidateGuardianTown.getNumTownBlocks() > winningNumTownBlocks) {
+				//New winning candidate found 
+				guardianTown = candidateGuardianTown;
+				winningNumTownBlocks = candidateGuardianTown.getNumTownBlocks();
+			}
+		}
+		return guardianTown;
+	}
+
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
@@ -14,6 +14,7 @@ import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.Translatable;
+import com.palmergames.bukkit.towny.object.Translation;
 import com.palmergames.bukkit.towny.object.Translator;
 import com.palmergames.util.TimeMgmt;
 import org.bukkit.entity.Player;
@@ -205,6 +206,7 @@ public class SiegeWarTownPeacefulnessUtil {
 					&& TownOccupationController.isTownOccupied(peacefulTown)
 					&& peacefulTown.getNationOrNull() == nationOfTownMovingHomeBlock) {
 				TownOccupationController.removeTownOccupation(peacefulTown);
+				TownyMessaging.sendPrefixedNationMessage(nationOfTownMovingHomeBlock, Translation.of("msg_nation_town_left", peacefulTown.getName()));
 				numPeacefulTownsReleased++;
 			}
 		}

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -504,7 +504,7 @@ sg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their 
 msg_err_peaceful_towns_cannot_revolt: '&cPeaceful towns cannot revolt.'
 msg_err_capital_towns_cannot_go_peaceful: '&cCapital towns cannot go peaceful.'
 msg_err_cannot_subvert_not_enough_permissions: "&cYou do not have enough permissions to subvert the town."
-msg_err_cannot_subvert_dont_own_guardian_town: "&cYou cannot subvert this peaceful town, because your nation does not own the required Guardian Town. The Guardian Town is: %s."
+msg_err_cannot_subvert_dont_own_guardian_town: "&cSubvert not possible, because your nation does not own the required Guardian Town: %s."
 
 # Town neutrality
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -349,11 +349,6 @@ hover_message_click_to_claim: "Click to claim money owed to you."
 #Added in 0.31
 msg_next_session_cannot_be_determined: "The next Siege Session has not been scheduled. Try again later."
 
-#Added in 0.32
-msg_err_cannot_subvert_towns_in_own_nation: "&cYou cannot subvert towns which are in your own nation."
-msg_err_cannot_subvert_town_zero_influence: "&cYou cannot subvert this town, because your nation has no Towny-Influence in the local area."
-msg_err_cannot_subvert_town_insufficient_influence: "&cYou cannot subvert this town, because %s has more Towny-Influence in the local area (%d), than your nation (%d)."
-
 #Added in 0.33
 nation_help_11 : 'Collect any income due to you from military salary.'
 msg_err_siege_war_collect_unavailable: "There is nothing for you to collect."
@@ -508,6 +503,7 @@ sg_err_peaceful_town_cannot_move_homeblock: "&cPeaceful towns cannot move their 
 msg_err_peaceful_towns_cannot_revolt: '&cPeaceful towns cannot revolt.'
 msg_err_capital_towns_cannot_go_peaceful: '&cCapital towns cannot go peaceful.'
 msg_err_cannot_subvert_not_enough_permissions: "&cYou do not have enough permissions to subvert the town."
+msg_err_cannot_subvert_dont_own_guardian_town: "&cYou cannot subvert this peaceful town, because your nation does not own the required Guardian Town. The Guardian Town is: %s."
 
 # Town neutrality
 

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -505,6 +505,7 @@ msg_err_peaceful_towns_cannot_revolt: '&cPeaceful towns cannot revolt.'
 msg_err_capital_towns_cannot_go_peaceful: '&cCapital towns cannot go peaceful.'
 msg_err_cannot_subvert_not_enough_permissions: "&cYou do not have enough permissions to subvert the town."
 msg_err_cannot_subvert_dont_own_guardian_town: "&cSubvert not possible, because your nation does not own the required Guardian Town: %s."
+msg_peaceful_towns_released_on_homeblock_move: "&bBecause %s moved its homeblock, %d peaceful town(s) which it was guarding, were released from occupation."
 
 # Town neutrality
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- It has been accepted for a while that the current peaceful-town-capture system is too complicated
- This PR returns the system to something closer to the 0.1.0 version

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```
	PEACEFUL_TOWNS_GUARDIAN_TOWN_SEARCH_RADIUS(
			"peaceful_towns.guardian_town_search_radius",
			"1200",
			"",
			"# Given any peaceful town, the largest-by-townblock, non-peaceful, non-sieged town, in this radius around the homeblock, is considered to be the guardian town.",
			"# If a nation owns the guardian town, that nation can instantly subvert & occupy the peaceful town"),
```

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #617 

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
