### PR TITLE
Add option for mayors of peaceful towns to be able to assign military ranks.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarNationEventListener.java
@@ -34,6 +34,9 @@ public class SiegeWarNationEventListener implements Listener {
 
 	@EventHandler (ignoreCancelled = true)
 	public void onNationRankGivenToPlayer(NationRankAddEvent event) {
+		if (!SiegeWarSettings.arePeacefulTownsNotAllowedToAssignMilitaryRanks())
+			return;
+
 		//In Siegewar, if target town is peaceful or occupied, can't add military rank
 		if(SiegeWarSettings.getWarSiegeEnabled()
 				&& PermissionUtil.doesNationRankAllowPermissionNode(event.getRank(), SiegeWarPermissionNodes.SIEGEWAR_NATION_SIEGE_BATTLE_POINTS)) {

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarTownEventListener.java
@@ -252,6 +252,9 @@ public class SiegeWarTownEventListener implements Listener {
 
 	@EventHandler(ignoreCancelled = true)
 	public void onTownRankGivenToPlayer(TownAddResidentRankEvent event) {
+		if (!SiegeWarSettings.arePeacefulTownsNotAllowedToAssignMilitaryRanks())
+			return;
+
 		//In Siegewar, if target town is peaceful or occupied, can't add military rank
 		if(SiegeWarSettings.getWarSiegeEnabled()
 				&& PermissionUtil.doesTownRankAllowPermissionNode(event.getRank(), SiegeWarPermissionNodes.SIEGEWAR_TOWN_SIEGE_BATTLE_POINTS)) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -627,6 +627,13 @@ public enum ConfigNodes {
 			"",
 			"# Given any peaceful town, the largest-by-townblock, non-peaceful, non-sieged town, in this radius around the homeblock, is considered to be the guardian town.",
 			"# If a nation owns the guardian town, that nation can instantly subvert & occupy the peaceful town"),
+	PEACEFUL_TOWNS_CANNOT_ASSIGN_MILITARY_RANKS(
+			"peaceful_towns.cannot_assign_military_ranks",
+			"true",
+			"",
+			"# Prevents players in peaceful towns from being given ranks with military-rank-permission nodes.",
+			"# It is not recommended to set this to false."),
+
 	OCCUPIED_TOWNS(
 			"occupied_towns",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -267,6 +267,10 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.PEACEFUL_TOWNS_GUARDIAN_TOWN_SEARCH_RADIUS);
 	}
 
+	public static boolean arePeacefulTownsNotAllowedToAssignMilitaryRanks() {
+		return Settings.getBoolean(ConfigNodes.PEACEFUL_TOWNS_CANNOT_ASSIGN_MILITARY_RANKS);
+	}
+
 	public static int getWarCommonPeacefulTownsNewTownConfirmationRequirementDays() {
 		return Settings.getInt(ConfigNodes.PEACEFUL_TOWNS_NEW_TOWN_CONFIRMATION_REQUIREMENT_DAYS);
 	}


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->

```
  - peaceful_towns.cannot_assign_military_ranks
    - Default: true
    - Prevents players in peaceful towns from being given ranks with military-rank-permission nodes.
    - It is not recommended to set this to false.
```

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


Closes #933.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
