### PR TITLE
Remove special siege outcome effects

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeController.java
@@ -242,7 +242,7 @@ public class SiegeController {
 		siege.setSiegeWinner(SiegeSide.NOBODY);
 		siege.setStatus(SiegeStatus.UNKNOWN);
 		SiegeWarSiegeCompletionUtil.setCommonSiegeCompletionValues(siege);
-		SiegeWarMoneyUtil.handleWarChest(siege, siege.getAttacker(), null);
+		SiegeWarMoneyUtil.handleWarChest(siege, siege.getAttacker());
 	}
 
 	/**

--- a/src/main/java/com/gmail/goosius/siegewar/enums/SiegeStatus.java
+++ b/src/main/java/com/gmail/goosius/siegewar/enums/SiegeStatus.java
@@ -12,9 +12,11 @@ import com.palmergames.bukkit.towny.object.Translation;
  * @author Goosius
  */
 public enum SiegeStatus {
-    IN_PROGRESS(true, Translation.of("siege_status_in_progress")), 
-	ATTACKER_DECISIVE_WIN(false, Translation.of("siege_status_attacker_win")), 
-	DEFENDER_DECISIVE_WIN(false, Translation.of("siege_status_defender_win")), 
+	IN_PROGRESS(true, Translation.of("siege_status_in_progress")),
+	ATTACKER_CRUSHING_WIN(false, Translation.of("siege_status_attacker_crushing_win")),
+	DEFENDER_CRUSHING_WIN(false, Translation.of("siege_status_defender_crushing_win")),
+	ATTACKER_DECISIVE_WIN(false, Translation.of("siege_status_attacker_decisive_win")), 
+	DEFENDER_DECISIVE_WIN(false, Translation.of("siege_status_defender_decisive_win")), 
 	ATTACKER_CLOSE_WIN(false, Translation.of("siege_status_attacker_close_win")),
 	DEFENDER_CLOSE_WIN(false, Translation.of("siege_status_defender_close_win")),
 	ATTACKER_ABANDON(false, Translation.of("siege_status_attacker_abandon")), 
@@ -35,6 +37,10 @@ public enum SiegeStatus {
         switch (line) {
             case "IN_PROGRESS":
                 return IN_PROGRESS;
+            case "ATTACKER_CRUSHING_WIN":
+                return ATTACKER_CRUSHING_WIN;
+            case "DEFENDER_CRUSHING_WIN":
+                return DEFENDER_CRUSHING_WIN;
             case "ATTACKER_DECISIVE_WIN":
                 return ATTACKER_DECISIVE_WIN;
             case "DEFENDER_DECISIVE_WIN":
@@ -82,6 +88,7 @@ public enum SiegeStatus {
 
 	public boolean attackersWon() {
 		switch(this) {
+		case ATTACKER_CRUSHING_WIN:
 		case ATTACKER_DECISIVE_WIN:
 		case ATTACKER_CLOSE_WIN:
 		case DEFENDER_SURRENDER:
@@ -93,29 +100,9 @@ public enum SiegeStatus {
 
 	public boolean defendersWon() {
 		switch(this) {
+		case DEFENDER_CRUSHING_WIN:
 		case DEFENDER_DECISIVE_WIN:
 		case DEFENDER_CLOSE_WIN:
-		case ATTACKER_ABANDON:
-			return true;
-		default:
-			return false;
-		}
-	}
-
-	public boolean reducesPlunder() {
-		switch(this) {
-		case ATTACKER_CLOSE_WIN:
-			return true;
-		default:
-			return false;
-		}
-	}
-
-	public boolean awardsOnlyWinners() {
-		switch(this) {
-		case ATTACKER_DECISIVE_WIN:
-		case DEFENDER_DECISIVE_WIN:
-		case DEFENDER_SURRENDER:
 		case ATTACKER_ABANDON:
 			return true;
 		default:
@@ -130,6 +117,9 @@ public enum SiegeStatus {
 	 */
 	public Translatable getTimedVictoryTypeText() {
 		switch(this) {
+			case ATTACKER_CRUSHING_WIN:
+			case DEFENDER_CRUSHING_WIN:
+				return Translatable.of("msg_crushing");
 			case ATTACKER_DECISIVE_WIN:
 			case DEFENDER_DECISIVE_WIN:
 				return Translatable.of("msg_decisive");

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/SiegeWarStatusScreenListener.java
@@ -317,6 +317,8 @@ public class SiegeWarStatusScreenListener implements Listener {
 						out.addAll(getInProgressStatusLines(siege, translator, event.getCommandSender()));
 						break;
 
+					case ATTACKER_CRUSHING_WIN:
+					case DEFENDER_CRUSHING_WIN:
 					case ATTACKER_DECISIVE_WIN:
 					case DEFENDER_DECISIVE_WIN:
 					case ATTACKER_CLOSE_WIN:
@@ -417,14 +419,18 @@ public class SiegeWarStatusScreenListener implements Listener {
         switch (siege.getStatus()) {
             case IN_PROGRESS:
                 return translator.of("status_town_siege_status_in_progress");
+            case ATTACKER_CRUSHING_WIN:
+                return translator.of("status_town_siege_status_crushing_attacker_win");
             case ATTACKER_DECISIVE_WIN:
-                return translator.of("status_town_siege_status_attacker_win");
+                return translator.of("status_town_siege_status_decisive_attacker_win");
 			case ATTACKER_CLOSE_WIN:
 				return translator.of("status_town_siege_status_close_attacker_win");
             case DEFENDER_SURRENDER:
                 return translator.of("status_town_siege_status_defender_surrender");
+            case DEFENDER_CRUSHING_WIN:
+                return translator.of("status_town_siege_status_crushing_defender_win");
             case DEFENDER_DECISIVE_WIN:
-                return translator.of("status_town_siege_status_defender_win");
+                return translator.of("status_town_siege_status_decisive_defender_win");
 			case DEFENDER_CLOSE_WIN:
 				return translator.of("status_town_siege_status_close_defender_win");
             case ATTACKER_ABANDON:

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/AbandonAttack.java
@@ -3,7 +3,6 @@ package com.gmail.goosius.siegewar.playeractions;
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
-import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
@@ -70,13 +69,6 @@ public class AbandonAttack {
 			//Standard effects
 			key= String.format("msg_%s_siege_defender_win_result", siege.getSiegeType().toLowerCase());
 			message.append(Translatable.of(key));
-			//Special effects
-			if(siege.getSiegeType() == SiegeType.REVOLT) {
-				message.append(Translatable.of("msg_revolt_siege_defender_decisive_win_demoralization", 
-						siege.getAttacker().getName(),
-						SiegeWarSettings.getSpecialVictoryEffectsSiegeBalancePenaltyOnDecisiveRebelVictory(),
-						SiegeWarSettings.getSpecialVictoryEffectsSiegeBalancePenaltyDurationDays()));
-			}
 		}
 
 		return message;

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlunderTown.java
@@ -2,7 +2,6 @@ package com.gmail.goosius.siegewar.playeractions;
 
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
-import com.gmail.goosius.siegewar.enums.SiegeType;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
 import com.gmail.goosius.siegewar.metadata.NationMetaDataController;
 import com.gmail.goosius.siegewar.metadata.TownMetaDataController;
@@ -97,12 +96,7 @@ public class PlunderTown {
 				SiegeWarSettings.getWarSiegePlunderAmountPerPlot()
 				* town.getTownBlocks().size()
 				* SiegeWarMoneyUtil.getMoneyMultiplier(town);
-		
-		//Adjust amount for ATTACKER_CLOSE_WIN.
-		if(siege.getStatus().reducesPlunder()) {
-			totalPlunderAmount = totalPlunderAmount / 100 * (100 - SiegeWarSettings.getSpecialVictoryEffectsPlunderReductionPercentageOnCloseVictory());
-		}
-		
+
 		//Redistribute money
 		if (SiegeWarSettings.isPlunderPaidOutOverDays()) {
 			// Plunder is paid out of server, and paid back over time.
@@ -171,12 +165,6 @@ public class PlunderTown {
 						townName,
 						TownyEconomyHandler.getFormattedBalance(totalPlunderAmount),
 						nation.getName()));
-		
-		//Send plunder reduction message for ATTACKER_CLOSE_WIN siege status.
-		if(siege.getStatus().reducesPlunder()) {
-			String langString = siege.getSiegeType() == SiegeType.CONQUEST ? "msg_conquest_siege_attacker_close_win_plunder_reduced" : "msg_revolt_siege_attacker_close_win_plunder_reduced";
-			Messaging.sendGlobalMessage(Translatable.of(langString, SiegeWarSettings.getSpecialVictoryEffectsPlunderReductionPercentageOnCloseVictory() + "%"));
-		}
 
 		//Send town bankrupted/destroyed message
 		if(townNewlyBankrupted) {

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -982,48 +982,29 @@ public enum ConfigNodes {
 			"",
 			"# The threshold required to cause defenders to lose their inventory. If the Siege point balance is equal to or greater than this number",
 			"# and disable_for_defenders is enabled, defenders will not keep their inventories."),
-
-	SPECIAL_VICTORY_EFFECTS(
-			"special_victory_effects",
+	TIMED_VICTORY_TYPES(
+			"timed_victory_types",
 			"",
 			"",
 			"",
 			"############################################################",
 			"# +------------------------------------------------------+ #",
-			"# |             Special Victory Effects                  | #",
+			"# |                Timed Victory Types               | #",
 			"# +------------------------------------------------------+ #",
 			"############################################################",
 			""),
-	SPECIAL_VICTORY_EFFECTS_DECISIVE_VICTORY_THRESHOLD(
-			"special_victory_effects.decisive_victory_threshold",
+    TIMED_VICTORY_TYPES_CRUSHING_VICTORY_THRESHOLD(
+            "timed_victory_types.crushing_victory_threshold",
+            "15000",
+            "",
+            "# If the siege ends in a timed win, with siege points over this threshold (positive or negative),",
+            "# then a crushing victory is declared."),
+	TIMED_VICTORY_TYPES_DECISIVE_VICTORY_THRESHOLD(
+			"timed_victory_types.decisive_victory_threshold",
 			"5000",
 			"",
-			"# If the siege ends without surrender/abandon, and if the siege points are at this threshold (positive or negative),",
+			"# If the siege ends in a timed win which is not a crushing victory, with siege points over this threshold (positive or negative),",
 			"# then a decisive victory is declared, otherwise a close victory is declared."),
-	SPECIAL_VICTORY_EFFECTS_WARCHEST_REDUCTION_PERCENTAGE_ON_CLOSE_VICTORY(
-			"special_victory_effects.warchest_reduction_percentage_on_close_victory",
-			"5",
-			"",
-			"# After a close victory, where a warchest is applicable, the warchest will be reduced by this amount.",
-			"# The losing side will receive the remainder."),
-	SPECIAL_VICTORY_EFFECTS_PLUNDER_REDUCTION_PERCENTAGE_ON_CLOSE_VICTORY(
-			"special_victory_effects.plunder_reduction_percentage_on_close_victory",
-			"50",
-			"",
-			"# After a close victory, where plunder is applicable, plunder will be reduced by this amount."),
-	SPECIAL_VICTORY_EFFECTS_SIEGE_BALANCE_PENALTY_ON_DECISIVE_REBEL_VICTORY(
-			"special_victory_effects.siege_balance_penalty_on_decisive_rebel_victory",
-			"-1500",
-			"",
-			"# After a decisive defender victory in a revolt siege,",
-			"# the former occupying nation is subject to a starting-siege-balance-penalty to any conquest sieges it initiates.",
-			"# If another such defeat occurs, the penalty is increased by this amount"),
-	SPECIAL_VICTORY_EFFECTS_SIEGE_BALANCE_PENALTY_DURATION_DAYS(
-			"special_victory_effects.siege_balance_penalty_duration_days",
-			"7",
-			"",
-			"# this value determines the duration of the starting-siege-balance-penalty.",
-			"# If another such defeat occurs, the the duration is refreshed."),
 	TOXICITY_REDUCTION(
 			"toxicity_reduction",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -543,24 +543,12 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.KEEP_INVENTORY_ON_SIEGEZONE_DEATH_DISABLE_FOR_DEFENDERS_THRESHOLD);
 	}
 
-	public static int getSpecialVictoryEffectsDecisiveVictoryThreshold() {
-		return Settings.getInt(ConfigNodes.SPECIAL_VICTORY_EFFECTS_DECISIVE_VICTORY_THRESHOLD);
+	public static int getTimedVictoryTypesCrushingVictoryThreshold() {
+		return Settings.getInt(ConfigNodes.TIMED_VICTORY_TYPES_CRUSHING_VICTORY_THRESHOLD);
 	}
 
-	public static int getSpecialVictoryEffectsWarchestReductionPercentageOnCloseVictory() {
-		return Settings.getInt(ConfigNodes.SPECIAL_VICTORY_EFFECTS_WARCHEST_REDUCTION_PERCENTAGE_ON_CLOSE_VICTORY);
-	}
-
-	public static int getSpecialVictoryEffectsPlunderReductionPercentageOnCloseVictory() {
-		return Settings.getInt(ConfigNodes.SPECIAL_VICTORY_EFFECTS_PLUNDER_REDUCTION_PERCENTAGE_ON_CLOSE_VICTORY);
-	}
-
-	public static int getSpecialVictoryEffectsSiegeBalancePenaltyOnDecisiveRebelVictory() {
-		return Settings.getInt(ConfigNodes.SPECIAL_VICTORY_EFFECTS_SIEGE_BALANCE_PENALTY_ON_DECISIVE_REBEL_VICTORY);
-	}
-
-	public static int getSpecialVictoryEffectsSiegeBalancePenaltyDurationDays() {
-		return Settings.getInt(ConfigNodes.SPECIAL_VICTORY_EFFECTS_SIEGE_BALANCE_PENALTY_DURATION_DAYS);
+	public static int getTimedVictoryTypesDecisiveVictoryThreshold() {
+		return Settings.getInt(ConfigNodes.TIMED_VICTORY_TYPES_DECISIVE_VICTORY_THRESHOLD);
 	}
 
 	public static boolean isToxicityReductionEnabled() {

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerTimedWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerTimedWin.java
@@ -15,16 +15,14 @@ import com.palmergames.bukkit.towny.object.Translatable;
 public class AttackerTimedWin {
 
     public static void attackerTimedWin(Siege siege) {
-        if(Math.abs(siege.getSiegeBalance()) >= SiegeWarSettings.getSpecialVictoryEffectsDecisiveVictoryThreshold()) {
+        if(Math.abs(siege.getSiegeBalance()) >= SiegeWarSettings.getTimedVictoryTypesCrushingVictoryThreshold()) {
+            siege.setStatus(SiegeStatus.ATTACKER_CRUSHING_WIN);
+        } else if(Math.abs(siege.getSiegeBalance()) >= SiegeWarSettings.getTimedVictoryTypesDecisiveVictoryThreshold()) {
             siege.setStatus(SiegeStatus.ATTACKER_DECISIVE_WIN);
-            Messaging.sendGlobalMessage(getStandardAttackerWinMessage(siege));
         } else {
             siege.setStatus(SiegeStatus.ATTACKER_CLOSE_WIN);
-            Messaging.sendGlobalMessage(getStandardAttackerWinMessage(siege));
-            Translatable specialEffectsMessage = getSpecialTimedAttackerWinMessage(siege);
-            if(specialEffectsMessage != null)
-                Messaging.sendGlobalMessage(specialEffectsMessage);
         }
+        Messaging.sendGlobalMessage(getStandardAttackerWinMessage(siege));
         AttackerWin.attackerWin(siege);
     }
 
@@ -52,21 +50,6 @@ public class AttackerTimedWin {
         String key2 = String.format("msg_%s_siege_attacker_win_result", siege.getSiegeType().toLowerCase());
         message.append(Translatable.of(key2));
         siege.setEndMessage(message.defaultLocale());
-        return message;
-    }
-
-    private static Translatable getSpecialTimedAttackerWinMessage(Siege siege) {
-        //Special effects message
-        Translatable message = null;
-        switch (siege.getSiegeType()) {
-            case CONQUEST:
-                if(siege.getStatus() == SiegeStatus.ATTACKER_CLOSE_WIN) {
-                    message = Translatable.of("msg_conquest_siege_attacker_close_win_warchest_reduced",
-                            SiegeWarSettings.getSpecialVictoryEffectsWarchestReductionPercentageOnCloseVictory() + "%",
-                            SiegeWarSettings.getSpecialVictoryEffectsPlunderReductionPercentageOnCloseVictory() + "%");
-                }
-                break;
-        }
         return message;
     }
 }

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/AttackerWin.java
@@ -21,6 +21,6 @@ public class AttackerWin {
 	public static void attackerWin(Siege siege) {
 		siege.setSiegeWinner(SiegeSide.ATTACKERS);
 		SiegeWarSiegeCompletionUtil.setCommonSiegeCompletionValues(siege);
-		SiegeWarMoneyUtil.handleWarChest(siege, siege.getAttacker(), siege.getTown());
+		SiegeWarMoneyUtil.handleWarChest(siege, siege.getAttacker());
 	}
 }

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderTimedWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderTimedWin.java
@@ -15,19 +15,14 @@ import com.palmergames.bukkit.towny.object.Translatable;
 public class DefenderTimedWin {
 
     public static void defenderTimedWin(Siege siege) {
-        if(Math.abs(siege.getSiegeBalance()) >= SiegeWarSettings.getSpecialVictoryEffectsDecisiveVictoryThreshold()) {
+        if(Math.abs(siege.getSiegeBalance()) >= SiegeWarSettings.getTimedVictoryTypesCrushingVictoryThreshold()) {
+            siege.setStatus(SiegeStatus.DEFENDER_CRUSHING_WIN);
+        } else if(Math.abs(siege.getSiegeBalance()) >= SiegeWarSettings.getTimedVictoryTypesDecisiveVictoryThreshold()) {
             siege.setStatus(SiegeStatus.DEFENDER_DECISIVE_WIN);
-            Messaging.sendGlobalMessage(getStandardTimedDefenderWinMessage(siege));
-            Translatable specialEffectsMessage = getSpecialTimedDefenderWinMessage(siege);
-            if(specialEffectsMessage != null)
-                Messaging.sendGlobalMessage(specialEffectsMessage);
         } else {
             siege.setStatus(SiegeStatus.DEFENDER_CLOSE_WIN);
-            Messaging.sendGlobalMessage(getStandardTimedDefenderWinMessage(siege));
-            Translatable specialEffectsMessage = getSpecialTimedDefenderWinMessage(siege);
-            if(specialEffectsMessage != null)
-                Messaging.sendGlobalMessage(specialEffectsMessage);
         }
+        Messaging.sendGlobalMessage(getStandardTimedDefenderWinMessage(siege));
         DefenderWin.defenderWin(siege);
     }
 
@@ -57,27 +52,4 @@ public class DefenderTimedWin {
         siege.setEndMessage(message.defaultLocale());
         return message;
     }
-
-    private static Translatable getSpecialTimedDefenderWinMessage(Siege siege) {
-        //Special effects message
-        Translatable message = null;
-        switch (siege.getSiegeType()) {
-            case CONQUEST:
-                if(siege.getStatus() == SiegeStatus.DEFENDER_CLOSE_WIN) {
-                    message = Translatable.of("msg_conquest_siege_defender_close_win_warchest_reduced",
-                            SiegeWarSettings.getSpecialVictoryEffectsPlunderReductionPercentageOnCloseVictory() + "%");
-                }
-                break;
-            case REVOLT:
-                if(siege.getStatus() == SiegeStatus.DEFENDER_DECISIVE_WIN) {
-                    message = Translatable.of("msg_revolt_siege_defender_decisive_win_demoralization",
-                            siege.getAttacker().getName(),
-                            SiegeWarSettings.getSpecialVictoryEffectsSiegeBalancePenaltyOnDecisiveRebelVictory(),
-                            SiegeWarSettings.getSpecialVictoryEffectsSiegeBalancePenaltyDurationDays());
-                }
-                break;
-        }
-        return message;
-    }
-
 }

--- a/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
+++ b/src/main/java/com/gmail/goosius/siegewar/timeractions/DefenderWin.java
@@ -21,7 +21,7 @@ public class DefenderWin
     public static void defenderWin(Siege siege) {
     	siege.setSiegeWinner(SiegeSide.DEFENDERS);
 		SiegeWarSiegeCompletionUtil.setCommonSiegeCompletionValues(siege);
-		SiegeWarMoneyUtil.handleWarChest(siege, siege.getTown(), siege.getAttacker());
+		SiegeWarMoneyUtil.handleWarChest(siege, siege.getTown());
     }
 
 }

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMoneyUtil.java
@@ -37,48 +37,15 @@ public class SiegeWarMoneyUtil {
 	 *
 	 * @param siege Siege
 	 * @param winningGovernment the winning Government
-	 * @param losingGovernment the losing Government, or null if the amount should be paid in full to the winner.
 	 */
-	public static void handleWarChest(Siege siege, Government winningGovernment, Government losingGovernment) {
+	public static void handleWarChest(Siege siege, Government winningGovernment) {
 		if (!siege.getSiegeType().paysWarChest() || !TownyEconomyHandler.isActive()) // Not a CONQUEST Siege.
 			return;
-
-		// If no losingGovernment is supplied, or it is a decisive ATTACKER_WIN, pay only the winner.
-		if (losingGovernment == null || siege.getStatus().awardsOnlyWinners()) {
-			giveWarChestTo(winningGovernment,
-					siege.getWarChestAmount(),
-					"War Chest Captured",
-					"msg_siege_war_attack_recover_war_chest");
-		
-		} else {
-			giveWarChestToBoth(siege, winningGovernment, losingGovernment);
-		}
-	}
-
-	/**
-	 * Split the warchest between both given governments
-	 * Used for a close victory
-	 * 
-	 * @param siege siege
-	 * @param winningGovernment the (closely) winning government
-	 * @param losingGovernment the (closely) losing government
-	 */
-	private static void giveWarChestToBoth(Siege siege, Government winningGovernment, Government losingGovernment) {
-		//Calculate amounts
-		double amountForLosingGovernment = siege.getWarChestAmount() / 100 * SiegeWarSettings.getSpecialVictoryEffectsWarchestReductionPercentageOnCloseVictory();
-		double amountForWinningGovernment = siege.getWarChestAmount() - amountForLosingGovernment;
-
-		//Give partial war chest to winner
+        
 		giveWarChestTo(winningGovernment,
-				amountForWinningGovernment,
-				"War Chest Partially Recovered",
-				"msg_siege_war_attack_partially_recover_war_chest");
-
-		//Give partial war chest to loser
-		giveWarChestTo(losingGovernment,
-				amountForLosingGovernment,
-				"War Chest Partially Recovered",
-				"msg_siege_war_attack_partially_recover_war_chest");
+				siege.getWarChestAmount(),
+				"War Chest Captured",
+				"msg_siege_war_attack_recover_war_chest");
 	}
 
 	private static void giveWarChestTo(Government governmentToAward,

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -251,8 +251,10 @@ status_town_siege_status: '&2 > Status: &a%s'
 status_town_siege_attacker: '&2 > Attacker: &a%s'
 status_town_siege_defender: '&2 > Defender: &a%s'
 status_town_siege_battle_points: '&2 > Points: &a%s &2/ &a%s'
-status_town_siege_status_attacker_win: 'Decisive Attacker Victory'
-status_town_siege_status_defender_win: 'Decisive Defender Victory'
+status_town_siege_status_crushing_attacker_win: 'Crushing Attacker Victory'
+status_town_siege_status_crushing_defender_win: 'Crushing Defender Victory'
+status_town_siege_status_decisive_attacker_win: 'Decisive Attacker Victory'
+status_town_siege_status_decisive_defender_win: 'Decisive Defender Victory'
 status_town_siege_status_close_attacker_win: 'Close Attacker Victory'
 status_town_siege_status_close_defender_win: 'Close Defender Victory'
 status_town_siege_status_attacker_abandon: 'Attacker Abandon'
@@ -530,6 +532,7 @@ msg_conquest_siege_timed_attacker_win: '&bCONQUEST SIEGE at %s > The attacking a
 msg_conquest_siege_timed_defender_win: '&bCONQUEST SIEGE at %s > The defending army of %s has won a %s victory against the attacking army of %s!'
 msg_revolt_siege_timed_attacker_win: '&bREVOLT SIEGE at %s > The attacking army of %s, which previously occupied the town, has defeated the rebels with a %s victory!'
 msg_revolt_siege_timed_defender_win: '&bREVOLT SIEGE at %s > The rebellion has succeeded! The attacking rebels have successfully driven off the attacking army of %s!, with a %s victory!'
+msg_crushing: 'CRUSHING'
 msg_decisive: 'DECISIVE'
 msg_close: 'CLOSE'
 
@@ -606,18 +609,10 @@ msg_nation_pay_upfront_siege_cost: '&bYour nation paid an upfront siege cost of 
 
 siege_status_attacker_close_win: 'Close Attacker Victory'
 siege_status_defender_close_win: 'Close Defender Victory'
-siege_status_attacker_win: 'Decisive Attacker Victory'
-siege_status_defender_win: 'Decisive Defender Victory'
-
-#Siege Special Victory Effects
-
-msg_conquest_siege_attacker_close_win_warchest_reduced: "&bBecause the siege victory was CLOSE, the besieged town was able to recover %s of the War Chest."
-msg_conquest_siege_defender_close_win_warchest_reduced: "&bBecause the siege victory was CLOSE, the besieging nation was able to recover %s of the War Chest."
-
-msg_conquest_siege_attacker_close_win_plunder_reduced: "&bBecause the recent siege victory was CLOSE, the usual plunder amount was reduced by %s."
-msg_revolt_siege_attacker_close_win_plunder_reduced: "&bBecause the recent siege victory CLOSE, the usual plunder amount was reduced by %s."
-
-msg_revolt_siege_defender_decisive_win_demoralization: "&bThe former occupying nation, %s, reels from the decisive loss of its colony, and is demoralized (%d siege-balance to conquest sieges it initiates), for %d days."
+siege_status_attacker_decisive_win: 'Decisive Attacker Victory'
+siege_status_defender_decisive_win: 'Decisive Defender Victory'
+siege_status_attacker_crushing_win: 'Crushing Attacker Victory'
+siege_status_defender_crushing_win: 'Crushing Defender Victory'
 
 #Toxicity Reduction
 


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
- Current code has the feature of "Special Siege Outcomes", such as splitting the warchest amounts between attacker/defender, reducing the plunder amount, and demoralizing a defeated occupier in a revolt siege.
- On inspection, the demoralization feature doesn't appear to be connected up.
- Also on reflection, these special outcomes probably add a bit too much complexity to the system to have any net benefit.
- So this PR removes the special siege outcomes feature.
- In addition, the PR adds a new outcome-level, which doesn't have any functional effect, but has gotta be pretty cool when it gets declared automatically in the general chat: "CRUSHING" victories.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
N/A


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
N/A

____
- [ x ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
