### PR TITLE
Add Option to force players to either Plunder or Invade a Town

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -124,6 +124,9 @@ public class InvadeTown {
 		if (siege.isTownInvaded())
 			throw new TownyException(translator.of("msg_err_town_already_invaded"));
 
+		if (SiegeWarSettings.isOnlyOneActionEnabled() && siege.isTownPlundered())
+			throw new TownyException(translator.of("msg_err_town_already_plundered_only_one_action"));
+
 		SiegeWarDistanceUtil.throwIfTownIsTooFarFromNationCapitalByWorld(residentsNation, targetTown);
 
 		SiegeWarDistanceUtil.throwIfTownIsTooFarFromNationCapitalByDistance(residentsNation, targetTown);

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
@@ -67,6 +67,9 @@ public class PlunderTown {
 		if(siege.isTownPlundered())
 			throw new TownyException(translator.of("msg_err_siege_war_town_already_plundered", townToBePlundered.getName()));
 
+		if (SiegeWarSettings.isOnlyOneActionEnabled() && siege.isTownInvaded())
+			throw new TownyException(translator.of("msg_err_town_already_invaded_only_one_action"));
+
 		// If the rebels won, plunder is not possible
 		if(siege.isRevoltSiege() && siege.getStatus().defendersWon())
 			throw new TownyException(translator.of("msg_err_siege_war_plunder_not_possible_rebels_won"));

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -141,7 +141,7 @@ public enum ConfigNodes {
 			"war.siege.switches.only_one_action_enabled",
 			"false",
 			"",
-			"# If true, players can only either siege or plunder a town, not both.",
+			"# If true, players can only either invade or plunder a town, not both.",
 			"# If false, players can perform both actions."
 	),
 

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -137,6 +137,14 @@ public enum ConfigNodes {
 			"",
 			"# When true, players will have a glowing effect."),
 
+	WAR_SIEGE_ONLY_ONE_ACTION_ENABLED(
+			"war.siege.switches.only_one_action_enabled",
+			"false",
+			"",
+			"# If true, players can only either siege or plunder a town, not both.",
+			"# If false, players can perform both actions."
+	),
+
 	WAR_SIEGE_MONEY(
 			"war.siege.money",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -512,6 +512,11 @@ public class SiegeWarSettings {
 	public static boolean isGlowingEnabled() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_GLOWING);
 	}
+
+	public static boolean isOnlyOneActionEnabled() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_ONLY_ONE_ACTION_ENABLED);
+	}
+
 	public static double getWarSiegeNationCostRefundPercentageOnDelete() {
 		return Settings.getDouble(ConfigNodes.WAR_SIEGE_NATION_COST_REFUND_PERCENTAGE_ON_DELETE);
 	}

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -709,3 +709,10 @@ msg_err_you_arent_able_to_abandon_or_surrender_this_siege: "You do not have the 
 msg_err_cannot_change_capital_because_peaceful: "&cYou cannot change the capital of the nation, because the new capital is peaceful."
 msg_err_your_town_cannot_be_peaceful_while_a_capital_city: "&cYour town could not change to peaceful because capital cities are not allowed to be peaceful."
 msg_err_cannot_start_siege_as_a_peaceful_town: "&cYou cannot begin a siege, because your town is peaceful."
+
+#Added in 2.13.0
+
+# Only One Action
+
+msg_err_town_already_plundered_only_one_action: "&cYou cannot invade an already plundered nation."
+msg_err_town_already_invaded_only_one_action: "&cYou cannot plunder an already invaded nation."


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This pull request aims to add an option to force players to either plunder or invade a nation. This is due to a possible exploit to plunder a nation and then invade them and tax them tons.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

```
New Config Option: war.siege.switches.only_one_action_enabled
  - Default: false
  - If true, players can only either invade or plunder a town, not both.
  - If false, players can perform both actions.
```

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #922

____
- [x] I have tested this pull request for defects on a server.
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
