### PR TITLE
SW-864 Lifted siegezone tp restriction except during Battle Sessions

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarBukkitEventListener.java
@@ -204,6 +204,7 @@ public class SiegeWarBukkitEventListener implements Listener {
 	private boolean siegeWarStopsNonResidentsTeleporting(PlayerTeleportEvent event) {
 		return SiegeWarSettings.getWarSiegeEnabled()
 			&& SiegeWarSettings.getWarSiegeNonResidentSpawnIntoSiegeZonesOrBesiegedTownsDisabled()
+			&& BattleSession.getBattleSession().isActive()
 			&& (event.getCause() == TeleportCause.PLUGIN || event.getCause() == TeleportCause.COMMAND);
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -82,11 +82,8 @@ public enum ConfigNodes {
 			"war.siege.switches.non_resident_spawn_into_siegezones_or_besieged_towns_disabled",
 			"true",
 			"",
-			"# If this setting is true, then only town residents are permitted to spawn into siegezones OR besieged towns.",
-			"# This setting is recommended to:",
-			"# 1. Protect players from accidentally spawning into a warzone while unprepared.",
-			"# 2. Discourage 'fake' sieges, by making the automatic siege impact harsher.",
-			"# 3. Even the spawn-advantage between attacking and defender."), 
+			"# If this setting is true, then during Battle Sessions, only town residents are permitted to spawn into Siege-Zones OR besieged towns.",
+			"# This setting is recommended to protect players from accidentally spawning into a PVP-active-area while unprepared."),
 	WAR_SIEGE_BESIEGED_TOWN_RECRUITMENT_DISABLED(
 			"war.siege.switches.besieged_town_recruitment_disabled",
 			"true",


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
- Issue discussed in #864 
- This PR fixes the issue by lifting the siegezone tp restriction, except during Battle Sessions

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
N/A

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #864

____
- [NA too trivial ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
