### PR TITLE
Add option to display beacons only when the battle session is active

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSelfListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarSelfListener.java
@@ -8,6 +8,7 @@ import com.gmail.goosius.siegewar.events.SiegeWarStartEvent;
 import com.gmail.goosius.siegewar.events.SiegeEndEvent;
 import com.gmail.goosius.siegewar.events.SiegeRemoveEvent;
 import com.gmail.goosius.siegewar.objects.Siege;
+import com.gmail.goosius.siegewar.utils.CosmeticUtil;
 import com.gmail.goosius.siegewar.utils.DiscordWebhook;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -39,6 +40,9 @@ public class SiegeWarSelfListener implements Listener {
 
 	@EventHandler
 	public void onBattleSessionEnded(BattleSessionEndedEvent event) {
+		if (SiegeWarSettings.getBeaconsBattleSessionOnly())
+			SiegeController.getSieges().forEach((siege) -> CosmeticUtil.removeFakeBeacons(siege));
+
 		if (!SiegeWarSettings.isDiscordWebhookEnabled() || !SiegeWarSettings.isSessionEndNotificationEnabled())
 			return;
 

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -713,6 +713,11 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# If enabled, client-side beacons will be shown for players at the siege banner while they are in a siege zone."),
+	BEACON_MARKERS_BATTLE_SESSION_ONLY(
+			"beacon_markers.battle_session_only",
+			"false",
+			"",
+			"# If enabled, client-side beacons will only be shown for players when there is an active battle session."),
 	BEACON_MARKERS_CAPTURE_COLOR(
 			"beacon_markers.capture_color",
 			"yellow",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -299,7 +299,8 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.BEACON_MARKERS_ENABLED);
 	}
 
-	public static boolean getBeaconsBattleSesionOnly() {
+	public static boolean getBeaconsBattleSessionOnly() {
+
 		return Settings.getBoolean(ConfigNodes.BEACON_MARKERS_BATTLE_SESSION_ONLY);
 	}
 

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -299,6 +299,10 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.BEACON_MARKERS_ENABLED);
 	}
 
+	public static boolean getBeaconsBattleSesionOnly() {
+		return Settings.getBoolean(ConfigNodes.BEACON_MARKERS_BATTLE_SESSION_ONLY);
+	}
+
 	public static String getBeaconCaptureColor() {
 		return Settings.getString(ConfigNodes.BEACON_MARKERS_CAPTURE_COLOR);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
@@ -5,6 +5,7 @@ import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.GlassColor;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.metadata.ResidentMetaDataController;
+import com.gmail.goosius.siegewar.objects.BattleSession;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.TownyUniverse;
@@ -54,7 +55,7 @@ public class CosmeticUtil {
 
     public static void evaluateBeacon(Player player, Siege siege) {
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
-		if (SiegeWarSettings.getBeaconsEnabled() && !ResidentMetaDataController.getBeaconsDisabled(resident))
+		if (SiegeWarSettings.getBeaconsEnabled() && (!SiegeWarSettings.getBeaconsBattleSesionOnly() || (SiegeWarSettings.getBeaconsBattleSesionOnly() && BattleSession.getBattleSession().isActive())) && !ResidentMetaDataController.getBeaconsDisabled(resident))
 			createFakeBeacon(player, siege.getFlagLocation(), getGlassColor(player, siege));
     }
 

--- a/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/CosmeticUtil.java
@@ -55,7 +55,7 @@ public class CosmeticUtil {
 
     public static void evaluateBeacon(Player player, Siege siege) {
 		Resident resident = TownyUniverse.getInstance().getResident(player.getUniqueId());
-		if (SiegeWarSettings.getBeaconsEnabled() && (!SiegeWarSettings.getBeaconsBattleSesionOnly() || (SiegeWarSettings.getBeaconsBattleSesionOnly() && BattleSession.getBattleSession().isActive())) && !ResidentMetaDataController.getBeaconsDisabled(resident))
+		if (SiegeWarSettings.getBeaconsEnabled() && (!SiegeWarSettings.getBeaconsBattleSessionOnly() || (SiegeWarSettings.getBeaconsBattleSessionOnly() && BattleSession.getBattleSession().isActive())) && !ResidentMetaDataController.getBeaconsDisabled(resident))
 			createFakeBeacon(player, siege.getFlagLocation(), getGlassColor(player, siege));
     }
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
beacon_markers.battle_session_only boolean key in the yaml allows players to make the fake beacons only show during an active battle session
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
beacon_markers.battle_session_only boolean key

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
