### PR TITLE
Disable /tell while battle session is active

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -313,12 +313,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 		if(event.getMessage().startsWith("/tell")) {
 			if(BattleSession.getBattleSession().isChatDisabled()) {
 				event.setCancelled(true);
-				String formattedDisableTime = TimeMgmt.getFormattedTimeValue(SiegeWarSettings.getToxicityReductionChatRestorationAfterBattleSessionMillis());
-				Translatable message = Translatable.of("msg_err_no_tell_in_battle_session", formattedDisableTime);
-				String discordLink = SiegeWarSettings.getToxicityReductionServerDiscordLink();
-				if (!discordLink.isEmpty())
-					message.append(Translatable.of("msg_can_also_chat_in_discord", discordLink));
-				event.setMessage(message.translate(Locale.ROOT));
+				SiegeWarNotificationUtil.notifyPlayerOfBattleSessionChatRestriction(event.getPlayer(), "tell");
 			}
 		}
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -310,13 +310,15 @@ public class SiegeWarBukkitEventListener implements Listener {
 	 * If toxicity reduction is enabled, the following effect applies:
 	 * - No /tell if a battle session is active (and for 10 mins after)
 	 * 
+	 * This method will pick up any command where the first arg is "/<anything>tell"
+	 * 
 	 * @param event the player command preprocess event 
 	 */
 	@EventHandler
 	public void onCommand(PlayerCommandPreprocessEvent event){
 		if(!SiegeWarSettings.getWarSiegeEnabled() || !SiegeWarSettings.isToxicityReductionEnabled())
 			return;
-		if(event.getMessage().startsWith("/tell")) {
+		if(event.getMessage().split(" ")[0].endsWith("tell")) {
 			if(BattleSession.getBattleSession().isChatDisabled()) {
 				event.setCancelled(true);
 				SiegeWarNotificationUtil.notifyPlayerOfBattleSessionChatRestriction(event.getPlayer(), "tell");

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -310,6 +310,8 @@ public class SiegeWarBukkitEventListener implements Listener {
 	 */
 	@EventHandler
 	public void onCommand(PlayerCommandPreprocessEvent event){
+		if(!SiegeWarSettings.getWarSiegeEnabled() || !SiegeWarSettings.isToxicityReductionEnabled())
+			return;
 		if(event.getMessage().startsWith("/tell")) {
 			if(BattleSession.getBattleSession().isChatDisabled()) {
 				event.setCancelled(true);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -1,9 +1,12 @@
 package com.gmail.goosius.siegewar.listeners;
 
 import java.util.List;
+import java.util.Locale;
 
+import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.utils.DataCleanupUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarNotificationUtil;
+import com.palmergames.util.TimeMgmt;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -20,6 +23,7 @@ import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
@@ -295,6 +299,27 @@ public class SiegeWarBukkitEventListener implements Listener {
 			return;
 		if(DataCleanupUtil.isLegacyArtefact(event.getResult())) {
 			event.setResult(null); //Cannot repair artefact
+		}
+	}
+
+	/**
+	 * If toxicity reduction is enabled, the following effect applies:
+	 * - No /tell if a battle session is active (and for 10 mins after)
+	 * 
+	 * @param event the player command preprocess event 
+	 */
+	@EventHandler
+	public void onCommand(PlayerCommandPreprocessEvent event){
+		if(event.getMessage().startsWith("/tell")) {
+			if(BattleSession.getBattleSession().isChatDisabled()) {
+				event.setCancelled(true);
+				String formattedDisableTime = TimeMgmt.getFormattedTimeValue(SiegeWarSettings.getToxicityReductionChatRestorationAfterBattleSessionMillis());
+				Translatable message = Translatable.of("msg_err_no_tell_in_battle_session", formattedDisableTime);
+				String discordLink = SiegeWarSettings.getToxicityReductionServerDiscordLink();
+				if (!discordLink.isEmpty())
+					message.append(Translatable.of("msg_can_also_chat_in_discord", discordLink));
+				event.setMessage(message.translate(Locale.ROOT));
+			}
 		}
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -61,6 +61,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -351,26 +352,21 @@ public class SiegeWarTownyEventListener implements Listener {
      */
     @EventHandler()
     public void on(AsyncChatHookEvent asyncChatHookEvent) {
-        if(!SiegeWarSettings.getWarSiegeEnabled() || !SiegeWarSettings.isToxicityReductionEnabled())
+        if(!SiegeWarSettings.getWarSiegeEnabled() 
+            || !SiegeWarSettings.isToxicityReductionEnabled()
+            || !BattleSession.getBattleSession().isChatDisabled())
             return;
 
         String channelName = asyncChatHookEvent.getChannel().getName();
-
-        if(channelName.equalsIgnoreCase("local")) {
-            if(SiegeWarDistanceUtil.isLocationInActiveSiegeZone(asyncChatHookEvent.getPlayer().getLocation())) {
-                asyncChatHookEvent.setCancelled(true);
-                Messaging.sendErrorMsg(asyncChatHookEvent.getPlayer(), Translatable.of("msg_err_no_local_chat_in_siege_zones"));
-            }
-        } else if (channelName.equalsIgnoreCase("general")) {
-            if(BattleSession.getBattleSession().isGeneralChatDisabled()) {
-                asyncChatHookEvent.setCancelled(true);
-                String formattedDisableTime = TimeMgmt.getFormattedTimeValue(SiegeWarSettings.getToxicityReductionGeneralChatRestorationAfterBattleSessionMillis());
-                Translatable message = Translatable.of("msg_err_no_general_chat_in_battle_session", formattedDisableTime);
-                String discordLink = SiegeWarSettings.getToxicityReductionServerDiscordLink();
-                if(!discordLink.isEmpty())
-                    message.append(Translatable.of("msg_can_also_chat_in_discord", discordLink));
-                Messaging.sendErrorMsg(asyncChatHookEvent.getPlayer(), message);
-            }
+        if(channelName.equalsIgnoreCase("local") || channelName.equalsIgnoreCase("general")) {
+            asyncChatHookEvent.setCancelled(true);
+            String formattedDisableTime = TimeMgmt.getFormattedTimeValue(SiegeWarSettings.getToxicityReductionChatRestorationAfterBattleSessionMillis());
+            String langStringKey = "msg_err_no_"+ channelName + "_chat_in_battle_session";
+            Translatable message = Translatable.of(langStringKey, formattedDisableTime);
+            String discordLink = SiegeWarSettings.getToxicityReductionServerDiscordLink();
+            if (!discordLink.isEmpty())
+                message.append(Translatable.of("msg_can_also_chat_in_discord", discordLink));
+            asyncChatHookEvent.setMessage(message.translate(Locale.ROOT));
         }
     }
 

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -348,25 +348,19 @@ public class SiegeWarTownyEventListener implements Listener {
      * 1. No local chat in Siege Zones
      * 2. No general chat if a BattleSession is in progress (and for 10 mins after)
      * 
-     * @param asyncChatHookEvent the TownyChat event
+     * @param event the AsyncChatHook event from TownyChat
      */
     @EventHandler()
-    public void on(AsyncChatHookEvent asyncChatHookEvent) {
+    public void on(AsyncChatHookEvent event) {
         if(!SiegeWarSettings.getWarSiegeEnabled() 
             || !SiegeWarSettings.isToxicityReductionEnabled()
             || !BattleSession.getBattleSession().isChatDisabled())
             return;
 
-        String channelName = asyncChatHookEvent.getChannel().getName();
+        String channelName = event.getChannel().getName();
         if(channelName.equalsIgnoreCase("local") || channelName.equalsIgnoreCase("general")) {
-            asyncChatHookEvent.setCancelled(true);
-            String formattedDisableTime = TimeMgmt.getFormattedTimeValue(SiegeWarSettings.getToxicityReductionChatRestorationAfterBattleSessionMillis());
-            String langStringKey = "msg_err_no_"+ channelName + "_chat_in_battle_session";
-            Translatable message = Translatable.of(langStringKey, formattedDisableTime);
-            String discordLink = SiegeWarSettings.getToxicityReductionServerDiscordLink();
-            if (!discordLink.isEmpty())
-                message.append(Translatable.of("msg_can_also_chat_in_discord", discordLink));
-            asyncChatHookEvent.setMessage(message.translate(Locale.ROOT));
+            event.setCancelled(true);
+            SiegeWarNotificationUtil.notifyPlayerOfBattleSessionChatRestriction(event.getPlayer(), channelName);
         }
     }
 

--- a/src/main/java/com/gmail/goosius/siegewar/objects/BattleSession.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/BattleSession.java
@@ -37,14 +37,14 @@ public class BattleSession {
 	private long scheduledEndTime;	//The time this battle session is scheduled to end
 	private Long scheduledStartTime;  //The time this battle session is scheduled to start
 	private long startTime;			//The time the session actually started
-	private boolean generalChatDisabled;
+	private boolean chatDisabled;
 	private long scheduledGeneralChatRestorationTime;
 
 	public BattleSession() {
 		active = false;
 		scheduledEndTime = 0;
 		scheduledStartTime = null;
-		generalChatDisabled = false;
+		chatDisabled = false;
 		scheduledGeneralChatRestorationTime = 0;
 	}
 
@@ -102,12 +102,12 @@ public class BattleSession {
 		this.startTime = startTime;
 	}
 
-	public boolean isGeneralChatDisabled() {
-		return generalChatDisabled;
+	public boolean isChatDisabled() {
+		return chatDisabled;
 	}
 
-	public void setGeneralChatDisabled(boolean generalChatDisabled) {
-		this.generalChatDisabled = generalChatDisabled;
+	public void setChatDisabled(boolean chatDisabled) {
+		this.chatDisabled = chatDisabled;
 	}
 
 	public long getScheduledGeneralChatRestorationTime() {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -520,7 +520,7 @@ public class SiegeWarSettings {
 	}
 
 	//Convenience Method
-	public static double getToxicityReductionGeneralChatRestorationAfterBattleSessionMillis() {
+	public static double getToxicityReductionChatRestorationAfterBattleSessionMillis() {
 		return getToxicityReductionGeneralChatRestorationAfterBattleSessionMinutes() * TimeMgmt.ONE_MINUTE_IN_MILLIS;
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 public class SiegeWarBattleSessionUtil {
 	
@@ -64,9 +63,12 @@ public class SiegeWarBattleSessionUtil {
 		Translatable message = Translatable.of("msg_war_siege_battle_session_started");
 		//If toxicity reduction is enabled, disable the general chat
 		if(SiegeWarSettings.isToxicityReductionEnabled()) {
-			battleSession.setGeneralChatDisabled(true);
-			String formattedDisableTime = TimeMgmt.getFormattedTimeValue(SiegeWarSettings.getToxicityReductionGeneralChatRestorationAfterBattleSessionMillis());
-			message.append(Translatable.of("msg_general_chat_now_disabled", formattedDisableTime));
+			battleSession.setChatDisabled(true);
+			String formattedDisableTime = TimeMgmt.getFormattedTimeValue(SiegeWarSettings.getToxicityReductionChatRestorationAfterBattleSessionMillis());
+			message.append(Translatable.of("msg_chat_now_disabled", formattedDisableTime));
+			String discordLink = SiegeWarSettings.getToxicityReductionServerDiscordLink();
+			if (!discordLink.isEmpty())
+				message.append(Translatable.of("msg_can_also_chat_in_discord", discordLink));
 		}
 		Messaging.sendGlobalMessage(message);
 		//Start the bossbar for the Battle Session
@@ -93,7 +95,7 @@ public class SiegeWarBattleSessionUtil {
 		BossBarUtil.removeBattleSessionBossBars();
 
 		//Schedule restoration of global chat
-		battleSession.setScheduledGeneralChatRestorationTime(System.currentTimeMillis() + SiegeWarSettings.getToxicityReductionGeneralChatRestorationAfterBattleSessionMillis());
+		battleSession.setScheduledGeneralChatRestorationTime(System.currentTimeMillis() + SiegeWarSettings.getToxicityReductionChatRestorationAfterBattleSessionMillis());
 	}
 
 	public static void endBattleSessionForSiege(Siege siege) {
@@ -200,8 +202,8 @@ public class SiegeWarBattleSessionUtil {
 
 			//Restore the general chat
 			if(SiegeWarSettings.isToxicityReductionEnabled()) {
-				if(battleSession.isGeneralChatDisabled() && System.currentTimeMillis() > battleSession.getScheduledGeneralChatRestorationTime()) {
-					battleSession.setGeneralChatDisabled(false);
+				if(battleSession.isChatDisabled() && System.currentTimeMillis() > battleSession.getScheduledGeneralChatRestorationTime()) {
+					battleSession.setChatDisabled(false);
 					Messaging.sendGlobalMessage(Translatable.of("msg_general_chat_now_restored"));
 				}
 			}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -204,7 +204,7 @@ public class SiegeWarBattleSessionUtil {
 			if(SiegeWarSettings.isToxicityReductionEnabled()) {
 				if(battleSession.isChatDisabled() && System.currentTimeMillis() > battleSession.getScheduledGeneralChatRestorationTime()) {
 					battleSession.setChatDisabled(false);
-					Messaging.sendGlobalMessage(Translatable.of("msg_general_chat_now_restored"));
+					Messaging.sendGlobalMessage(Translatable.of("msg_chat_now_restored"));
 				}
 			}
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
@@ -4,17 +4,21 @@ import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.objects.Siege;
+import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.Translatable;
 
+import com.palmergames.util.TimeMgmt;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -128,5 +132,4 @@ public class SiegeWarNotificationUtil {
 			e.printStackTrace();
 		}
 	}
-
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
@@ -132,4 +132,15 @@ public class SiegeWarNotificationUtil {
 			e.printStackTrace();
 		}
 	}
+
+	public static void notifyPlayerOfBattleSessionChatRestriction(Player player, String channelName) {
+		String formattedDisableTime = TimeMgmt.getFormattedTimeValue(SiegeWarSettings.getToxicityReductionChatRestorationAfterBattleSessionMillis());
+		String langStringKey = "msg_err_no_"+ channelName + "_chat_in_battle_session";
+		Translatable message = Translatable.of(langStringKey, formattedDisableTime);
+		String discordLink = SiegeWarSettings.getToxicityReductionServerDiscordLink();
+		if (!discordLink.isEmpty())
+			message.append(Translatable.of("msg_can_also_chat_in_discord", discordLink));
+		Messaging.sendMsg(player, message);
+
+	}
 }

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -621,8 +621,9 @@ msg_revolt_siege_defender_decisive_win_demoralization: "&bThe former occupying n
 
 #Toxicity Reduction
 
-msg_general_chat_now_disabled: " General Chat will be disabled while the Battle Session is active, and for %s after it ends."
-msg_general_chat_now_restored: "&bGeneral Chat has been restored."
-msg_err_no_local_chat_in_siege_zones: "&cLocal Chat is disabled in Siege Zones."
+msg_chat_now_disabled: " General Chat, Local Chat, and /tell, will be disabled while the Battle Session is active, and for %s after it ends. If you want to chat, try using /tc, /nc, or /ac."
+msg_chat_now_restored: "&bGeneral Chat, Local Chat, and /tell, have been restored."
 msg_err_no_general_chat_in_battle_session: "&cGeneral Chat is disabled while a Battle Session is active, and for %s after it ends. Try chatting using /tc, /nc, or /ac."
+msg_err_no_local_chat_in_battle_session: "&cLocal Chat is disabled while a Battle Session is active, and for %s after it ends. Try chatting using /tc, /nc, or /ac."
+msg_err_no_tell_in_battle_session: "&c/tell is disabled while a Battle Session is active, and for %s after it ends. Try chatting using /tc, /nc, or /ac."
 msg_can_also_chat_in_discord: " You can also chat in the server discord: %s."

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -621,8 +621,8 @@ msg_revolt_siege_defender_decisive_win_demoralization: "&bThe former occupying n
 
 #Toxicity Reduction
 
-msg_chat_now_disabled: " General Chat, Local Chat, and /tell, will be disabled while the Battle Session is active, and for %s after it ends. If you want to chat, try using /tc, /nc, or /ac."
-msg_chat_now_restored: "&bGeneral Chat, Local Chat, and /tell, have been restored."
+msg_chat_now_disabled: " General Chat, /lc, and /tell, will be disabled while the Battle Session is active, and for %s after it ends. If you want to chat, try using /tc, /nc, or /ac."
+msg_chat_now_restored: "&bGeneral Chat, /lc, and /tell, have been restored."
 msg_err_no_general_chat_in_battle_session: "&cGeneral Chat is disabled while a Battle Session is active, and for %s after it ends. Try chatting using /tc, /nc, or /ac."
 msg_err_no_local_chat_in_battle_session: "&cLocal Chat is disabled while a Battle Session is active, and for %s after it ends. Try chatting using /tc, /nc, or /ac."
 msg_err_no_tell_in_battle_session: "&c/tell is disabled while a Battle Session is active, and for %s after it ends. Try chatting using /tc, /nc, or /ac."


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- This PR adds a disabled for /tell while battle sessions are active
- It also bring all disables into the same simple scheme of "when a battle sessions is active, and for 10 mins after"

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
