### PR TITLE
Fix messaging-related issues, webhooks, folia-related beacon exception, add BannerControlSessionEndedEvent

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarAdminCommand.java
@@ -617,7 +617,7 @@ public class SiegeWarAdminCommand implements TabExecutor {
 				case "remove":
 					//Remove siege from system
 					SiegeController.removeSiege(siege);
-					Messaging.sendGlobalMessage(Translatable.of("msg_swa_remove_siege"));
+					Messaging.sendGlobalMessage(Translatable.of("msg_swa_remove_siege", siege.getTown().getName()));
 					Messaging.sendMsg(sender, Translatable.of("msg_swa_remove_siege_success"));
 					return;
 			}

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -330,6 +330,11 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 	}
 
 	private void parseSiegeWarTownCommand(Player player, String[] args) {
+		if (args.length == 0) {
+			showSiegeWarHelp(player);
+			return;
+		}
+
 		if (!player.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_COMMAND_SIEGEWAR_TOWN.getNode(args[0]))) {
 			player.sendMessage(Translatable.of("msg_err_command_disable").forLocale(player));
 			return;

--- a/src/main/java/com/gmail/goosius/siegewar/events/BannerControlSessionEndedEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/BannerControlSessionEndedEvent.java
@@ -1,0 +1,32 @@
+package com.gmail.goosius.siegewar.events;
+
+import com.gmail.goosius.siegewar.objects.Siege;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class BannerControlSessionEndedEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final Siege siege;
+
+    public BannerControlSessionEndedEvent(Siege siege) {
+        super(!Bukkit.getServer().isPrimaryThread());
+        this.siege = siege;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public Siege getSiege() {
+        return siege;
+    }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/events/BattleSessionEndedEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/BattleSessionEndedEvent.java
@@ -1,6 +1,7 @@
 package com.gmail.goosius.siegewar.events;
 
 import com.palmergames.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import com.palmergames.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -27,6 +28,6 @@ public class BattleSessionEndedEvent extends Event {
 	}
 
 	public String getMessage() {
-		return LegacyComponentSerializer.legacySection().deserialize(message).content();
+		return PlainTextComponentSerializer.plainText().serialize(LegacyComponentSerializer.legacySection().deserialize(message));
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/events/BattleSessionStartedEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/BattleSessionStartedEvent.java
@@ -1,6 +1,7 @@
 package com.gmail.goosius.siegewar.events;
 
 import com.palmergames.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import com.palmergames.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -27,6 +28,6 @@ public class BattleSessionStartedEvent extends Event {
 	}
 
 	public String getMessage() {
-		return LegacyComponentSerializer.legacySection().deserialize(message).content();
+		return PlainTextComponentSerializer.plainText().serialize(LegacyComponentSerializer.legacySection().deserialize(message));
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/events/SiegeCampStartEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/SiegeCampStartEvent.java
@@ -3,6 +3,7 @@ import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.objects.SiegeCamp;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import com.palmergames.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownBlock;
@@ -72,6 +73,6 @@ public class SiegeCampStartEvent extends Event {
     }
 
     public String getMessage() {
-        return LegacyComponentSerializer.legacySection().deserialize(message).content();
+        return PlainTextComponentSerializer.plainText().serialize(LegacyComponentSerializer.legacySection().deserialize(message));
     }
 }

--- a/src/main/java/com/gmail/goosius/siegewar/events/SiegeRemoveEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/SiegeRemoveEvent.java
@@ -2,6 +2,7 @@ package com.gmail.goosius.siegewar.events;
 
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.palmergames.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import com.palmergames.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Translatable;
 import org.bukkit.Bukkit;
@@ -97,6 +98,6 @@ public class SiegeRemoveEvent extends Event {
     }
 
     public String getMessage() {
-        return LegacyComponentSerializer.legacySection().deserialize(Translatable.of("msg_swa_remove_siege", getBesiegedTownName()).defaultLocale()).content();
+        return PlainTextComponentSerializer.plainText().serialize(LegacyComponentSerializer.legacySection().deserialize(Translatable.of("msg_swa_remove_siege", getBesiegedTownName()).defaultLocale()));
     }
 }

--- a/src/main/java/com/gmail/goosius/siegewar/events/SiegeWarStartEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/SiegeWarStartEvent.java
@@ -2,6 +2,7 @@ package com.gmail.goosius.siegewar.events;
 
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.palmergames.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import com.palmergames.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import org.bukkit.block.Block;
@@ -65,6 +66,6 @@ public class SiegeWarStartEvent extends Event {
 	}
 
     public String getMessage() {
-        return LegacyComponentSerializer.legacySection().deserialize(message).content();
+        return PlainTextComponentSerializer.plainText().serialize(LegacyComponentSerializer.legacySection().deserialize(message));
     }
 }

--- a/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/objects/Siege.java
@@ -5,6 +5,7 @@ import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import com.palmergames.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Government;
 import com.palmergames.bukkit.towny.object.Resident;
@@ -429,7 +430,7 @@ public class Siege {
 	}
 
 	public String getEndMessage() {
-		return LegacyComponentSerializer.legacySection().deserialize(endMessage).content();
+		return PlainTextComponentSerializer.plainText().serialize(LegacyComponentSerializer.legacySection().deserialize(endMessage));
 	}
 
 	public void setEndMessage(String message) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
@@ -86,15 +86,16 @@ public class CosmeticUtil {
 	}
 
 	public static void removeFakeBeacon(Player player, Location loc) {
-		player.sendBlockChange(loc.clone().subtract(0, 1, 0), Bukkit.createBlockData(loc.clone().subtract(0, 1, 0).getBlock().getType()));
-		player.sendBlockChange(loc.clone().subtract(0, 2, 0), Bukkit.createBlockData(loc.clone().subtract(0, 2, 0).getBlock().getType()));
+		SiegeWar.getSiegeWar().getScheduler().runLater(player, () -> {
+			player.sendBlockChange(loc.clone().subtract(0, 1, 0), Bukkit.createBlockData(loc.clone().subtract(0, 1, 0).getBlock().getType()));
+			player.sendBlockChange(loc.clone().subtract(0, 2, 0), Bukkit.createBlockData(loc.clone().subtract(0, 2, 0).getBlock().getType()));
 
-		int[][] ironBlockLocations = {{1, 1}, {1, 0}, {1, -1}, {0, 1}, {0, 0}, {0, -1}, {-1, 1}, {-1, 0}, {-1, -1}};
-		for (int i = 0; i < 9; i++) {
-			player.sendBlockChange(loc.clone().add(ironBlockLocations[i][0], -3, ironBlockLocations[i][1]), Bukkit.createBlockData(loc.clone().add(ironBlockLocations[i][0], -3, ironBlockLocations[i][1]).getBlock().getType()));
-		}
-
-		SiegeWar.getSiegeWar().getScheduler().runLater(player, () -> changeBlocksBackToNormal(player,loc), 1l);
+			int[][] ironBlockLocations = {{1, 1}, {1, 0}, {1, -1}, {0, 1}, {0, 0}, {0, -1}, {-1, 1}, {-1, 0}, {-1, -1}};
+			for (int i = 0; i < 9; i++) {
+				player.sendBlockChange(loc.clone().add(ironBlockLocations[i][0], -3, ironBlockLocations[i][1]), Bukkit.createBlockData(loc.clone().add(ironBlockLocations[i][0], -3, ironBlockLocations[i][1]).getBlock().getType()));
+			}
+			changeBlocksBackToNormal(player,loc);
+		}, 1L);
 	}
 
 	private static void changeBlocksBackToNormal(Player player, Location loc) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DiscordWebhook.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DiscordWebhook.java
@@ -1,6 +1,7 @@
 package com.gmail.goosius.siegewar.utils;
 
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
+import com.palmergames.bukkit.towny.object.Translatable;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.awt.Color;
@@ -401,7 +402,7 @@ public class DiscordWebhook {
                 .setDescription(lines[0]);
         if (lines.length > 1)
             for (int i = 1; i < lines.length; i++) {
-                embed.addField("Battle", lines[i], true);
+                embed.addField(Translatable.of("msg_swa_battle").defaultLocale(), lines[i], true);
             }
         webhook.addEmbed(embed);
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DiscordWebhook.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DiscordWebhook.java
@@ -393,9 +393,6 @@ public class DiscordWebhook {
     }
 
     public static void sendWebhookNotification(Color color, String message, boolean active) {
-        if (!active)
-            return;
-
         DiscordWebhook webhook = new DiscordWebhook(SiegeWarSettings.getDiscordWebhookUrl());
 
         String[] lines = message.split("\n");
@@ -411,7 +408,8 @@ public class DiscordWebhook {
         try {
             webhook.execute();
         } catch (java.io.IOException e) {
-            e.printStackTrace();
+            if (active)
+                e.printStackTrace();
         }
     }
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DiscordWebhook.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DiscordWebhook.java
@@ -1,6 +1,5 @@
 package com.gmail.goosius.siegewar.utils;
 
-import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -394,17 +393,25 @@ public class DiscordWebhook {
     }
 
     public static void sendWebhookNotification(Color color, String message, boolean active) {
+        if (!active)
+            return;
+
         DiscordWebhook webhook = new DiscordWebhook(SiegeWarSettings.getDiscordWebhookUrl());
 
-        webhook.addEmbed(new DiscordWebhook.EmbedObject()
+        String[] lines = message.split("\n");
+        EmbedObject embed = new DiscordWebhook.EmbedObject()
                 .setColor(color)
-                .setDescription(message)
-        );
+                .setDescription(lines[0]);
+        if (lines.length > 1)
+            for (int i = 1; i < lines.length; i++) {
+                embed.addField("Battle", lines[i], true);
+            }
+        webhook.addEmbed(embed);
+
         try {
             webhook.execute();
         } catch (java.io.IOException e) {
-            if (active)
-                SiegeWar.getSiegeWar().getLogger().severe(Arrays.toString(e.getStackTrace()));
+            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/DiscordWebhook.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/DiscordWebhook.java
@@ -1,5 +1,6 @@
 package com.gmail.goosius.siegewar.utils;
 
+import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.object.Translatable;
 
@@ -410,7 +411,7 @@ public class DiscordWebhook {
             webhook.execute();
         } catch (java.io.IOException e) {
             if (active)
-                e.printStackTrace();
+                SiegeWar.getSiegeWar().getLogger().severe(Arrays.toString(e.getStackTrace()));
         }
     }
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -5,6 +5,7 @@ import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
+import com.gmail.goosius.siegewar.events.BannerControlSessionEndedEvent;
 import com.gmail.goosius.siegewar.objects.BannerControlSession;
 import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
@@ -270,6 +271,8 @@ public class SiegeWarBannerControlUtil {
 				SiegeWar.severe("Problem evaluating banner control session for player " + bannerControlSession.getPlayer().getName());
 			}
 		}
+
+		Bukkit.getPluginManager().callEvent(new BannerControlSessionEndedEvent(siege));
 	}
 
 	private static void evaluateBannerControlPoints(Siege siege) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -280,10 +280,8 @@ public class SiegeWarBattleSessionUtil {
 	 * with a brief summary of who won any battles which were fought
 	 */
 	private static Translatable getBattleSessionEndedMessageHeader(Map<Siege, Integer> battleResults) {
-		Translatable header;
-
 		//Compile message
-		if(battleResults.size() == 0) {
+		if(battleResults.isEmpty()) {
 			return Translatable.of("msg_war_siege_battle_session_ended_without_battles");
 		} else {
 			return Translatable.of("msg_war_siege_battle_session_ended_with_battles");

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -655,3 +655,4 @@ msg_err_cannot_spawn_not_in_homeblock: "&cYou must be in your town homeblock to 
 
 #Added in 2.8.0
 msg_swa_remove_siege: '&bSiege of %s removed via admin commands.'
+msg_swa_battle: 'Battle'


### PR DESCRIPTION
- show help if args length is 0 (would throw exception before)
- fix besieged town name not getting sent to ingame translatable on siege remove 
- fix session end webhook notification
  before if a session ended and it had battles there'd be an exception and no webhook notification but now it works
![image](https://github.com/TownyAdvanced/SiegeWar/assets/26354814/e70b3745-470a-4085-92aa-73b48559c9ea)

- return from send notification if not active
- strip formatting from event messages properly
- fix beacon exceptions on folia
- add BannerControlSessionEndedEvent

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
