### PR TITLE
Staggered siege endings

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
@@ -22,35 +22,45 @@ public class SiegeWarTimerTaskController {
 	/**
 	 * Evaluate timed siege outcomes
 	 * e.g. who wins if siege victory timer runs out ?
+	 * 
+	 * A maximum of 1 siege will be ended when this method is called.
 	 */
 	public static void evaluateTimedSiegeOutcomes() {
 		for (Siege siege : SiegeController.getSieges()) {
-			evaluateTimedSiegeOutcome(siege);
+			if(evaluateTimedSiegeOutcome(siege))
+				return;
 		}
 	}
 
 	/**
 	 * Evaluate the timed outcome of 1 siege
 	 *
-	 * @param siege
+	 * @param siege the siege
+	 * @return true if the siege was ended by this method call      	   	
 	 */
-	private static void evaluateTimedSiegeOutcome(Siege siege) {
+	private static boolean evaluateTimedSiegeOutcome(Siege siege) {
 		switch(siege.getStatus()) {
 			case IN_PROGRESS:
 				//If last battle session has been completed, end siege and choose winner
-				if (siege.getNumBattleSessionsCompleted() >= SiegeWarSettings.getSiegeDurationBattleSessions())
+				if (siege.getNumBattleSessionsCompleted() >= SiegeWarSettings.getSiegeDurationBattleSessions()) {
 					SiegeController.endSiegeWithTimedWin(siege);
-				break;
+					return true;
+				} else
+					return false;
 
 			case PENDING_DEFENDER_SURRENDER:
-				if (siege.getNumBattleSessionsCompleted() >= SiegeWarSettings.getSiegeDurationBattleSessions())
+				if (siege.getNumBattleSessionsCompleted() >= SiegeWarSettings.getSiegeDurationBattleSessions()) {
 					SurrenderDefence.surrenderDefence(siege);
-				break;
+					return true;
+				} else 
+					return false;
 
 			case PENDING_ATTACKER_ABANDON:
-				if (siege.getNumBattleSessionsCompleted() >= SiegeWarSettings.getSiegeDurationBattleSessions())
+				if (siege.getNumBattleSessionsCompleted() >= SiegeWarSettings.getSiegeDurationBattleSessions()) {
 					AbandonAttack.abandonAttack(siege);
-				break;
+					return true;
+				} else 
+					return false;
 
 			default:
 				//Siege is inactive i.e. in the 'aftermath' phase
@@ -58,6 +68,7 @@ public class SiegeWarTimerTaskController {
 				if (System.currentTimeMillis() > TownMetaDataController.getSiegeImmunityEndTime(siege.getTown())) {
 					SiegeController.removeSiege(siege);
 				}
+				return false;
 		}
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/tasks/SiegeWarTimerTaskController.java
@@ -41,7 +41,7 @@ public class SiegeWarTimerTaskController {
 	private static boolean evaluateTimedSiegeOutcome(Siege siege) {
 		switch(siege.getStatus()) {
 			case IN_PROGRESS:
-				//If last battle session has been completed, end siege and choose winner
+				//If last battle session of the siege has been completed, end siege and choose winner
 				if (siege.getNumBattleSessionsCompleted() >= SiegeWarSettings.getSiegeDurationBattleSessions()) {
 					SiegeController.endSiegeWithTimedWin(siege);
 					return true;


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- With current code and default settings,  every siege ends at the same time .... after the last battle session of the week, thus severely spamming the console if there are many sieges.
- This PR resolves the issue by staggering the siege endings.  Now there will be at most one siege ending every 20 seconds.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
