### PR TITLE
Fix listpeacefultowns command doing the opposite of its intention, showing only unpeaceful towns.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -337,7 +337,7 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 	private void parseSiegeWarListPeacefulTownsCommand(Player player) {
 		TownyMessaging.sendMessage(player, ChatTools.formatTitle(Translatable.of("sw_peaceful_towns_title").forLocale(player)));
 		for (Town town : TownyAPI.getInstance().getTowns()) {
-			if (SiegeWarTownPeacefulnessUtil.isTownPeaceful(town))
+			if (!SiegeWarTownPeacefulnessUtil.isTownPeaceful(town))
 				continue;
 			TownyMessaging.sendMessage(player, " - <aqua>" + town.getFormattedName());
 		}


### PR DESCRIPTION


<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
