### PR TITLE
Configurable banner capture/control session radius

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -361,7 +361,8 @@ public enum ConfigNodes {
 			"",
 			"# The radius of the 'banner control'.",
 			"# This radius applies both horizontally and vertically, so players must be within radius on Y, and within radius horizontally.",
-			"# Players will begin a banner control session when inside this radius."),
+			"# Players will begin a banner control session when inside this radius.",
+			"# This radius also applies to siege camps."),
 	WAR_SIEGE_POINTS_BALANCING(
 			"war.siege.points_balancing",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -357,12 +357,13 @@ public enum ConfigNodes {
 			"# Various siege related effects can apply in this zone e.g. lose points on death, cannot TP in, cannot claim."),
 	WAR_SIEGE_BANNER_CONTROL_SESSION_RADIUS_BLOCKS(
 			"war.siege.distances.banner_control_session_radius_blocks",
-			"16",
+			"-1",
 			"",
 			"# The radius of the 'banner control'.",
 			"# This radius applies both horizontally and vertically, so players must be within radius on Y, and within radius horizontally.",
 			"# Players will begin a banner control session when inside this radius.",
-			"# This radius also applies to siege camps."),
+			"# This radius also applies to siege camps.",
+			"# Setting this value to below '0' will use the size of a Town Block as the radius."),
 	WAR_SIEGE_POINTS_BALANCING(
 			"war.siege.points_balancing",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -355,6 +355,13 @@ public enum ConfigNodes {
 			"# The radius of the 'siege zone'.",
 			"# This radius applies only horizontally, so players can never get above a siegezone (e.g. to place lava there or something).",
 			"# Various siege related effects can apply in this zone e.g. lose points on death, cannot TP in, cannot claim."),
+	WAR_SIEGE_BANNER_CONTROL_SESSION_RADIUS_BLOCKS(
+			"war.siege.distances.banner_control_session_radius_blocks",
+			"16",
+			"",
+			"# The radius of the 'banner control'.",
+			"# This radius applies both horizontally and vertically, so players must be within radius on Y, and within radius horizontally.",
+			"# Players will begin a banner control session when inside this radius."),
 	WAR_SIEGE_POINTS_BALANCING(
 			"war.siege.points_balancing",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import com.gmail.goosius.siegewar.SiegeController;
+import com.palmergames.bukkit.towny.TownySettings;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.util.TimeMgmt;
 import org.bukkit.Material;
@@ -128,7 +129,8 @@ public class SiegeWarSettings {
 	}
 
 	public static int getWarSiegeBannerControlSessionRadiusBlocks() {
-		return Settings.getInt(ConfigNodes.WAR_SIEGE_BANNER_CONTROL_SESSION_RADIUS_BLOCKS);
+		int radius = Settings.getInt(ConfigNodes.WAR_SIEGE_BANNER_CONTROL_SESSION_RADIUS_BLOCKS);
+		return radius < 0 ? TownySettings.getTownBlockSize() : radius;
 	}
 
 	public static boolean getWarSiegeNonResidentSpawnIntoSiegeZonesOrBesiegedTownsDisabled() {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -127,6 +127,10 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_ZONE_RADIUS_BLOCKS);
 	}
 
+	public static int getWarSiegeBannerControlSessionRadiusBlocks() {
+		return Settings.getInt(ConfigNodes.WAR_SIEGE_BANNER_CONTROL_SESSION_RADIUS_BLOCKS);
+	}
+
 	public static boolean getWarSiegeNonResidentSpawnIntoSiegeZonesOrBesiegedTownsDisabled() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_NON_RESIDENT_SPAWN_INTO_SIEGE_ZONES_OR_BESIEGED_TOWNS_DISABLED);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -106,7 +106,7 @@ public class SiegeWarBannerControlUtil {
 		String messageKey = SiegeWarSettings.isWildernessTrapWarfareMitigationEnabled() ? "msg_siege_war_banner_control_session_started_with_altitude" : "msg_siege_war_banner_control_session_started";
 		Messaging.sendMsg(player,
 			Translatable.of(messageKey,
-			TownySettings.getTownBlockSize(),
+			SiegeWarSettings.getWarSiegeBannerControlSessionRadiusBlocks(),
 			sessionDurationText));
 
 		//Notify player in action bar

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarDistanceUtil.java
@@ -139,7 +139,7 @@ public class SiegeWarDistanceUtil {
 	}
 
 	public static boolean isInTimedPointZone(Location location, Siege siege) {
-		return areLocationsClose(location, siege.getFlagLocation(), TownySettings.getTownBlockSize());
+		return areLocationsClose(location, siege.getFlagLocation(), SiegeWarSettings.getWarSiegeBannerControlSessionRadiusBlocks());
 	}
 
 	public static boolean areTownsClose(Town town1, Town town2, int radiusTownblocks) {
@@ -237,7 +237,7 @@ public class SiegeWarDistanceUtil {
 	 * @param camp {@link SiegeCamp} to check against.
 	 */
 	public static boolean isInSiegeCampZone(Location location, SiegeCamp camp) {
-		return areLocationsClose(location, camp.getBannerBlock().getLocation(), TownySettings.getTownBlockSize());
+		return areLocationsClose(location, camp.getBannerBlock().getLocation(), SiegeWarSettings.getWarSiegeBannerControlSessionRadiusBlocks());
 	}
 
 	/**


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Allows the operator of the server to configure the distance the banner can be captured at, following the same rules for the radius as before.

Does not change default behaviour, negative values will default to Town Block size and default is -1 - This does mean that it cannot be "disabled" - setting it to 0 is theoretically possible to capture (this can be tested by tp to banner location with .0 added to each coordinate) but likely impossible in reality.  - This could easily be rectified by changing "0" to use Town Block Radius, and negative values to disabling it entirely (or simply returning that they are not in the zone as it would be impossible) - Felt this was not relevant, the intention is not to allow it to be disabled and this would realistically be a different configuration that fully disables the feature and checks.

Does not require changes to language files.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
New config option: `war.siege.distances.banner_control_session_radius_blocks` defaulting to `-1`

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
N/A

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [X] if you have tested this code on a server. --->
Tested against Paper 1.20.4 and Towny 0.100.2.0, no faults when tested with default, negative, zero and positive values, behaviour is as expected.

Not tested against other versions, Spigot or other forks as the changes are minimal.


By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
