### PR TITLE
Add banner control session pre start event

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/events/BannerControlSessionPreStartEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/BannerControlSessionPreStartEvent.java
@@ -1,0 +1,48 @@
+package com.gmail.goosius.siegewar.events;
+
+import com.gmail.goosius.siegewar.objects.BannerControlSession;
+import com.gmail.goosius.siegewar.objects.Siege;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class BannerControlSessionPreStartEvent extends Event implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Siege siege;
+    private final BannerControlSession bannerControlSession;
+    private boolean cancelled;
+
+    public BannerControlSessionPreStartEvent(Siege siege, BannerControlSession bannerControlSession) {
+        this.siege = siege;
+        this.bannerControlSession = bannerControlSession;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public Siege getSiege() {
+        return siege;
+    }
+
+    public BannerControlSession getBannerControlSession() {
+        return bannerControlSession;
+    }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -6,6 +6,7 @@ import com.gmail.goosius.siegewar.SiegeWar;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.events.BannerControlSessionEndedEvent;
+import com.gmail.goosius.siegewar.events.BannerControlSessionPreStartEvent;
 import com.gmail.goosius.siegewar.events.BannerControlSessionStartedEvent;
 import com.gmail.goosius.siegewar.objects.BannerControlSession;
 import com.gmail.goosius.siegewar.objects.BattleSession;
@@ -99,6 +100,11 @@ public class SiegeWarBannerControlUtil {
 		long sessionEndTime = System.currentTimeMillis() + sessionDurationMillis;
 		BannerControlSession bannerControlSession =
 			new BannerControlSession(resident, player, siegeSide, sessionEndTime);
+
+		BannerControlSessionPreStartEvent preStartEvent = new BannerControlSessionPreStartEvent(siege, bannerControlSession);
+		Bukkit.getPluginManager().callEvent(preStartEvent);
+		if (preStartEvent.isCancelled()) return;
+
 		siege.addBannerControlSession(player, bannerControlSession);
 
 		//Notify Player in console


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
This PR adds the missing `BannerControlSessionPreStartEvent` to cancel a new potential banner control session. 

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
N/A

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
N/A

____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
