### PR TITLE
Add 'Bad-Config Warning' for High/Low plunder

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -87,7 +87,7 @@ public class SiegeWar extends JavaPlugin {
 		SiegeWarMoneyUtil.calculateEstimatedTotalMoneyInEconomy(siegeWarPluginError);
 
 		if(SiegeWarSettings.isBadConfigWarningsEnabled()) {
-			SiegeWarWarningsUtil.sendBadConfigsWarnings(Bukkit.getConsoleSender());
+			SiegeWarWarningsUtil.sendWarningsIfConfigsBad(Bukkit.getConsoleSender());
 		}
 		if(siegeWarPluginError) {
 			severe("SiegeWar did not load successfully, and is now in safe mode!");

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -4,6 +4,8 @@ import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.DataCleanupUtil;
 
 import com.gmail.goosius.siegewar.utils.PermsCleanupUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarMoneyUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarWarningsUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -82,6 +84,11 @@ public class SiegeWar extends JavaPlugin {
 		DataCleanupUtil.cleanupData(siegeWarPluginError, listenersRegistered);
 		PermsCleanupUtil.cleanupPerms(siegeWarPluginError);
 
+		SiegeWarMoneyUtil.calculateEstimatedTotalMoneyInEconomy(siegeWarPluginError);
+
+		if(SiegeWarSettings.isBadConfigWarningsEnabled()) {
+			SiegeWarWarningsUtil.sendBadConfigsWarnings(Bukkit.getConsoleSender());
+		}
 		if(siegeWarPluginError) {
 			severe("SiegeWar did not load successfully, and is now in safe mode!");
 		} else {

--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeWarPermissionNodes.java
@@ -47,7 +47,8 @@ public enum SiegeWarPermissionNodes {
 		SIEGEWAR_COMMAND_SIEGEWARADMIN_SIEGE("siegewar.command.siegewaradmin.siege"),
 		SIEGEWAR_COMMAND_SIEGEWARADMIN_NATION("siegewar.command.siegewaradmin.nation"),
 		SIEGEWAR_COMMAND_SIEGEWARADMIN_INSTALLPERMS("siegewar.command.siegewaradmin.installperms"),
-		SIEGEWAR_COMMAND_SIEGEWARADMIN_BATTLESESSION("siegewar.command.siegewaradmin.battlesession");
+		SIEGEWAR_COMMAND_SIEGEWARADMIN_BATTLESESSION("siegewar.command.siegewaradmin.battlesession"),
+		SIEGEWAR_COMMAND_SIEGEWARADMIN_BADCONFIGWARNINGS("siegewar.command.siegewaradmin.badconfigwarnings");
 
 	private String value;
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -2,7 +2,6 @@ package com.gmail.goosius.siegewar.listeners;
 
 import java.util.List;
 
-import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.utils.DataCleanupUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarNotificationUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarWarningsUtil;
@@ -217,7 +216,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 
 			//Warn player if there are dodgy configs
 			if(SiegeWarSettings.isBadConfigWarningsEnabled()) {
-				SiegeWarWarningsUtil.sendBadConfigsWarnings(event.getPlayer());
+				SiegeWarWarningsUtil.sendWarningsIfConfigsBad(event.getPlayer());
 			}
 		}
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -2,8 +2,10 @@ package com.gmail.goosius.siegewar.listeners;
 
 import java.util.List;
 
+import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.utils.DataCleanupUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarNotificationUtil;
+import com.gmail.goosius.siegewar.utils.SiegeWarWarningsUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -211,6 +213,11 @@ public class SiegeWarBukkitEventListener implements Listener {
 				 * Thus, this line will always trigger a warning message.
 				 */
 				SiegeWarNotificationUtil.sendSiegeZoneProximityWarning(event.getPlayer(), activeSiegeAtPlayerLocation);
+			}
+
+			//Warn player if there are dodgy configs
+			if(SiegeWarSettings.isBadConfigWarningsEnabled()) {
+				SiegeWarWarningsUtil.sendBadConfigsWarnings(event.getPlayer());
 			}
 		}
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -116,6 +116,7 @@ public class SiegeWarTownyEventListener implements Listener {
                 TownOccupationController.collectNationOccupationTax();
             }
             SiegeWarNationUtil.updateNationDemoralizationCounters();
+            SiegeWarMoneyUtil.calculateEstimatedTotalMoneyInEconomy(false);
         }
     }
 

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -986,8 +986,8 @@ public enum ConfigNodes {
 			"# If this value is true, then whenever the server starts, or whenever a SiegeWarAdmin logs in,",
 			"# a warning will be displayed if any important configs are set badly."),
 	BAD_CONFIG_WARNINGS_TOLERANCE_PERCENTAGE(
-		"bad_config_warnings.tolerance_percentage",
-			"5",
+			"bad_config_warnings.tolerance_percentage",
+			"5.0",
 			"",
 			"# This setting determines the tolerance of the bad-config-warnings.",
 			"# Example: If the 'ideal plunder rate' is set to 10%....then if the actual plunder config works out at below 5% or over 15%, a warning will be given."),

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -997,7 +997,7 @@ public enum ConfigNodes {
 			"",
 			"# This value determines the ideal configured plunder value.",
 			"# Example: If the ideal percentage is 10%, then on plunder, we want to take 10% of the estimated town value.",
-			"# NOTE: The estimated town value is calculated by summing all the money in the economy, dividing by total-num-townblocks, then multiplying by num-townblocks in the town.",
+			"# NOTE: The estimated town value is calculated by estimating all the money in the economy, dividing by total-num-townblocks on the server, then multiplying by num-townblocks in the town.",
 			"# The default value for this config is 15.0"),
 	BAD_CONFIG_WARNINGS_IDEAL_WARCHEST_PERCENTAGE(
 			"bad_config_warnings.ideal_warchest_percentage",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -1019,6 +1019,7 @@ public enum ConfigNodes {
 			"",
 			"# This value determines the ideal configured occupation-tax value.",
 			"# Example: If the ideal percentage is 0.25, then on each new day, we want to take 0.25% of the estimated town value.",
+			"# TIP: Generally you want to keep this low enough so that fake sieges for immunity purposes are not worthwhile.",
 			"# The default value is 0.375");
 	private final String Root;
 	private final String Default;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -967,8 +967,59 @@ public enum ConfigNodes {
 			"",
 			"",
 			"# If this value is not blank,",
-			"# Then players attempting general chat during battle sessions, will be directed towards the server discord.");
-
+			"# Then players attempting general chat during battle sessions, will be directed towards the server discord."),
+	BAD_CONFIG_WARNINGS(
+			"bad_config_warnings",
+			"",
+			"",
+			"",
+			"############################################################",
+			"# +------------------------------------------------------+ #",
+			"# |                 BAD CONFIG WARNINGS                  | #",
+			"# +------------------------------------------------------+ #",
+			"############################################################",
+			""),
+	BAD_CONFIG_WARNINGS_ENABLED(
+			"bad_config_warnings.enabled",
+			"true",
+			"",
+			"# If this value is true, then whenever the server starts, or whenever a SiegeWarAdmin logs in,",
+			"# a warning will be displayed if any important configs are set badly."),
+	BAD_CONFIG_WARNINGS_TOLERANCE_PERCENTAGE(
+		"bad_config_warnings.tolerance_percentage",
+			"5",
+			"",
+			"# This setting determines the tolerance of the bad-config-warnings.",
+			"# Example: If the 'ideal plunder rate' is set to 10%....then if the actual plunder config works out at below 5% or over 15%, a warning will be given."),
+	BAD_CONFIG_WARNINGS_IDEAL_PLUNDER_PERCENTAGE(
+		"bad_config_warnings.ideal_plunder_percentage",
+			"15.0",
+			"",
+			"# This value determines the ideal configured plunder value.",
+			"# Example: If the ideal percentage is 10%, then on plunder, we want to take 10% of the estimated town value.",
+			"# NOTE: The estimated town value is calculated by summing all the money in the economy, dividing by total-num-townblocks, then multiplying by num-townblocks in the town.",
+			"# The default value for this config is 15.0"),
+	BAD_CONFIG_WARNINGS_IDEAL_WARCHEST_PERCENTAGE(
+			"bad_config_warnings.ideal_warchest_percentage",
+			"7.5",
+			"",
+			"# This value determines the ideal configured warchest value.",
+			"# Example: If the ideal percentage is 5%, then on siege-start, we want to take 5% of the estimated town value.",
+			"# The default value is 7.5"),
+	BAD_CONFIG_WARNINGS_IDEAL_UPFRONTCOST_PERCENTAGE(
+			"bad_config_warnings.ideal_upfrontcost_percentage",
+			"3.75",
+			"",
+			"# This value determines the ideal configured upfront-cost value.",
+			"# Example: If the ideal percentage is 2.5%, then on siege-start, we want to take 2.5% of the estimated town value.",
+			"# The default value is 3.75"),
+	BAD_CONFIG_WARNINGS_IDEAL_OCCUPATIONTAX_PERCENTAGE(
+			"bad_config_warnings.ideal_occupationtax_percentage",
+			"0.375",
+			"",
+			"# This value determines the ideal configured occupation-tax value.",
+			"# Example: If the ideal percentage is 0.25, then on each new day, we want to take 0.25% of the estimated town value.",
+			"# The default value is 0.375");
 	private final String Root;
 	private final String Default;
 	private String[] comments;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -532,10 +532,10 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.BAD_CONFIG_WARNINGS_ENABLED);
 	}
 	public static double getBadConfigWarningsTolerancePercentage() {
-		return Settings.getInt(ConfigNodes.BAD_CONFIG_WARNINGS_TOLERANCE_PERCENTAGE);
+		return Settings.getDouble(ConfigNodes.BAD_CONFIG_WARNINGS_TOLERANCE_PERCENTAGE);
 	}
 	public static double getBadConfigWarningsIdealPlunderPercentage() {
-		return Settings.getInt(ConfigNodes.BAD_CONFIG_WARNINGS_IDEAL_PLUNDER_PERCENTAGE);
+		return Settings.getDouble(ConfigNodes.BAD_CONFIG_WARNINGS_IDEAL_PLUNDER_PERCENTAGE);
 	}
 
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -527,4 +527,15 @@ public class SiegeWarSettings {
 	public static String getToxicityReductionServerDiscordLink() {
 		return Settings.getString(ConfigNodes.TOXICITY_REDUCTION_DISCORD_LINK);
 	}
+
+	public static boolean isBadConfigWarningsEnabled() {
+		return Settings.getBoolean(ConfigNodes.BAD_CONFIG_WARNINGS_ENABLED);
+	}
+	public static double getBadConfigWarningsTolerancePercentage() {
+		return Settings.getInt(ConfigNodes.BAD_CONFIG_WARNINGS_TOLERANCE_PERCENTAGE);
+	}
+	public static double getBadConfigWarningsIdealPlunderPercentage() {
+		return Settings.getInt(ConfigNodes.BAD_CONFIG_WARNINGS_IDEAL_PLUNDER_PERCENTAGE);
+	}
+
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
@@ -23,7 +23,6 @@ import com.palmergames.bukkit.towny.utils.MoneyUtil;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 public class SiegeWarMoneyUtil {
@@ -411,6 +410,16 @@ public class SiegeWarMoneyUtil {
 		}
 	}
 
+	/**
+	 * Calculate the estimated amount of money in the economy.
+	 * 
+	 * The result is stored in this class.
+	 * 
+	 * Result = (All money in town banks + All money in nation banks)
+	 *          +10% (an estimate of how much else residents are carrying)
+	 * 
+	 * @param siegeWarPluginError true if SW is in error.
+	 */
 	public static void calculateEstimatedTotalMoneyInEconomy(boolean siegeWarPluginError) {
 		if(siegeWarPluginError) {
 			SiegeWar.severe("SiegeWar is in safe mode. Money calculation not attempted.");
@@ -429,6 +438,7 @@ public class SiegeWarMoneyUtil {
 		result *= 1.1;
 		//Record result
 		estimatedTotalMoneyInEconomy = result;
+		//Show useful info in console
 		SiegeWar.info("Estimated Total Money In Economy: " + estimatedTotalMoneyInEconomy);
 		SiegeWar.info("Total Number of Townblocks: " + TownyAPI.getInstance().getTownBlocks().size());
 		SiegeWar.info("Estimated Value Per Townblock: " + estimatedTotalMoneyInEconomy / TownyAPI.getInstance().getTownBlocks().size());

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
@@ -1,11 +1,13 @@
 package com.gmail.goosius.siegewar.utils;
 
 import com.gmail.goosius.siegewar.Messaging;
+import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.metadata.ResidentMetaDataController;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyEconomyHandler;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
@@ -21,9 +23,11 @@ import com.palmergames.bukkit.towny.utils.MoneyUtil;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class SiegeWarMoneyUtil {
+	private static double estimatedTotalMoneyInEconomy = -1;
 
 	/**
 	 * Give the war chest to the winner
@@ -407,4 +411,32 @@ public class SiegeWarMoneyUtil {
 		}
 	}
 
+	public static void calculateEstimatedTotalMoneyInEconomy(boolean siegeWarPluginError) {
+		if(siegeWarPluginError) {
+			SiegeWar.severe("SiegeWar is in safe mode. Money calculation not attempted.");
+			return;
+		}
+		double result = 0;
+		//Town Accounts
+		for(Town town: TownyAPI.getInstance().getTowns()) {
+			result += town.getAccount().getHoldingBalance();
+		}
+		//Nation Accounts
+		for(Nation nation: TownyAPI.getInstance().getNations()) {
+			result += nation.getAccount().getHoldingBalance();
+		}
+		//Resident Accounts. Add 10% as an estimate for what residents have
+		result *= 1.1;
+		//Record result
+		estimatedTotalMoneyInEconomy = result;
+		SiegeWar.info("Estimated Total Money In Economy: " + estimatedTotalMoneyInEconomy);
+		SiegeWar.info("Total Number of Townblocks: " + TownyAPI.getInstance().getTownBlocks().size());
+		SiegeWar.info("Estimated Value Per Townblock: " + estimatedTotalMoneyInEconomy / TownyAPI.getInstance().getTownBlocks().size());
+		SiegeWar.info("Ideal / Actual Plunder Value: " + SiegeWarWarningsUtil.calculateIdealPlunderValue() + " / " + SiegeWarSettings.getWarSiegePlunderAmountPerPlot());
+
+	}
+
+	public static double getEstimatedTotalMoneyInEconomy() {
+		return estimatedTotalMoneyInEconomy;
+	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
@@ -20,23 +20,24 @@ import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
 import com.palmergames.bukkit.towny.utils.MoneyUtil;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.Map;
 
 public class SiegeWarMoneyUtil {
-	private static double estimatedTotalMoneyInEconomy = -1;
+	private static double estimatedTotalMoneyInEconomy = 0;
 
 	/**
 	 * Give the war chest to the winner
 	 * Used for a decisive victory
 	 *
-	 * @param siege siege
-	 * @param winningGovernment the (decisively) winning government 	 
+	 * @param siege             siege
+	 * @param winningGovernment the (decisively) winning government
 	 */
 	public static void giveWarChestToWinner(Siege siege, Government winningGovernment) {
-		if(TownyEconomyHandler.isActive()) {
+		if (TownyEconomyHandler.isActive()) {
 			giveWarChestTo(winningGovernment,
 					siege.getWarChestAmount(),
 					"War Chest Captured",
@@ -47,13 +48,13 @@ public class SiegeWarMoneyUtil {
 	/**
 	 * Split the warchest between both given governments
 	 * Used for a close victory
-	 * 
-	 * @param siege siege
+	 *
+	 * @param siege             siege
 	 * @param winningGovernment the (closely) winning government
-	 * @param losingGovernment the (closely) losing government
+	 * @param losingGovernment  the (closely) losing government
 	 */
 	public static void giveWarChestToBoth(Siege siege, Government winningGovernment, Government losingGovernment) {
-		if(TownyEconomyHandler.isActive()) {
+		if (TownyEconomyHandler.isActive()) {
 			//Calculate amounts
 			double amountForLosingGovernment = siege.getWarChestAmount() / 100 * SiegeWarSettings.getSpecialVictoryEffectsWarchestReductionPercentageOnCloseVictory();
 			double amountForWinningGovernment = siege.getWarChestAmount() - amountForLosingGovernment;
@@ -73,22 +74,22 @@ public class SiegeWarMoneyUtil {
 	}
 
 	private static void giveWarChestTo(Government governmentToAward,
-									   double amountToAward, 
+									   double amountToAward,
 									   String depositComment,
 									   String messageTranslationKey) {
 		//Award Amount
 		governmentToAward.getAccount().deposit(amountToAward, depositComment);
-		
+
 		//Create message
 		Translatable message = Translatable.of(messageTranslationKey,
 				governmentToAward.getName(),
 				TownyEconomyHandler.getFormattedBalance(amountToAward));
-		
+
 		//Send message to government that got the money
 		if (governmentToAward instanceof Nation)
-			TownyMessaging.sendPrefixedNationMessage((Nation)governmentToAward, message);
+			TownyMessaging.sendPrefixedNationMessage((Nation) governmentToAward, message);
 		else
-			TownyMessaging.sendPrefixedTownMessage((Town)governmentToAward, message);
+			TownyMessaging.sendPrefixedTownMessage((Town) governmentToAward, message);
 	}
 
 	/**
@@ -100,10 +101,10 @@ public class SiegeWarMoneyUtil {
 	public static double getMoneyMultiplier(Town town) {
 		double extraMoneyPercentage = SiegeWarSettings.getWarSiegeExtraMoneyPercentagePerTownLevel();
 
-		if(extraMoneyPercentage == 0) {
+		if (extraMoneyPercentage == 0) {
 			return 1;
 		} else {
-			return 1 + ((extraMoneyPercentage / 100) * (town.getLevelID() -1));
+			return 1 + ((extraMoneyPercentage / 100) * (town.getLevelID() - 1));
 		}
 	}
 
@@ -112,10 +113,10 @@ public class SiegeWarMoneyUtil {
 	 *
 	 * @param player collecting the military salary
 	 * @return true if payment is made
-	 *         false if payment cannot be made for various reasons.
+	 * false if payment cannot be made for various reasons.
 	 */
 	public static boolean collectMilitarySalary(Player player) throws Exception {
-		if(!SiegeWarSettings.getWarSiegeEnabled() || !SiegeWarSettings.getWarSiegeMilitarySalaryEnabled()) {
+		if (!SiegeWarSettings.getWarSiegeEnabled() || !SiegeWarSettings.getWarSiegeMilitarySalaryEnabled()) {
 			return false;
 		}
 		return collectIncome(player, "Military Salary",
@@ -125,11 +126,11 @@ public class SiegeWarMoneyUtil {
 	/**
 	 * If the player is due an income, pays it to the player
 	 *
-	 * @param player collecting the military salary
-	 * @param reason reason for payment
+	 * @param player               collecting the military salary
+	 * @param reason               reason for payment
 	 * @param successMessageLangId relevant lang string id
 	 * @return true if payment is made
-	 *         false if payment cannot be made for various reasons.
+	 * false if payment cannot be made for various reasons.
 	 */
 	private static boolean collectIncome(Player player,
 										 String reason,
@@ -139,7 +140,7 @@ public class SiegeWarMoneyUtil {
 			return false;
 
 		int incomeAmount;
-		switch(reason.toLowerCase()) {
+		switch (reason.toLowerCase()) {
 			case "military salary":
 				incomeAmount = ResidentMetaDataController.getMilitarySalaryAmount(resident);
 				break;
@@ -147,12 +148,12 @@ public class SiegeWarMoneyUtil {
 				throw new TownyException("Unknown income type");
 		}
 
-		if(incomeAmount != 0) {
+		if (incomeAmount != 0) {
 			resident.getAccount().deposit(incomeAmount, reason);
-			switch(reason.toLowerCase()) {
+			switch (reason.toLowerCase()) {
 				case "military salary":
 					ResidentMetaDataController.clearMilitarySalary(resident);
-				break;
+					break;
 				default:
 					throw new TownyException("Unknown income type");
 			}
@@ -166,7 +167,7 @@ public class SiegeWarMoneyUtil {
 	/**
 	 * Make some military salary money available to a resident
 	 *
-	 * @param soldier the resident to grant the amount to.
+	 * @param soldier              the resident to grant the amount to.
 	 * @param militarySalaryAmount the amount
 	 */
 	public static void makeMilitarySalaryAvailable(Resident soldier, int militarySalaryAmount) {
@@ -187,7 +188,7 @@ public class SiegeWarMoneyUtil {
 		double cost = SiegeWarSettings.getWarSiegeWarchestCostPerPlot()
 				* town.getTownBlocks().size();
 		cost = applyMoneyModifiers(cost, town);
-		return  cost;
+		return cost;
 	}
 
 	public static double calculateTotalSiegeStartCost(Town town) {
@@ -196,13 +197,13 @@ public class SiegeWarMoneyUtil {
 
 	private static double applyMoneyModifiers(double cost, Town town) {
 		//Increase cost if town is capitol
-		if(SiegeWarSettings.getWarSiegeCapitalCostIncreasePercentage() > 0
-			&& town.isCapital()) {
+		if (SiegeWarSettings.getWarSiegeCapitalCostIncreasePercentage() > 0
+				&& town.isCapital()) {
 			cost *= (1 + (SiegeWarSettings.getWarSiegeCapitalCostIncreasePercentage() / 100));
 		}
 
 		//Increase cost due to money multiplier & town size
-		if(SiegeWarSettings.getWarSiegeExtraMoneyPercentagePerTownLevel() > 0) {
+		if (SiegeWarSettings.getWarSiegeExtraMoneyPercentagePerTownLevel() > 0) {
 			cost *= getMoneyMultiplier(town);
 		}
 
@@ -210,20 +211,19 @@ public class SiegeWarMoneyUtil {
 	}
 
 	/**
-	 *
-	 * @param totalAmountForSoldiers total amount
-	 * @param town the town which pays
-	 * @param soldierSharesMap the shares of soldiers
-	 * @param reason reason for payment
+	 * @param totalAmountForSoldiers  total amount
+	 * @param town                    the town which pays
+	 * @param soldierSharesMap        the shares of soldiers
+	 * @param reason                  reason for payment
 	 * @param removeMoneyFromTownBank if true, remove money from town
 	 * @return true if money was paid. False if there were no soldiers
 	 */
 	public static boolean distributeMoneyAmongSoldiers(double totalAmountForSoldiers,
-													Town town,
-													Map<Resident, Integer> soldierSharesMap,
-													String reason,
-													boolean removeMoneyFromTownBank) {
-		if(soldierSharesMap.size() == 0)
+													   Town town,
+													   Map<Resident, Integer> soldierSharesMap,
+													   String reason,
+													   boolean removeMoneyFromTownBank) {
+		if (soldierSharesMap.size() == 0)
 			return false;
 
 		//Withdraw money from town if needed
@@ -233,7 +233,7 @@ public class SiegeWarMoneyUtil {
 
 		//Find out total shares within the army
 		int totalArmyShares = 0;
-		for(Integer share: soldierSharesMap.values()) {
+		for (Integer share : soldierSharesMap.values()) {
 			totalArmyShares += share;
 		}
 
@@ -242,12 +242,12 @@ public class SiegeWarMoneyUtil {
 
 		//Pay each soldier
 		int amountToPaySoldier;
-		for(Map.Entry<Resident,Integer> soldierShareEntry: soldierSharesMap.entrySet()) {
-			amountToPaySoldier = (int)((amountValueOfOneShare * soldierShareEntry.getValue())); //Round down to avoid exploits for making extra money
-			switch(reason.toLowerCase()) {
+		for (Map.Entry<Resident, Integer> soldierShareEntry : soldierSharesMap.entrySet()) {
+			amountToPaySoldier = (int) ((amountValueOfOneShare * soldierShareEntry.getValue())); //Round down to avoid exploits for making extra money
+			switch (reason.toLowerCase()) {
 				case "military salary":
 					makeMilitarySalaryAvailable(soldierShareEntry.getKey(), amountToPaySoldier);
-				break;
+					break;
 				default:
 					throw new RuntimeException("Unknown Income Type");
 			}
@@ -257,9 +257,9 @@ public class SiegeWarMoneyUtil {
 
 	/**
 	 * Can the nation afford to start their siege?
-	 * 
+	 *
 	 * @param nation Nation starting a siege.
-	 * @param town Town being sieged.
+	 * @param town   Town being sieged.
 	 * @throws TownyException thrown nation cannot pay.
 	 */
 	public static void throwIfNationCannotAffordToStartSiege(Nation nation, Town town) throws TownyException {
@@ -278,7 +278,7 @@ public class SiegeWarMoneyUtil {
 	 */
 	public static void throwIfTownCannotAffordToStartSiege(Town town) throws TownyException {
 		double cost = calculateUpfrontSiegeStartCost(town);
-		if(cost > 0) {
+		if (cost > 0) {
 			if (!TownyEconomyHandler.isActive())
 				return; //Siege cost does not apply
 			if (!town.getAccount().canPayFromHoldings(cost))
@@ -300,7 +300,7 @@ public class SiegeWarMoneyUtil {
 
 		if (days <= 1)
 			TownMetaDataController.removePlunderDebt(town);
-		else 
+		else
 			TownMetaDataController.setPlunderDebtDays(town, days - 1);
 	}
 
@@ -343,17 +343,17 @@ public class SiegeWarMoneyUtil {
 	public static void makeNationRefundAvailable(Resident king) {
 		//Refund some of the initial setup cost to the king
 		if (TownySettings.isUsingEconomy()
-			&& SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete() > 0) {
+				&& SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete() > 0) {
 
 			//Make the nation refund available
 			//The player can later do "/n claim refund" to receive the money
-			int amountToRefund = (int)(TownySettings.getNewNationPrice() * 0.01 * SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete());
+			int amountToRefund = (int) (TownySettings.getNewNationPrice() * 0.01 * SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete());
 			ResidentMetaDataController.addNationRefundAmount(king, amountToRefund);
 
 			//If king is online, send message
-			if(king.isOnline()) {
+			if (king.isOnline()) {
 				Messaging.sendMsg(king.getPlayer(),
-					Translatable.of("msg_siege_war_nation_refund_available",
+						Translatable.of("msg_siege_war_nation_refund_available",
 								TownyEconomyHandler.getFormattedBalance(amountToRefund)).forLocale(king.getPlayer()));
 			}
 		}
@@ -375,7 +375,7 @@ public class SiegeWarMoneyUtil {
 			throw new TownyException(Translatable.of("msg_err_not_registered_1", player.getName()));
 
 		int refundAmount = ResidentMetaDataController.getNationRefundAmount(formerKing);
-		if(refundAmount != 0) {
+		if (refundAmount != 0) {
 			formerKing.getAccount().deposit(refundAmount, "Nation Refund");
 			ResidentMetaDataController.setNationRefundAmount(formerKing, 0);
 			Messaging.sendMsg(player, Translatable.of("msg_siege_war_nation_refund_claimed", TownyEconomyHandler.getFormattedBalance(refundAmount)));
@@ -388,19 +388,19 @@ public class SiegeWarMoneyUtil {
 
 	/**
 	 * Pay the upfront cost of starting the siege
-	 * 
+	 *
 	 * @param siege the siege
 	 */
 	public static void payUpfrontSiegeStartCost(Siege siege) {
 		double cost = SiegeWarMoneyUtil.calculateUpfrontSiegeStartCost(siege.getTown());
-		if(TownyEconomyHandler.isActive() && SiegeWarSettings.getWarSiegeUpfrontCostPerPlot() > 0) {
-			if(siege.getSiegeType() == SiegeType.CONQUEST) {
+		if (TownyEconomyHandler.isActive() && SiegeWarSettings.getWarSiegeUpfrontCostPerPlot() > 0) {
+			if (siege.getSiegeType() == SiegeType.CONQUEST) {
 				siege.getAttacker().getAccount().withdraw(cost, "Upfront cost of starting siege.");
 				Translatable moneyMessage =
 						Translatable.of("msg_nation_pay_upfront_siege_cost",
 								TownyEconomyHandler.getFormattedBalance(cost));
-				TownyMessaging.sendPrefixedNationMessage((Nation)siege.getAttacker(), moneyMessage);
-			} else if(siege.getSiegeType() == SiegeType.REVOLT) {
+				TownyMessaging.sendPrefixedNationMessage((Nation) siege.getAttacker(), moneyMessage);
+			} else if (siege.getSiegeType() == SiegeType.REVOLT) {
 				siege.getTown().getAccount().withdraw(cost, "Upfront cost of starting siege.");
 				Translatable moneyMessage =
 						Translatable.of("msg_town_pay_upfront_siege_cost",
@@ -412,19 +412,25 @@ public class SiegeWarMoneyUtil {
 
 	/**
 	 * Calculate the estimated amount of money in the economy.
-	 * 
+	 * <p>
 	 * The result is stored in this class.
-	 * 
+	 * <p>
 	 * Result = (All money in town banks + All money in nation banks)
-	 *          +10% (an estimate of how much else residents are carrying)
-	 * 
+	 * +10% (an estimate of how much else residents are carrying)
+	 *
 	 * @param siegeWarPluginError true if SW is in error.
 	 */
 	public static void calculateEstimatedTotalMoneyInEconomy(boolean siegeWarPluginError) {
-		if(siegeWarPluginError) {
+		if (siegeWarPluginError) {
 			SiegeWar.severe("SiegeWar is in safe mode. Money calculation not attempted.");
 			return;
 		}
+		Bukkit.getScheduler().runTaskAsynchronously(
+				SiegeWar.getSiegeWar(),
+				SiegeWarMoneyUtil::calculateEstimatedTotalMoneyInEconomyNow);
+	}
+
+	private static void calculateEstimatedTotalMoneyInEconomyNow() {
 		double result = 0;
 		//Town Accounts
 		for(Town town: TownyAPI.getInstance().getTowns()) {
@@ -443,7 +449,6 @@ public class SiegeWarMoneyUtil {
 		SiegeWar.info("Total Number of Townblocks: " + TownyAPI.getInstance().getTownBlocks().size());
 		SiegeWar.info("Estimated Value Per Townblock: " + estimatedTotalMoneyInEconomy / TownyAPI.getInstance().getTownBlocks().size());
 		SiegeWar.info("Ideal / Actual Plunder Value: " + SiegeWarWarningsUtil.calculateIdealPlunderValue() + " / " + SiegeWarSettings.getWarSiegePlunderAmountPerPlot());
-
 	}
 
 	public static double getEstimatedTotalMoneyInEconomy() {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
@@ -27,17 +27,18 @@ import java.util.ArrayList;
 import java.util.Map;
 
 public class SiegeWarMoneyUtil {
-	private static double estimatedTotalMoneyInEconomy = 0;
+
+	private static double estimatedTotalMoneyInEconomy;
 
 	/**
 	 * Give the war chest to the winner
 	 * Used for a decisive victory
 	 *
-	 * @param siege             siege
-	 * @param winningGovernment the (decisively) winning government
+	 * @param siege siege
+	 * @param winningGovernment the (decisively) winning government 	 
 	 */
 	public static void giveWarChestToWinner(Siege siege, Government winningGovernment) {
-		if (TownyEconomyHandler.isActive()) {
+		if(TownyEconomyHandler.isActive()) {
 			giveWarChestTo(winningGovernment,
 					siege.getWarChestAmount(),
 					"War Chest Captured",
@@ -48,13 +49,13 @@ public class SiegeWarMoneyUtil {
 	/**
 	 * Split the warchest between both given governments
 	 * Used for a close victory
-	 *
-	 * @param siege             siege
+	 * 
+	 * @param siege siege
 	 * @param winningGovernment the (closely) winning government
-	 * @param losingGovernment  the (closely) losing government
+	 * @param losingGovernment the (closely) losing government
 	 */
 	public static void giveWarChestToBoth(Siege siege, Government winningGovernment, Government losingGovernment) {
-		if (TownyEconomyHandler.isActive()) {
+		if(TownyEconomyHandler.isActive()) {
 			//Calculate amounts
 			double amountForLosingGovernment = siege.getWarChestAmount() / 100 * SiegeWarSettings.getSpecialVictoryEffectsWarchestReductionPercentageOnCloseVictory();
 			double amountForWinningGovernment = siege.getWarChestAmount() - amountForLosingGovernment;
@@ -74,22 +75,22 @@ public class SiegeWarMoneyUtil {
 	}
 
 	private static void giveWarChestTo(Government governmentToAward,
-									   double amountToAward,
+									   double amountToAward, 
 									   String depositComment,
 									   String messageTranslationKey) {
 		//Award Amount
 		governmentToAward.getAccount().deposit(amountToAward, depositComment);
-
+		
 		//Create message
 		Translatable message = Translatable.of(messageTranslationKey,
 				governmentToAward.getName(),
 				TownyEconomyHandler.getFormattedBalance(amountToAward));
-
+		
 		//Send message to government that got the money
 		if (governmentToAward instanceof Nation)
-			TownyMessaging.sendPrefixedNationMessage((Nation) governmentToAward, message);
+			TownyMessaging.sendPrefixedNationMessage((Nation)governmentToAward, message);
 		else
-			TownyMessaging.sendPrefixedTownMessage((Town) governmentToAward, message);
+			TownyMessaging.sendPrefixedTownMessage((Town)governmentToAward, message);
 	}
 
 	/**
@@ -101,10 +102,10 @@ public class SiegeWarMoneyUtil {
 	public static double getMoneyMultiplier(Town town) {
 		double extraMoneyPercentage = SiegeWarSettings.getWarSiegeExtraMoneyPercentagePerTownLevel();
 
-		if (extraMoneyPercentage == 0) {
+		if(extraMoneyPercentage == 0) {
 			return 1;
 		} else {
-			return 1 + ((extraMoneyPercentage / 100) * (town.getLevelID() - 1));
+			return 1 + ((extraMoneyPercentage / 100) * (town.getLevelID() -1));
 		}
 	}
 
@@ -113,10 +114,10 @@ public class SiegeWarMoneyUtil {
 	 *
 	 * @param player collecting the military salary
 	 * @return true if payment is made
-	 * false if payment cannot be made for various reasons.
+	 *         false if payment cannot be made for various reasons.
 	 */
 	public static boolean collectMilitarySalary(Player player) throws Exception {
-		if (!SiegeWarSettings.getWarSiegeEnabled() || !SiegeWarSettings.getWarSiegeMilitarySalaryEnabled()) {
+		if(!SiegeWarSettings.getWarSiegeEnabled() || !SiegeWarSettings.getWarSiegeMilitarySalaryEnabled()) {
 			return false;
 		}
 		return collectIncome(player, "Military Salary",
@@ -126,11 +127,11 @@ public class SiegeWarMoneyUtil {
 	/**
 	 * If the player is due an income, pays it to the player
 	 *
-	 * @param player               collecting the military salary
-	 * @param reason               reason for payment
+	 * @param player collecting the military salary
+	 * @param reason reason for payment
 	 * @param successMessageLangId relevant lang string id
 	 * @return true if payment is made
-	 * false if payment cannot be made for various reasons.
+	 *         false if payment cannot be made for various reasons.
 	 */
 	private static boolean collectIncome(Player player,
 										 String reason,
@@ -140,7 +141,7 @@ public class SiegeWarMoneyUtil {
 			return false;
 
 		int incomeAmount;
-		switch (reason.toLowerCase()) {
+		switch(reason.toLowerCase()) {
 			case "military salary":
 				incomeAmount = ResidentMetaDataController.getMilitarySalaryAmount(resident);
 				break;
@@ -148,12 +149,12 @@ public class SiegeWarMoneyUtil {
 				throw new TownyException("Unknown income type");
 		}
 
-		if (incomeAmount != 0) {
+		if(incomeAmount != 0) {
 			resident.getAccount().deposit(incomeAmount, reason);
-			switch (reason.toLowerCase()) {
+			switch(reason.toLowerCase()) {
 				case "military salary":
 					ResidentMetaDataController.clearMilitarySalary(resident);
-					break;
+				break;
 				default:
 					throw new TownyException("Unknown income type");
 			}
@@ -167,7 +168,7 @@ public class SiegeWarMoneyUtil {
 	/**
 	 * Make some military salary money available to a resident
 	 *
-	 * @param soldier              the resident to grant the amount to.
+	 * @param soldier the resident to grant the amount to.
 	 * @param militarySalaryAmount the amount
 	 */
 	public static void makeMilitarySalaryAvailable(Resident soldier, int militarySalaryAmount) {
@@ -188,7 +189,7 @@ public class SiegeWarMoneyUtil {
 		double cost = SiegeWarSettings.getWarSiegeWarchestCostPerPlot()
 				* town.getTownBlocks().size();
 		cost = applyMoneyModifiers(cost, town);
-		return cost;
+		return  cost;
 	}
 
 	public static double calculateTotalSiegeStartCost(Town town) {
@@ -197,13 +198,13 @@ public class SiegeWarMoneyUtil {
 
 	private static double applyMoneyModifiers(double cost, Town town) {
 		//Increase cost if town is capitol
-		if (SiegeWarSettings.getWarSiegeCapitalCostIncreasePercentage() > 0
-				&& town.isCapital()) {
+		if(SiegeWarSettings.getWarSiegeCapitalCostIncreasePercentage() > 0
+			&& town.isCapital()) {
 			cost *= (1 + (SiegeWarSettings.getWarSiegeCapitalCostIncreasePercentage() / 100));
 		}
 
 		//Increase cost due to money multiplier & town size
-		if (SiegeWarSettings.getWarSiegeExtraMoneyPercentagePerTownLevel() > 0) {
+		if(SiegeWarSettings.getWarSiegeExtraMoneyPercentagePerTownLevel() > 0) {
 			cost *= getMoneyMultiplier(town);
 		}
 
@@ -211,19 +212,20 @@ public class SiegeWarMoneyUtil {
 	}
 
 	/**
-	 * @param totalAmountForSoldiers  total amount
-	 * @param town                    the town which pays
-	 * @param soldierSharesMap        the shares of soldiers
-	 * @param reason                  reason for payment
+	 *
+	 * @param totalAmountForSoldiers total amount
+	 * @param town the town which pays
+	 * @param soldierSharesMap the shares of soldiers
+	 * @param reason reason for payment
 	 * @param removeMoneyFromTownBank if true, remove money from town
 	 * @return true if money was paid. False if there were no soldiers
 	 */
 	public static boolean distributeMoneyAmongSoldiers(double totalAmountForSoldiers,
-													   Town town,
-													   Map<Resident, Integer> soldierSharesMap,
-													   String reason,
-													   boolean removeMoneyFromTownBank) {
-		if (soldierSharesMap.size() == 0)
+													Town town,
+													Map<Resident, Integer> soldierSharesMap,
+													String reason,
+													boolean removeMoneyFromTownBank) {
+		if(soldierSharesMap.size() == 0)
 			return false;
 
 		//Withdraw money from town if needed
@@ -233,7 +235,7 @@ public class SiegeWarMoneyUtil {
 
 		//Find out total shares within the army
 		int totalArmyShares = 0;
-		for (Integer share : soldierSharesMap.values()) {
+		for(Integer share: soldierSharesMap.values()) {
 			totalArmyShares += share;
 		}
 
@@ -242,12 +244,12 @@ public class SiegeWarMoneyUtil {
 
 		//Pay each soldier
 		int amountToPaySoldier;
-		for (Map.Entry<Resident, Integer> soldierShareEntry : soldierSharesMap.entrySet()) {
-			amountToPaySoldier = (int) ((amountValueOfOneShare * soldierShareEntry.getValue())); //Round down to avoid exploits for making extra money
-			switch (reason.toLowerCase()) {
+		for(Map.Entry<Resident,Integer> soldierShareEntry: soldierSharesMap.entrySet()) {
+			amountToPaySoldier = (int)((amountValueOfOneShare * soldierShareEntry.getValue())); //Round down to avoid exploits for making extra money
+			switch(reason.toLowerCase()) {
 				case "military salary":
 					makeMilitarySalaryAvailable(soldierShareEntry.getKey(), amountToPaySoldier);
-					break;
+				break;
 				default:
 					throw new RuntimeException("Unknown Income Type");
 			}
@@ -257,9 +259,9 @@ public class SiegeWarMoneyUtil {
 
 	/**
 	 * Can the nation afford to start their siege?
-	 *
+	 * 
 	 * @param nation Nation starting a siege.
-	 * @param town   Town being sieged.
+	 * @param town Town being sieged.
 	 * @throws TownyException thrown nation cannot pay.
 	 */
 	public static void throwIfNationCannotAffordToStartSiege(Nation nation, Town town) throws TownyException {
@@ -278,7 +280,7 @@ public class SiegeWarMoneyUtil {
 	 */
 	public static void throwIfTownCannotAffordToStartSiege(Town town) throws TownyException {
 		double cost = calculateUpfrontSiegeStartCost(town);
-		if (cost > 0) {
+		if(cost > 0) {
 			if (!TownyEconomyHandler.isActive())
 				return; //Siege cost does not apply
 			if (!town.getAccount().canPayFromHoldings(cost))
@@ -300,7 +302,7 @@ public class SiegeWarMoneyUtil {
 
 		if (days <= 1)
 			TownMetaDataController.removePlunderDebt(town);
-		else
+		else 
 			TownMetaDataController.setPlunderDebtDays(town, days - 1);
 	}
 
@@ -343,17 +345,17 @@ public class SiegeWarMoneyUtil {
 	public static void makeNationRefundAvailable(Resident king) {
 		//Refund some of the initial setup cost to the king
 		if (TownySettings.isUsingEconomy()
-				&& SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete() > 0) {
+			&& SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete() > 0) {
 
 			//Make the nation refund available
 			//The player can later do "/n claim refund" to receive the money
-			int amountToRefund = (int) (TownySettings.getNewNationPrice() * 0.01 * SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete());
+			int amountToRefund = (int)(TownySettings.getNewNationPrice() * 0.01 * SiegeWarSettings.getWarSiegeNationCostRefundPercentageOnDelete());
 			ResidentMetaDataController.addNationRefundAmount(king, amountToRefund);
 
 			//If king is online, send message
-			if (king.isOnline()) {
+			if(king.isOnline()) {
 				Messaging.sendMsg(king.getPlayer(),
-						Translatable.of("msg_siege_war_nation_refund_available",
+					Translatable.of("msg_siege_war_nation_refund_available",
 								TownyEconomyHandler.getFormattedBalance(amountToRefund)).forLocale(king.getPlayer()));
 			}
 		}
@@ -375,7 +377,7 @@ public class SiegeWarMoneyUtil {
 			throw new TownyException(Translatable.of("msg_err_not_registered_1", player.getName()));
 
 		int refundAmount = ResidentMetaDataController.getNationRefundAmount(formerKing);
-		if (refundAmount != 0) {
+		if(refundAmount != 0) {
 			formerKing.getAccount().deposit(refundAmount, "Nation Refund");
 			ResidentMetaDataController.setNationRefundAmount(formerKing, 0);
 			Messaging.sendMsg(player, Translatable.of("msg_siege_war_nation_refund_claimed", TownyEconomyHandler.getFormattedBalance(refundAmount)));
@@ -388,19 +390,19 @@ public class SiegeWarMoneyUtil {
 
 	/**
 	 * Pay the upfront cost of starting the siege
-	 *
+	 * 
 	 * @param siege the siege
 	 */
 	public static void payUpfrontSiegeStartCost(Siege siege) {
 		double cost = SiegeWarMoneyUtil.calculateUpfrontSiegeStartCost(siege.getTown());
-		if (TownyEconomyHandler.isActive() && SiegeWarSettings.getWarSiegeUpfrontCostPerPlot() > 0) {
-			if (siege.getSiegeType() == SiegeType.CONQUEST) {
+		if(TownyEconomyHandler.isActive() && SiegeWarSettings.getWarSiegeUpfrontCostPerPlot() > 0) {
+			if(siege.getSiegeType() == SiegeType.CONQUEST) {
 				siege.getAttacker().getAccount().withdraw(cost, "Upfront cost of starting siege.");
 				Translatable moneyMessage =
 						Translatable.of("msg_nation_pay_upfront_siege_cost",
 								TownyEconomyHandler.getFormattedBalance(cost));
-				TownyMessaging.sendPrefixedNationMessage((Nation) siege.getAttacker(), moneyMessage);
-			} else if (siege.getSiegeType() == SiegeType.REVOLT) {
+				TownyMessaging.sendPrefixedNationMessage((Nation)siege.getAttacker(), moneyMessage);
+			} else if(siege.getSiegeType() == SiegeType.REVOLT) {
 				siege.getTown().getAccount().withdraw(cost, "Upfront cost of starting siege.");
 				Translatable moneyMessage =
 						Translatable.of("msg_town_pay_upfront_siege_cost",
@@ -454,4 +456,5 @@ public class SiegeWarMoneyUtil {
 	public static double getEstimatedTotalMoneyInEconomy() {
 		return estimatedTotalMoneyInEconomy;
 	}
+
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWarningsUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWarningsUtil.java
@@ -1,0 +1,46 @@
+package com.gmail.goosius.siegewar.utils;
+
+import com.gmail.goosius.siegewar.Messaging;
+import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
+import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.object.Translatable;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class SiegeWarWarningsUtil {
+    
+    /**
+     * Send bad configs warnings
+     *
+     * @param sender the CommandSender to send the message to
+     */
+    public static void sendBadConfigsWarnings(CommandSender sender) {
+        if(sender instanceof Player && !sender.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_COMMAND_SIEGEWARADMIN_BADCONFIGWARNINGS.getNode())) {
+            return;
+        }
+        sendBadPlunderWarning(sender);
+    }
+
+    private static void sendBadPlunderWarning(CommandSender sender) {
+        double actualConfiguredValue = SiegeWarSettings.getWarSiegePlunderAmountPerPlot();
+        double idealConfiguredValue = calculateIdealPlunderValue();
+        double toleranceAmount = idealConfiguredValue * SiegeWarSettings.getBadConfigWarningsTolerancePercentage() / 100;
+        double lowerBound = idealConfiguredValue - toleranceAmount;
+        double upperBound = idealConfiguredValue + toleranceAmount;
+        if(actualConfiguredValue > upperBound) {
+            Messaging.sendErrorMsg(sender, Translatable.of("msg_err_plunder_configured_too_high", "" + idealConfiguredValue , "" + actualConfiguredValue));
+        } else if (actualConfiguredValue < lowerBound) {
+            Messaging.sendErrorMsg(sender, Translatable.of("msg_err_plunder_configured_too_low", "" + idealConfiguredValue, "" + actualConfiguredValue));
+        }
+    }
+
+    public static double calculateIdealPlunderValue() {
+        double allMoney = SiegeWarMoneyUtil.getEstimatedTotalMoneyInEconomy();
+        double numTownBlocks = TownyAPI.getInstance().getTownBlocks().size();
+        double valuePerTownBlock = allMoney / numTownBlocks;
+        double idealPlunderValue = valuePerTownBlock * SiegeWarSettings.getBadConfigWarningsIdealPlunderPercentage() / 100;
+        return idealPlunderValue;
+    }
+}
+

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWarningsUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarWarningsUtil.java
@@ -15,14 +15,14 @@ public class SiegeWarWarningsUtil {
      *
      * @param sender the CommandSender to send the message to
      */
-    public static void sendBadConfigsWarnings(CommandSender sender) {
+    public static void sendWarningsIfConfigsBad(CommandSender sender) {
         if(sender instanceof Player && !sender.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_COMMAND_SIEGEWARADMIN_BADCONFIGWARNINGS.getNode())) {
             return;
         }
-        sendBadPlunderWarning(sender);
+        sendWarningIfPlunderConfigBad(sender);
     }
 
-    private static void sendBadPlunderWarning(CommandSender sender) {
+    private static void sendWarningIfPlunderConfigBad(CommandSender sender) {
         double actualConfiguredValue = SiegeWarSettings.getWarSiegePlunderAmountPerPlot();
         double idealConfiguredValue = calculateIdealPlunderValue();
         double toleranceAmount = idealConfiguredValue * SiegeWarSettings.getBadConfigWarningsTolerancePercentage() / 100;

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -626,3 +626,7 @@ msg_general_chat_now_restored: "&bGeneral Chat has been restored."
 msg_err_no_local_chat_in_siege_zones: "&cLocal Chat is disabled in Siege Zones."
 msg_err_no_general_chat_in_battle_session: "&cGeneral Chat is disabled while a Battle Session is active, and for %s after it ends. Try chatting using /tc, /nc, or /ac."
 msg_can_also_chat_in_discord: " You can also chat in the server discord: %s."
+
+#Bad Config Warnings
+msg_err_plunder_configured_too_high: "&cWARNING: The server's configured value for money:plunder:amount_per_plot is too high. The calculated ideal value is %s, but the actual configured value is %s."
+msg_err_plunder_configured_too_low: "&cWARNING: The server's configured value for money:plunder:amount_per_plot is too low. The calculated ideal value is %s, but the actual configured value is %s."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ author: [Goosius,LlmDl]
 website: 'townyadvanced.github.io'
 prefix: ${project.artifactId}
 depend: [Towny]
-softdepend: [TownyCultures, dynmap, Dynmap-Towny]
+softdepend: [TownyCultures, TownyChat, dynmap, Dynmap-Towny]
 
 description: A war system made by Goosius for Towny.
 
@@ -37,6 +37,7 @@ permissions:
             siegewar.command.siegewaradmin.nation: true
             siegewar.command.siegewaradmin.installperms: true
             siegewar.command.siegewaradmin.battlesession: true
+            siegewar.command.siegewaradmin.badconfigwarnings: true
 
     siegewar.command.siegewar.*:
         description: User is able to do all /siegewar commands.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
- Background
   - As per the theme of 2.1.0, this PR addresses toxicity.
   - A leading cause of toxicity on some servers, is that the "stakes" of sieges are too high. 
   - Example: If town is set to lose a big amount of plunder on a siege-loss (e.g. 80% of the town bank), then both the siege and its aftermath will tend to be high-stress/high-toxicity affairs.
   - Alternatively if the town was set to lose a relatively low amount of plunder (e.g. 15% of the town bank), it would be hard to argue after the release of SW 2.0.0, that this wouldn't improve the atmosphere on the server, considering:
     - The list of victor-benefits which do not change, including increased national reputation, expansion of the nation, reduction of an enemy nation, and taxing the occupied town.
     - The list of victor-benefits which actually improve, including having more fun & less stress during the siege, and having people to fight the next weekend, rather than having those people simply quit the server.
   - Generally SW 2.1.0 will refute the assertion that sieges "should matter a lot". Instead, SW 2.1.0 will support the assertion that sieges "should not matter too much" i.e. that Sieges can be configured to work well as low-stakes competitions, an approach which is provably successful in many successful low-stakes games such as friendly football matches, chess matches, or multi-player-shooter games like battlefield, call-of-duty, or counterstrike.
- PR Details
  - This PR adds a warning system to help servers identify if their configured siege-money values are too high.
  - Server's get some new configs, in which they can define what "too high" means for them, and can setup the warnings to whichever tolerance threshold they prefer.
  - In this PR, only the plunder-warning-system is added. Other warnings will be added in upcoming PR's 
  - The warning is given in 2 places:
    - When the server starts up, a warning is shown in the console if plunder is too high/low
    - When a SiegeWarAdmin logs in, the same warning is shown to them
   - Note: The feature's estimate of all-resident-money is quite rough, for the main reason that it seems difficult to create an algorithm which was easy for servers to understand and use.  For example, if all the money of residents were simply summed, there might be a resident somewhere who had somehow cheated to get an extra million in gold - and in order not to throw the calculations off, server admin's would have to do the extra step of locating that particular resident and changing their account balance.
    
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```
	BAD_CONFIG_WARNINGS(
			"bad_config_warnings",
			"",
			"",
			"",
			"############################################################",
			"# +------------------------------------------------------+ #",
			"# |                 BAD CONFIG WARNINGS                  | #",
			"# +------------------------------------------------------+ #",
			"############################################################",
			""),
	BAD_CONFIG_WARNINGS_ENABLED(
			"bad_config_warnings.enabled",
			"true",
			"",
			"# If this value is true, then whenever the server starts, or whenever a SiegeWarAdmin logs in,",
			"# a warning will be displayed if any important configs are set badly."),
	BAD_CONFIG_WARNINGS_TOLERANCE_PERCENTAGE(
			"bad_config_warnings.tolerance_percentage",
			"5.0",
			"",
			"# This setting determines the tolerance of the bad-config-warnings.",
			"# Example: If the 'ideal plunder rate' is set to 10%....then if the actual plunder config works out at below 5% or over 15%, a warning will be given."),
	BAD_CONFIG_WARNINGS_IDEAL_PLUNDER_PERCENTAGE(
		"bad_config_warnings.ideal_plunder_percentage",
			"15.0",
			"",
			"# This value determines the ideal configured plunder value.",
			"# Example: If the ideal percentage is 10%, then on plunder, we want to take 10% of the estimated town value.",
			"# NOTE: The estimated town value is calculated by summing all the money in the economy, dividing by total-num-townblocks, then multiplying by num-townblocks in the town.",
			"# The default value for this config is 15.0"),
	BAD_CONFIG_WARNINGS_IDEAL_WARCHEST_PERCENTAGE(
			"bad_config_warnings.ideal_warchest_percentage",
			"7.5",
			"",
			"# This value determines the ideal configured warchest value.",
			"# Example: If the ideal percentage is 5%, then on siege-start, we want to take 5% of the estimated town value.",
			"# The default value is 7.5"),
	BAD_CONFIG_WARNINGS_IDEAL_UPFRONTCOST_PERCENTAGE(
			"bad_config_warnings.ideal_upfrontcost_percentage",
			"3.75",
			"",
			"# This value determines the ideal configured upfront-cost value.",
			"# Example: If the ideal percentage is 2.5%, then on siege-start, we want to take 2.5% of the estimated town value.",
			"# The default value is 3.75"),
	BAD_CONFIG_WARNINGS_IDEAL_OCCUPATIONTAX_PERCENTAGE(
			"bad_config_warnings.ideal_occupationtax_percentage",
			"0.375",
			"",
			"# This value determines the ideal configured occupation-tax value.",
			"# Example: If the ideal percentage is 0.25, then on each new day, we want to take 0.25% of the estimated town value.",
			"# The default value is 0.375");
```

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
