### PR TITLE
Stop unstable blocks from preventing sieges.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlaceBlock.java
@@ -30,6 +30,7 @@ import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.Banner;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -302,9 +303,6 @@ public class PlaceBlock {
 		if (nearbyTown.isRuined())
 			throw new TownyException(translator.of("msg_err_cannot_start_siege_at_ruined_town"));
 
-		if(SiegeWarBlockUtil.isSupportBlockUnstable(bannerBlock))
-			throw new TownyException(translator.of("msg_err_siege_war_banner_support_block_not_stable"));
-
 		if (!SiegeWarSettings.doesTodayAllowASiegeToStart())
 			throw new TownyException(translator.of("msg_err_cannot_start_sieges_today"));
 
@@ -313,6 +311,9 @@ public class PlaceBlock {
 			SiegeWarMoneyUtil.throwIfTownCannotAffordToStartSiege(nearbyTown);
 			//Start Revolt siege
 			StartRevoltSiege.processStartSiegeRequest(player, residentsTown, residentsNation, nearbyTownBlock, nearbyTown, bannerBlock);
+			// Replace unstable block below banner.
+			if(SiegeWarBlockUtil.isSupportBlockUnstable(bannerBlock))
+				bannerBlock.getRelative(BlockFace.DOWN).setType(Material.STONE);
 			//Immediately remove occupation
 			TownOccupationController.removeTownOccupation(nearbyTown);
 		} else {
@@ -327,6 +328,10 @@ public class PlaceBlock {
 
 			if (SiegeWarSettings.doesThisNationHaveTooManyActiveSieges(residentsNation))
 				throw new TownyException(translator.of("msg_err_siege_war_nation_has_too_many_active_siege_attacks"));
+
+			// Replace unstable block below banner.
+			if(SiegeWarBlockUtil.isSupportBlockUnstable(bannerBlock))
+				bannerBlock.getRelative(BlockFace.DOWN).setType(Material.STONE);
 
 			//Conquest siege
 			StartConquestSiege.processStartSiegeRequest(player, residentsTown, residentsNation, nearbyTownBlock, nearbyTown, bannerBlock);


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Instead of cancelling the siege altogether, we replace an unstable block with Stone, the same way that missing banners are treated mid-siege.


____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->
Closes #1002.

____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
