### PR TITLE
Fix max-conquest-sieges-per nation being bypassed by Siege Assemblies.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/events/SiegeEndEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/SiegeEndEvent.java
@@ -6,7 +6,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * This event is triggered immediately after a siege ends

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeCampUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeCampUtil.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
+import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
 import com.gmail.goosius.siegewar.objects.SiegeCamp;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
@@ -90,6 +91,18 @@ public class SiegeCampUtil {
 	private static void finishSiegeCamp(SiegeCamp camp) {
 
 		if (camp.getAttackerPoints() >= SiegeWarSettings.getSiegeCampPointsForSuccess()) {
+
+			Nation attackingNation = null;
+			if (camp.getAttacker() instanceof Nation)
+				attackingNation = (Nation) camp.getAttacker();
+
+			// Check to make sure the nation would not have too many active conquest sieges.
+			if (camp.getSiegeType().equals(SiegeType.CONQUEST)
+				&& attackingNation != null && SiegeWarSettings.doesThisNationHaveTooManyActiveSieges(attackingNation)) {
+				TownyMessaging.sendPrefixedNationMessage(attackingNation, Translatable.of("msg_err_siege_war_nation_has_too_many_active_siege_attacks"));
+				return;
+			}
+
 			// Attackers scored enough points to start the Siege in ernest.
 			camp.startSiege();
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleCommanderUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleCommanderUtil.java
@@ -11,8 +11,6 @@ import com.palmergames.bukkit.towny.object.Translation;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
-import java.util.Locale;
-
 public class SiegeWarBattleCommanderUtil {
     
     /**


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

Rechecks that the nation does not have too many active Conquest sieges
when a SiegeAssembly finishes.

Removes unused 2 imports.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes https://github.com/TownyAdvanced/SiegeWar/issues/886.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
