### PR TITLE
Fixed revolt prevention bug

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -221,22 +221,30 @@ public class PlaceBlock {
 			throw new TownyException(Translatable.of("msg_err_this_town_is_not_allowed_to_be_attacked"));
 		
 		if(SiegeWarTownPeacefulnessUtil.isTownPeaceful(nearbyTown)) {
-			//Town is peaceful, so this action is a subversion or peaceful-revolt attempt
+			//Town is peaceful
 			if(residentsTown == nearbyTown) {
+				//This is the banner planter's town. This is an attempted revolt
 				if(TownOccupationController.isTownOccupied(residentsTown)) {
 					throw new TownyException(Translatable.of("peaceful_towns_cannot_revolt"));
 				}
 			} else {
+				//This is not the banner planter's town. This is an attempted subversion
 				PeacefullySubvertTown.processActionRequest(player, residentsNation, nearbyTown);
 			}
 		} else {
-			//Town is not peaceful, so this action is a start-siege or invade-town request
-			if (SiegeController.hasSiege(nearbyTown)) {
-				//If there is a siege, it is an attempt to invade the town
-				InvadeTown.processInvadeTownRequest(player, residentsNation, nearbyTown, SiegeController.getSiege(nearbyTown));
-			} else {
-				//If there is no siege, it is an attempt to start a new siege
+			//Town is not peaceful
+			if (residentsTown == nearbyTown) {
+				//This is the banner planter's town. This is an attempted revolt
 				evaluateStartNewSiegeAttempt(player, residentsTown, residentsNation, nearbyTownBlock, nearbyTown, bannerBlock);
+			} else {
+				//This is not the banner planter's town
+				if(SiegeController.hasSiege(nearbyTown)) {
+					//Town has siege. This is an attempted invasion
+					InvadeTown.processInvadeTownRequest(player, residentsNation, nearbyTown, SiegeController.getSiege(nearbyTown));
+				} else {
+					//Town has no siege. This is an attempted siege start
+					evaluateStartNewSiegeAttempt(player, residentsTown, residentsNation, nearbyTownBlock, nearbyTown, bannerBlock);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerTimedWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerTimedWin.java
@@ -43,8 +43,8 @@ public class AttackerTimedWin {
             case REVOLT:
                 message = Translatable.of(key,
                         siege.getTown().getName(),
-                        siege.getAttacker().getName());
-                        siege.getStatus().getTimedVictoryTypeText();
+                        siege.getAttacker().getName(),
+                        siege.getStatus().getTimedVictoryTypeText());
                 break;
         }
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
@@ -275,10 +275,12 @@ public class SiegeWarMoneyUtil {
 	 */
 	public static void throwIfTownCannotAffordToStartSiege(Town town) throws TownyException {
 		double cost = calculateUpfrontSiegeStartCost(town);
-		if (!TownyEconomyHandler.isActive())
-			return; //Siege cost does not apply
-		if (!town.getAccount().canPayFromHoldings(cost))
-			throw new TownyException(Translatable.of("msg_err_your_town_cannot_afford_to_siege_for_x", TownyEconomyHandler.getFormattedBalance(cost)));
+		if(cost > 0) {
+			if (!TownyEconomyHandler.isActive())
+				return; //Siege cost does not apply
+			if (!town.getAccount().canPayFromHoldings(cost))
+				throw new TownyException(Translatable.of("msg_err_your_town_cannot_afford_to_siege_for_x", TownyEconomyHandler.getFormattedBalance(cost)));
+		}
 	}
 
 	public static void payDailyPlunderDebt() {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
 - With current code, it is not possible for a revolt to break through siege immunity
 - This PR fixes the issue
 - It also adds a minor optimization around upfront-siege-cost
 - Also fixes a small messaging bug

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
