### PR TITLE
Added logic to block HUD in folia

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -237,7 +237,7 @@ public class SiegeWar extends JavaPlugin {
 		return null; // Doesn't matter because SiegeWar will not pass the onEnable phase.
 	}
 
-	private static boolean isFoliaClassPresent() {
+	public static boolean isFoliaClassPresent() {
 		try {
 			Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
 			return true;

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -204,6 +204,9 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 
 	private void parseSiegeWarHudCommand(Player player, String[] args) {
 		try {
+			if(SiegeWar.isFoliaClassPresent()) {
+				throw new TownyException(Translatable.of("msg_err_hud_not_available_in_folia"));
+			}
 			if (args.length == 0) {
 				TownyMessaging.sendMessage(player, ChatTools.formatTitle("/siegewar hud"));
 				TownyMessaging.sendMessage(player, ChatTools.formatCommand("Eg", "/sw hud", "[town]", ""));

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -182,6 +182,7 @@ msg_war_siege_battle_session_break_cannot_get_banner_control: "&cBanner control 
 hud_siege_balance: 'Siege Balance: '
 hud_warchest: 'War Chest: '
 hud_battle_time_remaining: 'BAT Time Left: '
+msg_err_hud_not_available_in_folia: "&cThe HUD is not available in Folia."
 
 #Dynmap
 dynmap_siege_battle_time_left: 'Battle Time Left: %s'


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
- With current code there is an exception when trying to use the HUD with Folia
- As per the issue ticket, HUD's generally are not yet possible with Folia
- This PR adds logic to prevent HUD usage (with an error message) is folia is present

____
#### New Nodes/Commands/ConfigOptions: 
NA


____
#### Relevant Issue ticket:
Closes #857


____
- [NA too trivial] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
