### PR TITLE
Add configurable cost to remain peaceful.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownyEventListener.java
@@ -117,6 +117,9 @@ public class SiegeWarTownyEventListener implements Listener {
             }
             SiegeWarNationUtil.updateNationDemoralizationCounters();
             SiegeWarMoneyUtil.calculateEstimatedTotalMoneyInEconomy(false);
+            if (SiegeWarSettings.getTownPeacefulnessCost() > 0.0) {
+                SiegeWarTownPeacefulnessUtil.chargeForPeacefulTowns();
+            }
         }
     }
 

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -228,6 +228,14 @@ public enum ConfigNodes {
 			"# The value specifies what proportion of the initial nation cost is refunded, when the nation is deleted or defeated.",
 			"# This feature supports nations which actively participate in geopolitics but are ultimately defeated by stronger opponents.",
 			"# Set to 0.0 to disable"),
+	WAR_SIEGE_TOWN_PEACEFULNESS_COST(
+			"war.siege.money.town_peacefulness_daily_cost",
+			"0.0",
+			"",
+			"# The cost that a town must pay to remain peaceful. Disabled when set to 0.0.",
+			"# This cost is paid after a town pays their upkeep and has their days-to-peaceful-change counted.",
+			"# If a town cannot pay the peaceful cost after they have their peaceful setting changed back to false."),
+	
 	WAR_SIEGE_QUANTITIES(
 			"war.siege.quantities",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -516,6 +516,10 @@ public class SiegeWarSettings {
 		return Settings.getDouble(ConfigNodes.WAR_SIEGE_NATION_COST_REFUND_PERCENTAGE_ON_DELETE);
 	}
 
+	public static double getTownPeacefulnessCost() {
+		return Settings.getDouble(ConfigNodes.WAR_SIEGE_TOWN_PEACEFULNESS_COST);
+	}
+
 	public static boolean isKeepInventoryOnSiegeZoneDeathEnabled() {
 		return Settings.getBoolean(ConfigNodes.KEEP_INVENTORY_ON_SIEGEZONE_DEATH_ENABLED);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarTownPeacefulnessUtil.java
@@ -215,4 +215,25 @@ public class SiegeWarTownPeacefulnessUtil {
 		return numPeacefulTownsReleased;
 	}
 
+	public static void chargeForPeacefulTowns() {
+		double townPeacefulnessCost = SiegeWarSettings.getTownPeacefulnessCost();
+		if (townPeacefulnessCost <= 0.0)
+			return;
+		TownyAPI.getInstance().getTowns().stream()
+			.filter(SiegeWarTownPeacefulnessUtil::isTownPeaceful)
+			.filter(SiegeWarTownPeacefulnessUtil::cannotAffordPeacefulNess)
+			.forEach(SiegeWarTownPeacefulnessUtil::removePeacefulness);
+
+		TownyAPI.getInstance().getTowns().stream()
+			.filter(SiegeWarTownPeacefulnessUtil::isTownPeaceful)
+			.forEach(t-> t.getAccount().withdraw(townPeacefulnessCost, "Daily SiegeWar peaceful cost."));
+	}
+
+	private static boolean cannotAffordPeacefulNess(Town town) {
+		return !town.getAccount().canPayFromHoldings(SiegeWarSettings.getTownPeacefulnessCost());
+	}
+
+	private static void removePeacefulness(Town town) {
+		setTownPeacefulness(town, false);
+	}
 }


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```
	WAR_SIEGE_TOWN_PEACEFULNESS_COST(
			"war.siege.money.town_peacefulness_daily_cost",
			"0.0",
			"",
			"# The cost that a town must pay to remain peaceful. Disabled when set to 0.0.",
			"# This cost is paid after a town pays their upkeep and has their days-to-peaceful-change counted.",
			"# If a town cannot pay the peaceful cost after they have their peaceful setting changed back to false."),
```

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->

Closes #931.
____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
