### PR TITLE
Add the option to make timed point zone (banner control session) not require player stand in the wilderness.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -385,7 +385,8 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# If true will check if the player is in wilderness and check the radius blocks when checking if a player is in a timed point zone.",
-			"# If false it will only check the radius blocks when checking if a player is in a timed point zone."),
+			"# If false it will only check the radius blocks when checking if a player is in a timed point zone.",
+			"# Setting this to false is not intended behavior and may break some features, you should only really use this if you're moving the banner to inside of towns"),
 	WAR_SIEGE_BANNER_PLACE_DISTANCE_TOWN_BLOCKS(
 			"war.siege.distances.banner_place_distance_town_blocks","","",""),
 	WAR_SIEGE_BANNER_PLACE_DISTANCE_TOWN_BLOCKS_MAX(

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -380,6 +380,12 @@ public enum ConfigNodes {
 			"# Players will begin a banner control session when inside this radius.",
 			"# This radius also applies to siege camps.",
 			"# Setting this value to below '0' will use the size of a Town Block as the radius."),
+	WAR_SIEGE_BANNER_CONTROL_SESSION_CHECK_WILDERNESS(
+			"war.siege.distances.banner_control_session_check_wilderness",
+			"true",
+			"",
+			"# If true will check if the player is in wilderness and check the radius blocks when checking if a player is in a timed point zone.",
+			"# If false it will only check the radius blocks when checking if a player is in a timed point zone."),
 	WAR_SIEGE_BANNER_PLACE_DISTANCE_TOWN_BLOCKS(
 			"war.siege.distances.banner_place_distance_town_blocks","","",""),
 	WAR_SIEGE_BANNER_PLACE_DISTANCE_TOWN_BLOCKS_MAX(

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -133,6 +133,10 @@ public class SiegeWarSettings {
 		return radius < 0 ? TownySettings.getTownBlockSize() : radius;
 	}
 
+	public static boolean getWarSiegeBannerControlSessionCheckWilderness() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_BANNER_CONTROL_SESSION_CHECK_WILDERNESS);
+	}
+
 	public static int getWarSiegeBannerPlaceDistanceBlocksMax() {
 		int max = Settings.getInt(ConfigNodes.WAR_SIEGE_BANNER_PLACE_DISTANCE_TOWN_BLOCKS_MAX);
 		int min = getWarSiegeBannerPlaceDistanceBlocksMin();

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
@@ -31,7 +31,7 @@ public class SiegeWarScoringUtil {
 	 * @return true if a player in in the timed point zone
 	 */
 	public static boolean isPlayerInTimedPointZone(Player player, Siege siege) {
-		return TownyAPI.getInstance().isWilderness(player.getLocation())
+		return (!SiegeWarSettings.getWarSiegeBannerControlSessionCheckWilderness() || TownyAPI.getInstance().isWilderness(player.getLocation()))
 				&& SiegeWarDistanceUtil.isInTimedPointZone(player.getLocation(), siege);
 	}
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
makes it so players can choose if they want people to only be able to cap the banner from wilderness or not, defaults to true meaning players can only cap the banner if they're in wilderness (vanilla sw behavior)

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
war.siege.distances.banner_control_session_check_wilderness


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
