### PR TITLE
Add missing 'ignoreCancelled=true' tags

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarActionListener.java
@@ -27,10 +27,13 @@ public class SiegeWarActionListener implements Listener {
 	private final SiegeWar plugin;
 	
 	public SiegeWarActionListener(SiegeWar siegeWar) {
-
 		plugin = siegeWar;
 	}
-	
+
+	/**
+	 * Process block build.
+	 * Note: This event can be un-cancelled by SW
+	 */
 	@EventHandler
 	public void onBlockBuild(TownyBuildEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled())
@@ -40,7 +43,7 @@ public class SiegeWarActionListener implements Listener {
 	/*
 	 * SW will prevent an block break from altering an area around a banner.
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onBlockBreak(TownyDestroyEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			try {
@@ -55,7 +58,7 @@ public class SiegeWarActionListener implements Listener {
 	/*
 	 * SW will prevent fire from altering an area around a banner.
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onBurn(TownyBurnEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled() && SiegeWarBlockUtil.isBlockNearAnActiveSiegeBanner(event.getBlock())) {
 			event.setCancelled(true);
@@ -65,7 +68,7 @@ public class SiegeWarActionListener implements Listener {
 	/*
 	 * SW can affect the emptying of buckets, which could affect a banner.
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onBucketUse(TownyBuildEvent event) {
 		if(SiegeWarSettings.getWarSiegeEnabled() 
 				&& !event.isCancelled()

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -201,7 +201,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 			&& (event.getCause() == TeleportCause.PLUGIN || event.getCause() == TeleportCause.COMMAND);
 	}
 
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void on(PlayerJoinEvent event) {
 		if (isSWEnabledAndIsThisAWarAllowedWorld(event.getPlayer().getWorld())) {
 			Siege activeSiegeAtPlayerLocation = SiegeController.getActiveSiegeAtLocation(event.getPlayer().getLocation());
@@ -223,7 +223,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 		}
 	}
 
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onPlayerQuit(PlayerQuitEvent event) {
 		if(!isSWEnabledAndIsThisAWarAllowedWorld(event.getPlayer().getWorld()))
 			return;
@@ -236,7 +236,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 	}
 
 	//Stops TNT/Minecarts from destroying blocks in the siegezone wilderness
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void on(EntityExplodeEvent event) {
 		if(isSWEnabledAndIsThisAWarAllowedWorld(event.getEntity().getWorld())
 				&& !event.isCancelled()
@@ -314,7 +314,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 	 * 
 	 * @param event the player command preprocess event 
 	 */
-	@EventHandler
+	@EventHandler (ignoreCancelled = true)
 	public void onCommand(PlayerCommandPreprocessEvent event){
 		if(!SiegeWarSettings.getWarSiegeEnabled() || !SiegeWarSettings.isToxicityReductionEnabled())
 			return;

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -141,7 +141,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 	/*
 	 * SW can affect whether an inventory is dropped and also can degrade an inventory.
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onPlayerDeath(PlayerDeathEvent event) {
 		//Check for siege-war related death effects
 		if(isSWEnabledAndIsThisAWarAllowedWorld(event.getEntity().getWorld())) {

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -32,7 +32,7 @@ import org.bukkit.event.Listener;
 public class SiegeWarNationEventListener implements Listener {
 
 
-	@EventHandler
+	@EventHandler (ignoreCancelled = true)
 	public void onNationRankGivenToPlayer(NationRankAddEvent event) {
 		//In Siegewar, if target town is peaceful or occupied, can't add military rank
 		if(SiegeWarSettings.getWarSiegeEnabled()
@@ -56,7 +56,7 @@ public class SiegeWarNationEventListener implements Listener {
 	/*
 	 * SiegeWar will disable nation-zones if the town has a siege.
 	 */
-	@EventHandler
+	@EventHandler (ignoreCancelled = true)
 	public void onNationZoneStatus(NationZoneTownBlockStatusEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled() 
 			&& SiegeController.hasActiveSiege(event.getTown()))	{
@@ -68,7 +68,7 @@ public class SiegeWarNationEventListener implements Listener {
 	 * A nation being deleted with a siege means the siege ends,
 	 * and a king may receive a refund.
 	 */
-	@EventHandler
+	@EventHandler (ignoreCancelled = true)
 	public void onDeleteNation(DeleteNationEvent event) {
 		if(!SiegeWarSettings.getWarSiegeEnabled())
 			return;
@@ -93,7 +93,7 @@ public class SiegeWarNationEventListener implements Listener {
 		}
 	}
 
-	@EventHandler
+	@EventHandler (ignoreCancelled = true)
 	public void onPreNationEnemyRemove(NationPreRemoveEnemyEvent event) {
 		if(!SiegeWarSettings.getWarSiegeEnabled())
 			return;
@@ -162,6 +162,7 @@ public class SiegeWarNationEventListener implements Listener {
 		}
 	}
 
+	@EventHandler(ignoreCancelled = true)
 	public void onNationChangeKingEvent(NationKingChangeEvent event) {
 		if(!SiegeWarSettings.getWarSiegeEnabled())
 			return;
@@ -183,7 +184,7 @@ public class SiegeWarNationEventListener implements Listener {
 	 *
 	 * @param event the nation town pre leave event
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onTownAttemptsToLeaveNation(NationPreTownLeaveEvent event) {
 		if(!SiegeWarSettings.getWarSiegeEnabled())
 			return;

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarPlotEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarPlotEventListener.java
@@ -20,7 +20,7 @@ public class SiegeWarPlotEventListener implements Listener {
 	 *
 	 * @param event the test event
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onTownBlockPVPTest(TownBlockPVPTestEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()
 		    && event.getTownBlock().getWorld().isWarAllowed()

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSafeModeListener.java
@@ -71,7 +71,7 @@ public class SiegeWarSafeModeListener implements Listener {
 		event.setCancelled(true);
 	}
 
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onShortTime(NewShortTimeEvent event) {
 		if (!plugin.isError())
 			return;

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSelfListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSelfListener.java
@@ -10,7 +10,7 @@ import com.palmergames.bukkit.towny.object.Translatable;
 
 public class SiegeWarSelfListener implements Listener {
 	
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onBattleSessionPreStart(BattleSessionPreStartEvent event) {
 		if (SiegeWarSettings.cancelBattleSessionWhenNoActiveSieges()
 		&& (SiegeController.getSieges().isEmpty() || SiegeController.getSieges().stream().noneMatch(siege -> siege.getStatus().isActive()))) {

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -47,7 +47,7 @@ public class SiegeWarStatusScreenListener implements Listener {
 	 * via the resident status screen. Components are clickable to
 	 * claim monies owed.
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onResidentStatusScreen(ResidentStatusScreenEvent event) {
 		int salary = ResidentMetaDataController.getMilitarySalaryAmount(event.getResident());
 		if (salary > 0) {
@@ -62,7 +62,7 @@ public class SiegeWarStatusScreenListener implements Listener {
 	/*
 	 * SiegeWar will add lines to Nation which have a siege
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onNationStatusScreen(NationStatusScreenEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			final Translator translator = Translator.locale(event.getCommandSender());
@@ -162,7 +162,7 @@ public class SiegeWarStatusScreenListener implements Listener {
 	/*
 	 * SiegeWar will add lines to towns which have a siege
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onTownStatusScreen(TownStatusScreenEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			final Translator translator = Translator.locale(event.getCommandSender());

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -46,7 +46,7 @@ public class SiegeWarTownEventListener implements Listener {
 		plugin = instance;
 	}
 
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onTownGoesToRuin(TownRuinedEvent event) {
 		//Remove siege if town has one
 		if (SiegeController.hasSiege(event.getTown()))
@@ -59,7 +59,7 @@ public class SiegeWarTownEventListener implements Listener {
 	/*
 	 * If town is under siege, town cannot recruit new members
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onTownAddResident(TownPreAddResidentEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled() && SiegeWarSettings.getWarSiegeBesiegedTownRecruitmentDisabled()) {
 
@@ -76,7 +76,7 @@ public class SiegeWarTownEventListener implements Listener {
 	 * The SW peacefulness setting may then get applied
 	 * Also the SW siege immunity time is set
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onCreateNewTown(NewTownEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			Town town = event.getTown();
@@ -93,7 +93,7 @@ public class SiegeWarTownEventListener implements Listener {
 	/*
 	 * Upon attempting to claim land, SW will stop it under some conditions.
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onTownClaim(TownPreClaimEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			if (SiegeWarSettings.getWarSiegeBesiegedTownClaimingDisabled()) {
@@ -133,7 +133,7 @@ public class SiegeWarTownEventListener implements Listener {
 	/*
 	 * Siege War will prevent unclaiming land in some situations.
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onTownUnclaim(TownPreUnclaimCmdEvent event) {
 		Translator translator = Translator.locale(event.getResident().getPlayer());
 		if (SiegeWarSettings.getWarCommonOccupiedTownUnClaimingDisabled() && TownOccupationController.isTownOccupied(event.getTown())) {
@@ -164,7 +164,7 @@ public class SiegeWarTownEventListener implements Listener {
 	 * this is preferred over the alternative scheme of keeping the qualified towns and releasing the disqualified towns.
 	 * 
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void on(TownPreSetHomeBlockEvent event) {
 		if (SiegeWarSettings.getWarSiegeEnabled()) {
 			Translator translator = Translator.locale(event.getPlayer());
@@ -197,13 +197,13 @@ public class SiegeWarTownEventListener implements Listener {
 	/*
 	 * A town being deleted with a siege means the siege ends.
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onDeleteTown(DeleteTownEvent event) {
 		if (SiegeController.hasSiege(event.getTownUUID()))
 			SiegeController.removeSiege(SiegeController.getSiegeByTownUUID(event.getTownUUID()));
 	}
 
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onTownMerge(TownPreMergeEvent event) {
 		if (SiegeController.hasSiege(event.getSuccumbingTown())) {
 			event.setCancelMessage(Translation.of("msg_err_cannot_merge_towns"));
@@ -234,7 +234,7 @@ public class SiegeWarTownEventListener implements Listener {
 	 *
 	 * @param event the pre-tax event
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onTownIsAboutToPayRegularTaxToNation(PreTownPaysNationTaxEvent event) {
 		if(!SiegeWarSettings.getWarSiegeEnabled())
 			return;
@@ -244,7 +244,7 @@ public class SiegeWarTownEventListener implements Listener {
 		}
 	}
 
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onTownRankGivenToPlayer(TownAddResidentRankEvent event) {
 		//In Siegewar, if target town is peaceful or occupied, can't add military rank
 		if(SiegeWarSettings.getWarSiegeEnabled()

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -78,7 +78,7 @@ public class SiegeWarTownyEventListener implements Listener {
 	   /*
      * Siegewar has to be conscious of when Towny has loaded the Towny database.
      */
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onTownyDatabaseLoad(TownyLoadedDatabaseEvent event) {
     	SiegeWar.info("Towny database reload detected, reloading sieges...");
         SiegeController.loadAll();
@@ -87,7 +87,7 @@ public class SiegeWarTownyEventListener implements Listener {
 	/*
 	 * When Towny is reloading the languages, make sure we're re-injecting our language strings. 
 	 */
-	@EventHandler
+	@EventHandler(ignoreCancelled = true)
 	public void onTownyLoadLanguages(TranslationLoadEvent event) {
 		Plugin plugin = SiegeWar.getSiegeWar();
 		Path langFolderPath = Paths.get(plugin.getDataFolder().getPath()).resolve("lang");
@@ -100,7 +100,7 @@ public class SiegeWarTownyEventListener implements Listener {
 				event.addTranslation(language, map.getKey(), map.getValue());
 	}
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onNewDay(NewDayEvent event) {
         if (SiegeWarSettings.getWarSiegeEnabled()) {
             if (SiegeWarSettings.isPlunderPaidOutOverDays()) {
@@ -120,7 +120,7 @@ public class SiegeWarTownyEventListener implements Listener {
     /*
      * On NewHours SW makes some calculations.
      */
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onNewHour(NewHourEvent event) {
         if(SiegeWarSettings.getWarSiegeEnabled()) {
             SiegeWarImmunityUtil.evaluateExpiredImmunities();
@@ -131,7 +131,7 @@ public class SiegeWarTownyEventListener implements Listener {
     /*
      * On each ShortTime period, SW makes some calcuations.
      */
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onShortTime(NewShortTimeEvent event) {
         if (SiegeWarSettings.getWarSiegeEnabled()) {
             SiegeWarNotificationUtil.sendSiegeZoneProximityWarnings();
@@ -151,7 +151,7 @@ public class SiegeWarTownyEventListener implements Listener {
      * @param event the TownyExplodingBlocksEvent event
      * @throws TownyException if something is misconfigured
      */
-    @EventHandler(priority = EventPriority.HIGH)
+    @EventHandler(priority = EventPriority.HIGH,ignoreCancelled = true)
     public void onBlockExploding(TownyExplodingBlocksEvent event) throws TownyException {
         if(!SiegeWarSettings.getWarSiegeEnabled())
             return;
@@ -255,7 +255,7 @@ public class SiegeWarTownyEventListener implements Listener {
      * Prevent an outlaw being teleported away if the town they are outlawed in has an active siege.
      * @param event OutlawTeleportEvent thrown by Towny.
      */
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onOutlawTeleportEvent(OutlawTeleportEvent event) {
         if (SiegeWarSettings.getWarSiegeEnabled() 
                 && event.getOutlawLocation() != null
@@ -271,7 +271,7 @@ public class SiegeWarTownyEventListener implements Listener {
      * undo the cancellation
      * @param event the event
      */
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void on (TownyFriendlyFireTestEvent event) {
     	if (!event.isPVP()
     	        && SiegeWarSettings.getWarSiegeEnabled() 
@@ -339,7 +339,7 @@ public class SiegeWarTownyEventListener implements Listener {
      * 
      * @param event the AsyncChatHook event from TownyChat
      */
-    @EventHandler()
+    @EventHandler(ignoreCancelled = true)
     public void on(AsyncChatHookEvent event) {
         if(!SiegeWarSettings.getWarSiegeEnabled() 
             || !SiegeWarSettings.isToxicityReductionEnabled()


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- In the current code, in many cases, if an event has been cancelled by another plugin, SiegeWar ignores the cancellation.
- For example, if another plugin cancelled the death event.....SW would still process the death and award kill-points.
- This is not good, we want SW to respect the actions of other plugins where possible.
- This PR resolves the issue by adding the missing ignoreCancelled=true tags.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
N/A

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #832

____
- [N/A] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
