### PR TITLE
Add config option to enable sieging of nation capitals.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/InvadeTown.java
@@ -121,7 +121,7 @@ public class InvadeTown {
 		if (!siege.getStatus().allowsInvading())
 			throw new TownyException(translator.of("msg_err_cannot_invade_without_victory"));
 
-        if (siege.getTown().isCapital())
+        if (!SiegeWarSettings.getWarSiegeInvadeCapitalEnabled() && siege.getTown().isCapital())
             throw new TownyException(translator.of("msg_err_cannot_capture_capital_town"));
         
 		if (siege.isTownInvaded())

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -72,6 +72,11 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# If true, then invasions are enabled."),
+	WAR_SIEGE_INVADE_CAPITAL_ENABLED(
+			"war.siege.switches.invade_capital_enabled",
+			"false",
+			"",
+			"# If true, then invasions of capitals are enabled."),
 	WAR_SIEGE_MILITARY_SALARY_ENABLED(
 			"war.siege.switches.military_salary_enabled",
 			"true",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -50,6 +50,10 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_INVADE_ENABLED);
 	}
 
+		public static boolean getWarSiegeInvadeCapitalEnabled() {
+		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_INVADE_CAPITAL_ENABLED);
+	}
+
 	public static boolean getWarSiegePlunderEnabled() {
 		return Settings.getDouble(ConfigNodes.WAR_SIEGE_PLUNDER_AMOUNT_PER_PLOT) > 0;
 	}


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
adds config toggle for if nation capitals can be invaded after attackers win a siege

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
WAR_SIEGE_INVADE_CAPITAL_ENABLED

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [X] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->
tested both true/false

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
