### PR TITLE
Add option to punish defenders with inventory loss when they are losing by too many points.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>2.12.0</version>
+  <version>2.13.0</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeSide.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeSide.java
@@ -41,6 +41,18 @@ public enum SiegeSide {
 		return SiegeSide.NOBODY;
 	}
 
+	public static boolean isDefender(Siege siege, Player player) {
+		return getPlayerSiegeSide(siege, player).equals(SiegeSide.DEFENDERS);
+	}
+
+	public static boolean isAttacker(Siege siege, Player player) {
+		return getPlayerSiegeSide(siege, player).equals(SiegeSide.ATTACKERS);
+	}
+
+	public static boolean isNobody(Siege siege, Player player) {
+		return getPlayerSiegeSide(siege, player).equals(SiegeSide.NOBODY);
+	}
+
 	private static boolean isTownGuard(Player player, Town town) {
 		return town.hasResident(player)
 				&& player.hasPermission(SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS.getNode());

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -10,6 +10,7 @@ import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.tasks.SiegeWarTimerTaskController;
+import com.gmail.goosius.siegewar.utils.SiegeWarBattleSessionUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarBlockProtectionUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarBlockUtil;
 import com.gmail.goosius.siegewar.utils.SiegeWarDistanceUtil;
@@ -472,7 +473,8 @@ public class SiegeWarTownyEventListener implements Listener {
 				Siege siege = SiegeWarAPI.getActiveSiegeAtLocation(event.getLocation());
 				if (!SiegeSide.isDefender(siege, event.getPlayer()))
 					return;
-				if (siege.getSiegeBalance() > SiegeWarSettings.getDefendersDropInventoryWhenLosingThreshold())
+				if (SiegeWarBattleSessionUtil.getSiegeBalanceIfSessionEndedNow(siege)
+					< SiegeWarSettings.getDefendersDropInventoryWhenLosingThreshold())
 					return;
 
 				event.setCancelled(true);
@@ -487,7 +489,7 @@ public class SiegeWarTownyEventListener implements Listener {
 			// But we don't want defenders that are losing too greatly to keep their inventories.
 			if (SiegeWarSettings.isDefendersDropInventoryWhenLosingEnabled()
 				&& SiegeSide.isDefender(siege, event.getPlayer())
-				&& siege.getSiegeBalance() <= SiegeWarSettings.getDefendersDropInventoryWhenLosingThreshold())
+				&& SiegeWarBattleSessionUtil.getSiegeBalanceIfSessionEndedNow(siege) >= SiegeWarSettings.getDefendersDropInventoryWhenLosingThreshold())
 				return;
 
 			SiegeWarInventoryUtil.degradeInventory(event.getPlayer());

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -969,7 +969,7 @@ public enum ConfigNodes {
 			"keep_inventory_on_siegezone_death.disable_for_defenders.enable",
 			"false",
 			"",
-			"# This feature, when enabled, will cause defenders to not keep their inventory if the Siege point balance is too far negative.",
+			"# This feature, when enabled, will cause defenders to not keep their inventory if the Siege point balance is too far positive.",
 			"# ie: They defenders are losing by a great number."),
 	KEEP_INVENTORY_ON_SIEGEZONE_DEATH_DISABLE_FOR_DEFENDERS_THRESHOLD(
 			"keep_inventory_on_siegezone_death.disable_for_defenders.threshold",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -973,9 +973,9 @@ public enum ConfigNodes {
 			"# ie: They defenders are losing by a great number."),
 	KEEP_INVENTORY_ON_SIEGEZONE_DEATH_DISABLE_FOR_DEFENDERS_THRESHOLD(
 			"keep_inventory_on_siegezone_death.disable_for_defenders.threshold",
-			"-500",
+			"500",
 			"",
-			"# The threshold required to cause defenders to lose their inventory. If the Siege point balance is equal to or lower than this number",
+			"# The threshold required to cause defenders to lose their inventory. If the Siege point balance is equal to or greater than this number",
 			"# and disable_for_defenders is enabled, defenders will not keep their inventories."),
 
 	SPECIAL_VICTORY_EFFECTS(

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -963,6 +963,21 @@ public enum ConfigNodes {
 			"# The percentage by which a player's tools (including swords & armour) degrade when they die.",
 			"# TIP: If this is set too high, new / casual / prone-to-dying players will be effectively excluded from sieges.",
 			"# The default value is 5.0"),
+	KEEP_INVENTORY_ON_SIEGEZONE_DEATH_DISABLE_FOR_DEFENDERS_ROOT(
+			"keep_inventory_on_siegezone_death.disable_for_defenders","","",""),
+	KEEP_INVENTORY_ON_SIEGEZONE_DEATH_DISABLE_FOR_DEFENDERS_ENABLE(
+			"keep_inventory_on_siegezone_death.disable_for_defenders.enable",
+			"false",
+			"",
+			"# This feature, when enabled, will cause defenders to not keep their inventory if the Siege point balance is too far negative.",
+			"# ie: They defenders are losing by a great number."),
+	KEEP_INVENTORY_ON_SIEGEZONE_DEATH_DISABLE_FOR_DEFENDERS_THRESHOLD(
+			"keep_inventory_on_siegezone_death.disable_for_defenders.threshold",
+			"-500",
+			"",
+			"# The threshold required to cause defenders to lose their inventory. If the Siege point balance is equal to or lower than this number",
+			"# and disable_for_defenders is enabled, defenders will not keep their inventories."),
+
 	SPECIAL_VICTORY_EFFECTS(
 			"special_victory_effects",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -524,6 +524,14 @@ public class SiegeWarSettings {
 		return Settings.getDouble(ConfigNodes.KEEP_INVENTORY_ON_SIEGEZONE_DEATH_TOOL_DEGRADE_PERCENTAGE);
 	}
 
+	public static boolean isDefendersDropInventoryWhenLosingEnabled() {
+		return Settings.getBoolean(ConfigNodes.KEEP_INVENTORY_ON_SIEGEZONE_DEATH_DISABLE_FOR_DEFENDERS_ENABLE);
+	}
+
+	public static int getDefendersDropInventoryWhenLosingThreshold() {
+		return Settings.getInt(ConfigNodes.KEEP_INVENTORY_ON_SIEGEZONE_DEATH_DISABLE_FOR_DEFENDERS_THRESHOLD);
+	}
+
 	public static int getSpecialVictoryEffectsDecisiveVictoryThreshold() {
 		return Settings.getInt(ConfigNodes.SPECIAL_VICTORY_EFFECTS_DECISIVE_VICTORY_THRESHOLD);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -189,6 +189,15 @@ public class SiegeWarBattleSessionUtil {
 		Messaging.sendGlobalMessage(Translatable.of("msg_attackers_have_triggered_a_jail_break_freeing", StringMgmt.join(freedNames, ", ")));
 	}
 
+	public static int getSiegeBalanceIfSessionEndedNow(Siege siege) {
+		int siegeBalanceAdjustment = calculateSiegeBalanceAdjustment(siege);
+		int futureBalance = siege.getSiegeBalance() + siegeBalanceAdjustment;
+		if(SiegeWarSettings.getSiegeBalanceCapValue() != -1) {
+			futureBalance = Math.min(futureBalance, SiegeWarSettings.getSiegeBalanceCapValue());
+		}
+		return futureBalance;
+	}
+
 	public static void evaluateBattleSessions() {
 		BattleSession battleSession = BattleSession.getBattleSession();
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

```
  - keep_inventory_on_siegezone_death.disable_for_defenders.enable
    - Default: false
    - This feature, when enabled, will cause defenders to not keep their inventory if the Siege point balance is too far positive.
    - ie: They defenders are losing by a great number.
  - keep_inventory_on_siegezone_death.disable_for_defenders.threshold
    - Default: 500
    - The threshold required to cause defenders to lose their inventory. If the Siege point balance is equal to or greater than this number
      and disable_for_defenders is enabled, defenders will not keep their inventories.
```
____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #919 

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
