### PR TITLE
applySiegeEndLoreToBannerState on correct thread

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarLoreListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarLoreListener.java
@@ -1,5 +1,6 @@
 package com.gmail.goosius.siegewar.listeners;
 
+import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.events.PreSiegeCampEvent;
 import com.gmail.goosius.siegewar.events.SiegeEndEvent;
 import com.gmail.goosius.siegewar.events.SiegeWarStartEvent;
@@ -45,7 +46,7 @@ public class SiegeWarLoreListener implements Listener {
         if (!SiegeWarSettings.isSiegeLoreEnabled()) return;
 
         //Set outcome, winner, points, end time
-        SiegeWarLoreUtil.applySiegeEndLoreToBannerState(event.getSiege());
+        SiegeWar.getSiegeWar().getScheduler().run(event.getSiege().getFlagLocation(), () -> SiegeWarLoreUtil.applySiegeEndLoreToBannerState(event.getSiege()));
     }
 
     @EventHandler


### PR DESCRIPTION
on-behalf-of: @mvndi <marroq@marroq.xyz>

This fixes an exception that happens on folia when a siege ends
```
[04:02:05] [Folia Async Scheduler Thread #6/ERROR]: [ca.spottedleaf.moonrise.common.util.TickThread] Thread Folia Async Scheduler Thread #6 failed main thread check: Cannot read world asynchronously
java.lang.Throwable: null
	at ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(TickThread.java:37) ~[parchment-1.21.3.jar:1.21.3-DEV-0249f75]
	at org.bukkit.craftbukkit.block.CraftBlock.getNMS(CraftBlock.java:80) ~[parchment-1.21.3.jar:1.21.3-DEV-0249f75]
	at org.bukkit.craftbukkit.block.CraftBlockStates.getBlockState(CraftBlockStates.java:249) ~[parchment-1.21.3.jar:1.21.3-DEV-0249f75]
	at org.bukkit.craftbukkit.block.CraftBlockStates.getBlockState(CraftBlockStates.java:241) ~[parchment-1.21.3.jar:1.21.3-DEV-0249f75]
	at org.bukkit.craftbukkit.block.CraftBlock.getState(CraftBlock.java:349) ~[parchment-1.21.3.jar:1.21.3-DEV-0249f75]
	at SiegeWar-2.14.2.jar/com.gmail.goosius.siegewar.utils.SiegeWarLoreUtil.applySiegeEndLoreToBannerState(SiegeWarLoreUtil.java:385) ~[SiegeWar-2.14.2.jar:?]
	at SiegeWar-2.14.2.jar/com.gmail.goosius.siegewar.listeners.SiegeWarLoreListener.onSiegeEnd(SiegeWarLoreListener.java:48) ~[SiegeWar-2.14.2.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor233.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[parchment-1.21.3.jar:1.21.3-DEV-0249f75]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[parchment-1.21.3.jar:1.21.3-DEV-0249f75]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at SiegeWar-2.14.2.jar/com.gmail.goosius.siegewar.utils.SiegeWarSiegeCompletionUtil.setCommonSiegeCompletionValues(SiegeWarSiegeCompletionUtil.java:42) ~[SiegeWar-2.14.2.jar:?]
	at SiegeWar-2.14.2.jar/com.gmail.goosius.siegewar.timeractions.AttackerWin.attackerWin(AttackerWin.java:23) ~[SiegeWar-2.14.2.jar:?]
	at SiegeWar-2.14.2.jar/com.gmail.goosius.siegewar.timeractions.AttackerTimedWin.attackerTimedWin(AttackerTimedWin.java:28) ~[SiegeWar-2.14.2.jar:?]
	at MvndiTowny-1.0-SNAPSHOT.jar/net.mvndicraft.mvnditowny.listeners.WarzoneChunkListener.onBattleSessionEnd(WarzoneChunkListener.java:136) ~[MvndiTowny-1.0-SNAPSHOT.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor449.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[parchment-1.21.3.jar:1.21.3-DEV-0249f75]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[parchment-1.21.3.jar:1.21.3-DEV-0249f75]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at SiegeWar-2.14.2.jar/com.gmail.goosius.siegewar.utils.SiegeWarBannerControlUtil.evaluateExistingBannerControlSessions(SiegeWarBannerControlUtil.java:277) ~[SiegeWar-2.14.2.jar:?]
	at SiegeWar-2.14.2.jar/com.gmail.goosius.siegewar.utils.SiegeWarBannerControlUtil.evaluateBannerControl(SiegeWarBannerControlUtil.java:43) ~[SiegeWar-2.14.2.jar:?]
	at SiegeWar-2.14.2.jar/com.gmail.goosius.siegewar.tasks.SiegeWarTimerTaskController.evaluateBannerControl(SiegeWarTimerTaskController.java:80) ~[SiegeWar-2.14.2.jar:?]
	at SiegeWar-2.14.2.jar/com.gmail.goosius.siegewar.listeners.SiegeWarTownyEventListener.onShortTime(SiegeWarTownyEventListener.java:147) ~[SiegeWar-2.14.2.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor193.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[parchment-1.21.3.jar:1.21.3-DEV-0249f75]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[parchment-1.21.3.jar:1.21.3-DEV-0249f75]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[parchment-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at Towny-0.101.0.0.jar/com.palmergames.bukkit.util.BukkitTools.fireEvent(BukkitTools.java:378) ~[Towny-0.101.0.0.jar:?]
	at Towny-0.101.0.0.jar/com.palmergames.bukkit.towny.tasks.ShortTimerTask.run(ShortTimerTask.java:33) ~[Towny-0.101.0.0.jar:?]
	at Towny-0.101.0.0.jar/com.palmergames.bukkit.towny.scheduling.TaskScheduler.lambda$runAsyncRepeating$11(TaskScheduler.java:122) ~[Towny-0.101.0.0.jar:?]
	at Towny-0.101.0.0.jar/com.palmergames.bukkit.towny.scheduling.impl.FoliaTaskScheduler.lambda$runAsyncRepeating$8(FoliaTaskScheduler.java:145) ~[Towny-0.101.0.0.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaAsyncScheduler$AsyncScheduledTask.run(FoliaAsyncScheduler.java:217) ~[parchment-1.21.3.jar:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```

____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
