### PR TITLE
Make it possible to show the time to the next BattleSession from more than 1 day in advance.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -390,14 +390,17 @@ public class SiegeWarSettings {
 	}
 
 	@Nullable
-	public static LocalDateTime getFirstBattleSessionStartTimeForTomorrowUtc() {
-		LocalDate tomorrow = LocalDate.now().plusDays(1);
-		List<LocalDateTime> allBattleSessionStartTimesForTomorrow = getAllBattleSessionStartTimesForDay(tomorrow); 
-		if(allBattleSessionStartTimesForTomorrow.size() != 0) {
-			return allBattleSessionStartTimesForTomorrow.get(0);
-		} else {
-			return null;
+	public static LocalDateTime getNextBattleSessionDaysInAdvance() {
+		LocalDateTime nextSession = null;
+		// Check the next 1-6 days for battle session start times. 
+		for (int i = 1 ; i < 7 ; i++) {
+			List<LocalDateTime> allBattleSessionStartTimesForDate = getAllBattleSessionStartTimesForDay(LocalDate.now().plusDays(i));
+			if (allBattleSessionStartTimesForDate.size() != 0) {
+				nextSession = allBattleSessionStartTimesForDate.get(0);
+				break;
+			}
 		}
+		return nextSession;
 	}
 
 	private static List<LocalDateTime> getAllBattleSessionStartTimesForDay(LocalDate day) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -350,9 +350,9 @@ public class SiegeWarBattleSessionUtil {
 			}
 		}
 
-		//If no configured-start-time was found, look for the first configured time for tomorrow
+		//If no configured-start-time was found, look for the first configured time for the rest of the week.
 		if(nextStartDateTime == null) {
-			nextStartDateTime = SiegeWarSettings.getFirstBattleSessionStartTimeForTomorrowUtc();
+			nextStartDateTime = SiegeWarSettings.getNextBattleSessionDaysInAdvance();
 		}
 
 		//If nextStartTime is still null, return null, else return the UTC time in millis of the given value.


### PR DESCRIPTION

<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->


Sessions might not be starting an extended period of time, this PR makes it possible for the code to look more than 1 day in advance when it cannot otherwise find a next session for the day.

It will look up to 6 days away, since we don't want to look at the current day of the week.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
