### PR TITLE
Fixed max attacks per nation

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -403,6 +403,17 @@ public class SiegeController {
 		return result;
 	}
 
+	public static int getNumActiveConquestAttackSieges(Nation nation) {
+		int result = 0;
+		Map<Siege, Town> activeOffensiveSieges = getActiveOffensiveSieges(nation);
+		for(Map.Entry<Siege,Town> mapEntry: activeOffensiveSieges.entrySet()) {
+			if(mapEntry.getKey().getSiegeType() == SiegeType.CONQUEST) {
+				result ++;
+			}
+		}
+		return result;
+	}
+
 	public static Map<Siege, Town> getActiveDefensiveSieges(Nation nation) {
 		Map<Siege, Town> result = new HashMap<>();
 		for(Siege siege : SiegeController.getSieges()) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -235,7 +235,7 @@ public enum ConfigNodes {
 		"war.siege.quantities.max_active_siege_attacks_per_nation",
 		"3",
 		"",
-			"# The value specifies the maximum number of active attack sieges allowed per nation." +
+			"# The value specifies the maximum number of active conquest-attack sieges allowed per nation." +
 			"# A low setting will generally reduce the aggression level on the server.",
 			"# A low setting will also rebalance the system in favour of smaller nations.",
 		 	"# This is because it will prevent larger nations from conducting as many sieges as their resources would otherwise allow."),

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -134,7 +134,7 @@ public class SiegeWarSettings {
 	}
 
 	public static boolean doesThisNationHaveTooManyActiveSieges(Nation nation) {
-		return SiegeController.getActiveOffensiveSieges(nation).size() >= getWarSiegeMaxActiveSiegeAttacksPerNation();
+		return SiegeController.getNumActiveConquestAttackSieges(nation) >= getWarSiegeMaxActiveSiegeAttacksPerNation();
 	}
 
 	public static boolean getWarCommonPeacefulTownsEnabled() {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- With current code, revolt sieges started against a nation are counted in their "max attacks"
- This should not be the case. Only conquest sieges started by a nation should count
- This PR fixes the issue

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [N/A too trivial ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
