### PR TITLE
Create BattleSessionPenaltyPointsEvent

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/events/BattleSessionPenaltyPointsEvent.java
+++ b/src/main/java/com/gmail/goosius/siegewar/events/BattleSessionPenaltyPointsEvent.java
@@ -1,0 +1,69 @@
+package com.gmail.goosius.siegewar.events;
+
+import com.gmail.goosius.siegewar.objects.Siege;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BattleSessionPenaltyPointsEvent extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public enum Reason {
+        DEATH,
+        KILLED_BY_DEFENDER,
+        KILLED_BY_ATTACKER
+    }
+
+    private final @NotNull Siege siege;
+    private final int pointsPenalized;
+    private final @NotNull Reason reason;
+
+    private final boolean victimWasAttacker;
+    private final @NotNull Player victim;
+    private final @Nullable Player killer;
+
+    public BattleSessionPenaltyPointsEvent(@NotNull Siege siege, int pointsPenalized, @NotNull Reason reason, boolean victimWasAttacker, @NotNull Player victim, @Nullable Player killer) {
+        this.siege = siege;
+        this.pointsPenalized = pointsPenalized;
+        this.reason = reason;
+        this.victimWasAttacker = victimWasAttacker;
+        this.victim = victim;
+        this.killer = killer;
+    }
+
+    public @NotNull Siege getSiege() {
+        return siege;
+    }
+
+    public int getPointsPenalized() {
+        return pointsPenalized;
+    }
+
+    public @NotNull Reason getReason() {
+        return reason;
+    }
+
+    public boolean isVictimWasAttacker() {
+        return victimWasAttacker;
+    }
+
+    public @NotNull Player getVictim() {
+        return victim;
+    }
+
+    public @Nullable Player getKiller() {
+        return killer;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static @NotNull HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarScoringUtil.java
@@ -2,10 +2,12 @@ package com.gmail.goosius.siegewar.utils;
 
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
+import com.gmail.goosius.siegewar.events.BattleSessionPenaltyPointsEvent;
 import com.gmail.goosius.siegewar.objects.Siege;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Translatable;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -65,8 +67,10 @@ public class SiegeWarScoringUtil {
 		//Generate message
 		String langKey;
 		Translatable message;
+		final BattleSessionPenaltyPointsEvent.Reason reason;
 		Player killer = getPlayerKiller(player);
 		if(killer != null) {
+			reason = residentIsAttacker ? BattleSessionPenaltyPointsEvent.Reason.KILLED_BY_DEFENDER : BattleSessionPenaltyPointsEvent.Reason.KILLED_BY_ATTACKER;
 			langKey = residentIsAttacker ? 	"msg_siege_war_attacker_killed_by_player" : "msg_siege_war_defender_killed_by_player";
 			message = Translatable.of(
 				langKey,
@@ -75,6 +79,7 @@ public class SiegeWarScoringUtil {
 				killer.getName(),
 				Math.abs(battlePoints));
 		} else {
+			reason = BattleSessionPenaltyPointsEvent.Reason.DEATH;
 			langKey = residentIsAttacker ? 	"msg_siege_war_attacker_death" : "msg_siege_war_defender_death";
 			message = Translatable.of(
 				langKey,
@@ -82,6 +87,9 @@ public class SiegeWarScoringUtil {
 				player.getName(),
 				Math.abs(battlePoints));
 		}
+
+		Bukkit.getPluginManager().callEvent( new BattleSessionPenaltyPointsEvent(siege, Math.abs(battlePoints), reason, residentIsAttacker, player, killer));
+
 
 		//Send messages to siege participants
 		SiegeWarNotificationUtil.informSiegeParticipants(siege, message);


### PR DESCRIPTION
#### Description: 
This event is designed to fire when a SiegeWarScoringUtil issues points for a players death (penalty points).

Right now through SiegeWarAPI, you have to recreate the SiegeWarScoringUtil just to determine how many points were awarded for a players death. This simply little event lightens the load on addon developers.

____
#### New Nodes/Commands/ConfigOptions: 
New Event: BattleSessionPenaltyPointsEvent
- Fires after calculating Penalty Points, provides a nice easy way for addons to track kills/deaths/points and etc.


____
#### Relevant Issue ticket:
None


____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
