### PR TITLE
Add Chat-Restriction feature to reduce toxicity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -42,6 +42,7 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.object.TranslationLoader;
 import com.palmergames.util.StringMgmt;
+import com.palmergames.util.TimeMgmt;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -344,7 +345,7 @@ public class SiegeWarTownyEventListener implements Listener {
     /**
      * If toxicity reduction is enabled, the following effects apply:
      * 1. No local chat in Siege Zones
-     * 2. No general chat if a BattleSession is in progress
+     * 2. No general chat if a BattleSession is in progress (and for 10 mins after)
      * 
      * @param asyncChatHookEvent the TownyChat event
      */
@@ -361,9 +362,14 @@ public class SiegeWarTownyEventListener implements Listener {
                 Messaging.sendErrorMsg(asyncChatHookEvent.getPlayer(), Translatable.of("msg_err_no_local_chat_in_siege_zones"));
             }
         } else if (channelName.equalsIgnoreCase("general")) {
-            if(BattleSession.getBattleSession().isActive()) {
+            if(BattleSession.getBattleSession().isGeneralChatDisabled()) {
                 asyncChatHookEvent.setCancelled(true);
-                Messaging.sendErrorMsg(asyncChatHookEvent.getPlayer(), Translatable.of("msg_err_no_general_chat_in_battle_session"));
+                String formattedDisableTime = TimeMgmt.getFormattedTimeValue(SiegeWarSettings.getToxicityReductionGeneralChatRestorationAfterBattleSessionMillis());
+                Translatable message = Translatable.of("msg_err_no_general_chat_in_battle_session", formattedDisableTime);
+                String discordLink = SiegeWarSettings.getToxicityReductionServerDiscordLink();
+                if(!discordLink.isEmpty())
+                    message.append(Translatable.of("msg_can_also_chat_in_discord", discordLink));
+                Messaging.sendErrorMsg(asyncChatHookEvent.getPlayer(), message);
             }
         }
     }

--- a/src/main/java/com/gmail/goosius/siegewar/objects/BattleSession.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/BattleSession.java
@@ -37,11 +37,15 @@ public class BattleSession {
 	private long scheduledEndTime;	//The time this battle session is scheduled to end
 	private Long scheduledStartTime;  //The time this battle session is scheduled to start
 	private long startTime;			//The time the session actually started
+	private boolean generalChatDisabled;
+	private long scheduledGeneralChatRestorationTime;
 
 	public BattleSession() {
 		active = false;
 		scheduledEndTime = 0;
 		scheduledStartTime = null;
+		generalChatDisabled = false;
+		scheduledGeneralChatRestorationTime = 0;
 	}
 
 	//Singleton
@@ -97,4 +101,21 @@ public class BattleSession {
 	public void setStartTime(long startTime) {
 		this.startTime = startTime;
 	}
+
+	public boolean isGeneralChatDisabled() {
+		return generalChatDisabled;
+	}
+
+	public void setGeneralChatDisabled(boolean generalChatDisabled) {
+		this.generalChatDisabled = generalChatDisabled;
+	}
+
+	public long getScheduledGeneralChatRestorationTime() {
+		return scheduledGeneralChatRestorationTime;
+	}
+
+	public void setScheduledGeneralChatRestorationTime(double scheduledGeneralChatRestorationTime) {
+		this.scheduledGeneralChatRestorationTime = (long)scheduledGeneralChatRestorationTime;
+	}
+
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -935,7 +935,28 @@ public enum ConfigNodes {
 			"7",
 			"",
 			"# this value determines the duration of the starting-siege-balance-penalty.",
-			"# If another such defeat occurs, the the duration is refreshed.");
+			"# If another such defeat occurs, the the duration is refreshed."),
+	TOXICITY_REDUCTION(
+			"toxicity_reduction",
+			"",
+			"",
+			"",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |                  TOXICITY REDUCTION                  | #",
+			"# +------------------------------------------------------+ #",
+			"############################################################",
+			""),
+	TOXICITY_REDUCTION_ENABLED(
+			"toxicity_reduction.enabled",
+			"true",
+			"",
+			"# If this value is true, the following chat effects apply:",
+			"# 1. Local Chat is not possible in Siege-Zones.",
+			"# 2. Global Chat is not possible during Battle Sessions (and for 10 mins after).",
+			"# TIP 1: This feature reduces aggression and toxicity among siege participants.",
+			"# TIP 2: This feature but also saves the rest of the server from being spammed with mid-siege smack-talk.");
+
 	private final String Root;
 	private final String Default;
 	private String[] comments;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -953,9 +953,21 @@ public enum ConfigNodes {
 			"",
 			"# If this value is true, the following chat effects apply:",
 			"# 1. Local Chat is not possible in Siege-Zones.",
-			"# 2. Global Chat is not possible during Battle Sessions (and for 10 mins after).",
+			"# 2. General Chat is not possible during Battle Sessions (and for 10 mins after).",
 			"# TIP 1: This feature reduces aggression and toxicity among siege participants.",
-			"# TIP 2: This feature but also saves the rest of the server from being spammed with mid-siege smack-talk.");
+			"# TIP 2: This feature also helps save the rest of the server from being spammed with siege-related smack-talk."),
+	TOXICITY_REDUCTION_GENERAL_CHAT_RESTORATION_AFTER_BATTLE_SESSION_MINUTES(
+			"toxicity_reduction.general_chat_restoration_after_battle_session_minutes",
+			"10",
+			"",
+			"# This value determines when the general chat will be restored after each battle session.",
+			"# The default value is 10."),
+	TOXICITY_REDUCTION_DISCORD_LINK(
+			"toxicity_reduction.discord_link",
+			"",
+			"",
+			"# If this value is not blank,",
+			"# Then players attempting general chat during battle sessions, will be directed towards the server discord.");
 
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -11,6 +11,7 @@ import java.time.LocalTime;
 
 import com.gmail.goosius.siegewar.SiegeController;
 import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.util.TimeMgmt;
 import org.bukkit.Material;
 
 import org.bukkit.entity.EntityType;
