### PR TITLE
Fixed nation plunder stats

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -96,14 +96,21 @@ public class SiegeWarStatusScreenListener implements Listener {
 			}
 			
 			//[War History]
-			// Towny Captured ...
-			// Towns Plundered ...
+			// Towns Captured / Lost ...
+			// Plunder Gained ...
 			if(SiegeWarSettings.getWarSiegeNationStatisticsEnabled()) {
 				//Create the text inside the hover item
 				Component hoverText = Component.empty();
 				hoverText = hoverText.append(Component.text(translator.of("status_nation_town_stats", NationMetaDataController.getTotalTownsGained(nation), NationMetaDataController.getTotalTownsLost(nation))));
 				hoverText = hoverText.append(Component.newline());
-				hoverText = hoverText.append(Component.text(translator.of("status_nation_plunder_stats", NationMetaDataController.getTotalPlunderGained(nation), NationMetaDataController.getTotalPlunderLost(nation))));
+
+				/*
+				 * There is a problem in SW2.0.0 with recording plunder lost:
+				 * 1. Unlike in the previous occupation system, when you capture a town, all traces of the previous owner are removed.
+				 * 2. Thus if a winning besieger invades first before plundering ... the system has no knowledge of the previous nation, to record the plunderLost stat.
+				 * 3. I suggest this fix be part of a wider scheme to upgrade the feature .... e.g. add siege victories, defeats, type of sieges, types of victory etc. 
+				 */
+				hoverText = hoverText.append(Component.text(translator.of("status_nation_plunder_stats", NationMetaDataController.getTotalPlunderGained(nation))));
 				//Add the hover item to the screen
 				event.getStatusScreen().addComponentOf("siegeWar_warHistoryHover",
 						Component.empty()

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -281,7 +281,7 @@ msg_err_siege_war_plunder_not_possible_rebels_won: '&cPlunder not possible becau
 
 #Nation war history
 status_nation_town_stats: '&2Captures Foreign/Home: &a%d&2/&a%d'
-status_nation_plunder_stats: '&2Plunder Gains/Losses: &a%d&2/&a%d'
+status_nation_plunder_stats: '&2Plunder Gains: &a%d'
 
 #Siege effects
 msg_err_siege_war_cannot_spawn_into_siegezone_or_besieged_town: '&cOnly town residents can spawn into a besieged town or siege zone.'


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- With current code, there is a problem with recording plunder lost:
  - Unlike in the previous occupation system, when you capture a town, all traces of the previous owner are removed.
  - Thus if a winning besieger invades first before plundering ... the system has no knowledge of the previous nation, to record the national plunderLost stat.
  - This PR fixes the problem in the safest way possible, by simply removing the display of the plunderlost stat
- In future, perhaps in SW 2.1.0, this can be fixed, probably required adding to the siege object metadata scheme. Something which I am averse to doing in SW 2.0.0 as the feature is not critical, the fix is not trivial, and I'm already in the middle of regression testing.
- The fix could potentially be part of wider upgrade of the feature too - to add siege victories, siege losses, types of sieges, types of victories, players killed in sieges etc.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
