### PR TITLE
Bugfix for death points

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>2.4.0</version>
+  <version>2.4.1</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -74,11 +74,10 @@ public class PlayerDeath {
 				return;
 
 			Town deadResidentTown = deadResident.getTownOrNull();
-			Siege siege = findAValidSiege(deadPlayer, deadResidentTown);
+			Siege siege = findNearbyActiveSiegeWherePlayerIsParticipant(deadPlayer, deadResidentTown);
 
 			// If player is confirmed as close to one or more sieges in which they are
-			// eligible to be involved, apply siege point penalty for the nearest one, and
-			// keep inventory
+			// eligible to be involved, apply siege point penalty for the nearest one
 			if (siege != null) {
 				//Award penalty points w/ notification if siege is in progress
 				if(siege.getStatus() == SiegeStatus.IN_PROGRESS) {
@@ -104,7 +103,7 @@ public class PlayerDeath {
 			&& !TownyUniverse.getInstance().getPermissionSource().testPermission(deadPlayer, NATION_POINTS_NODE);
 	}
 
-	private static Siege findAValidSiege(Player deadPlayer, Town deadResidentTown) {
+	private static Siege findNearbyActiveSiegeWherePlayerIsParticipant(Player deadPlayer, Town deadResidentTown) {
 		Siege nearestSiege = null;
 		double smallestDistanceToSiege = 0;
 
@@ -119,8 +118,8 @@ public class PlayerDeath {
 			if(!SiegeWarDistanceUtil.isInSiegeZone(deadPlayer, candidateSiege))
 				continue;
 
-			//Is player an attacker or defender in this siege?
-			if(SiegeSide.getPlayerSiegeSide(nearestSiege, deadPlayer) == SiegeSide.NOBODY)
+			//Skip if player is not an official attacker or defender in siege
+			if(SiegeSide.getPlayerSiegeSide(candidateSiege, deadPlayer) == SiegeSide.NOBODY)
 				continue;
 
 			//Set nearestSiege if it is 1st viable one OR closer than smallestDistanceToSiege.


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- With current code, there is a bug in the PlayerDeath class, which fails to award points, and throws a nullpointer instead.
- Strangely, nobody has logged a bug ticket yet for this, even though it seems to have been present since SW 2.2.0, and seems to prevent any death points being awarded.
- This PR fixes the issue, and also does one refactor-rename of a method for clarity.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