@@ -512,5 +513,18 @@ public class SiegeWarSettings {
 
 	public static boolean isToxicityReductionEnabled() {
 		return Settings.getBoolean(ConfigNodes.TOXICITY_REDUCTION_ENABLED);
+	}
+
+	public static double getToxicityReductionGeneralChatRestorationAfterBattleSessionMinutes() {
+		return Settings.getDouble(ConfigNodes.TOXICITY_REDUCTION_GENERAL_CHAT_RESTORATION_AFTER_BATTLE_SESSION_MINUTES);
+	}
+
+	//Convenience Method
+	public static double getToxicityReductionGeneralChatRestorationAfterBattleSessionMillis() {
+		return getToxicityReductionGeneralChatRestorationAfterBattleSessionMinutes() * TimeMgmt.ONE_MINUTE_IN_MILLIS;
+	}
+
+	public static String getToxicityReductionServerDiscordLink() {
+		return Settings.getString(ConfigNodes.TOXICITY_REDUCTION_DISCORD_LINK);
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -509,4 +509,8 @@ public class SiegeWarSettings {
 	public static int getSpecialVictoryEffectsSiegeBalancePenaltyDurationDays() {
 		return Settings.getInt(ConfigNodes.SPECIAL_VICTORY_EFFECTS_SIEGE_BALANCE_PENALTY_DURATION_DAYS);
 	}
+
+	public static boolean isToxicityReductionEnabled() {
+		return Settings.getBoolean(ConfigNodes.TOXICITY_REDUCTION_ENABLED);
+	}
 }

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -619,3 +619,7 @@ msg_revolt_siege_attacker_close_win_plunder_reduced: "&bBecause the recent siege
 
 msg_revolt_siege_defender_decisive_win_demoralization: "&bThe former occupying nation, %s, reels from the decisive loss of its colony, and is demoralized (%d siege-balance to conquest sieges it initiates), for %d days."
 
+#Toxicity Reduction
+
+msg_err_no_local_chat_in_siege_zones: "&cYou cannot use Local Chat in Siege Zones."
+msg_err_no_general_chat_in_battle_session: "&cYou cannot use General Chat while a Battle Session is active."

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -621,5 +621,8 @@ msg_revolt_siege_defender_decisive_win_demoralization: "&bThe former occupying n
 
 #Toxicity Reduction
 
-msg_err_no_local_chat_in_siege_zones: "&cYou cannot use Local Chat in Siege Zones."
-msg_err_no_general_chat_in_battle_session: "&cYou cannot use General Chat while a Battle Session is active."
+msg_general_chat_now_disabled: " General Chat will be disabled while the Battle Session is active, and for %s after it ends."
+msg_general_chat_now_restored: "&bGeneral Chat has been restored."
+msg_err_no_local_chat_in_siege_zones: "&cLocal Chat is disabled in Siege Zones."
+msg_err_no_general_chat_in_battle_session: "&cGeneral Chat is disabled while a Battle Session is active, and for %s after it ends. Try chatting using /tc, /nc, or /ac."
+msg_can_also_chat_in_discord: " You can also chat in the server discord: %s."


### PR DESCRIPTION
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- For some time I've been impressed with how World-of-Warcraft handles warring player factions ..... i.e. the factions (horde, allience), cannot even speak to each other in-game.
  - This feature naturally reduces toxicity, since a primary source of toxicity (enemies smack talking each other in battle) is completely removed.
- This PR adds a flavour of this to SiegeWar:
  - In keeping with the SW2.0.0 ethos this feature is very simple:
    - In SiegeZones, local chat is not possible
    - During Battle Sessions, and for 10 mins after, global chat is not possible
  - Notes:
    - Naturally players may try to find a way around this. In particular, some may try to mouth-off on the server discord. However I expect this workaround will not be reduce much the impact of this feature, because:
      - While fighting, player's will need to concentrate on the game screen, and so will naturally be discouraged from extensive discording.
      - Discord server chat is generally easier to moderate than in-game chat, as the interface is friendlier, the rules are more easily accessible, moderators don't have to log into the game to stop a player talking, and players can be banned on discord without being banned in-game.
 
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```
############################################################
# +------------------------------------------------------+ #
# |                  TOXICITY REDUCTION                  | #
# +------------------------------------------------------+ #
############################################################
  
toxicity_reduction:
  
  # If this value is true, the following chat effects apply:
  # 1. Local Chat is not possible in Siege-Zones.
  # 2. General Chat is not possible during Battle Sessions (and for 10 mins after).
  # TIP 1: This feature reduces aggression and toxicity among siege participants.
  # TIP 2: This feature but also saves the rest of the server from being spammed with mid-siege smack-talk.
  enabled: 'true'
  
  # This value determines when the general chat will be restored after each battle session.
  # The default value is 10.
  general_chat_restoration_after_battle_session_minutes: '10'
  
  # If this value is not blank,
  # Then players attempting general chat during battle sessions, will be directed towards the server discord.
  discord_link:
```

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
