### PR TITLE
Added start-day-limiter by specified week

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -774,6 +774,12 @@ public enum ConfigNodes {
 			"# Multiple entries should be separated by a comma.",
 			"# Permitted values: monday, tuesday, wednesday, thursday, friday, saturday, sunday.",
 			"# By default, sieges are started only on Thursday"),
+	SIEGE_START_DAY_LIMITER_ALLOWED_WEEKS(
+			"siege_start_day_limiter.allowed_siege_start_weeks",
+			"weekly",
+			"",
+			"# This setting allows siege starts to be limited by week.",
+			"# Permitted values: weekly, odd-weeks-only, even-weeks-only"),
 	BATTLE_SESSION_SCHEDULER(
 			"battle_session_scheduler",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -1,6 +1,7 @@
 package com.gmail.goosius.siegewar.settings;
 
 import java.awt.Color;
+import java.time.temporal.WeekFields;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Locale;
@@ -22,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 public class SiegeWarSettings {
 	
 	private static List<DayOfWeek> allowedDaysList = null;
+	private static String allowedWeeks = null;
 	private static List<Material> siegeZoneWildernessForbiddenBlockMaterials = null;
 	private static List<Material> siegeZoneWildernessForbiddenBucketMaterials = null;
 	private static List<EntityType> siegeZoneWildernessForbiddenExplodeEntityTypes = null;
@@ -373,6 +375,10 @@ public class SiegeWarSettings {
 		return Settings.getInt(ConfigNodes.WAR_SIEGE_SIEGECAMPS_DURATION_IN_MINUTES);
 	}
 
+	public static String getSiegeStartDayLimiterAllowedWeeks() {
+		return Settings.getString(ConfigNodes.SIEGE_START_DAY_LIMITER_ALLOWED_WEEKS);
+	}
+
 	public static List<DayOfWeek> getSiegeStartDayLimiterAllowedDays() {
 		List<DayOfWeek> allowedDaysList = new ArrayList<>();
 		String[] allowedDaysStringArray = Settings.getString(ConfigNodes.SIEGE_START_DAY_LIMITER_ALLOWED_DAYS).toUpperCase(Locale.ROOT).replaceAll(" ", "").split(",");
@@ -387,9 +393,22 @@ public class SiegeWarSettings {
 	}
 
 	public static boolean doesTodayAllowASiegeToStart() {
-		if (allowedDaysList == null)
+		//Check week of year
+		if(allowedWeeks == null)
+			allowedWeeks = getSiegeStartDayLimiterAllowedWeeks();
+		int weekOfYear = LocalDate.now().get(WeekFields.ISO.weekOfWeekBasedYear());
+		if(allowedWeeks.equalsIgnoreCase("even-weeks-only") && weekOfYear %2 != 0)
+			return false;
+		if(allowedWeeks.equalsIgnoreCase("odd-weeks-only") && weekOfYear %2 != 1)
+			return false;
+
+		//Check day of week
+		if(allowedDaysList == null)
 			allowedDaysList = getSiegeStartDayLimiterAllowedDays();
-		return allowedDaysList.contains(LocalDate.now().getDayOfWeek());
+		if(!allowedDaysList.contains(LocalDate.now().getDayOfWeek()))
+			return false;
+
+		return true;
 	}
 
 	public static int getSiegeBalanceCapValue() {

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -364,7 +364,7 @@ nation_help_siegewar_11 : 'Collect any income due to you from military salary.'
 msg_err_siege_war_collect_unavailable: "There is nothing for you to collect."
 msg.battle.session.cleanup.starting: "The previous Battle Session did not complete. Initiating Battle Session Cleanup. Each battle will be resolved as a draw, with both attacker and defender battle points being applied to the siege balance."
 msg.battle.session.cleanup.complete: "Battle Session Cleanup complete. %d battles were resolved."
-msg_err_cannot_start_sieges_today: "&cYour server has limited the days-of-the-week when sieges can be started. Sieges cannot be started today."
+msg_err_cannot_start_sieges_today: "&cYour server has limited the days when sieges can be started. Sieges cannot be started today."
 
 #Added in 0.36
 msg_err_nation_neutrality_not_supported: '&cSiegeWar does not support nation neutrality.'


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
* Allows siege start days to be limited to one every 2 weeks

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
```
	SIEGE_START_DAY_LIMITER_ALLOWED_WEEKS(
			"siege_start_day_limiter.allowed_siege_start_weeks",
			"weekly",
			"",
			"# This setting allows siege starts to be limited by week.",
			"# Permitted values: weekly, odd-weeks-only, even-weeks-only"),
```

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #992 

____
- [ N/A Hopefully too trivial  ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
