### PR TITLE
Add config option: allowed_siege_battle_session_weeks

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -854,6 +854,12 @@ public enum ConfigNodes {
 			"true",
 			"",
 			"# Should sessions be cancelled when there are no active sieges?"),
+	BATTLE_SESSION_SCHEDULER_ALLOWED_WEEKS(
+			"battle_session_scheduler.allowed_siege_battle_session_weeks",
+			"weekly",
+			"",
+			"# This setting allows siege battle sessions to be limited by week.",
+			"# Permitted values: weekly, odd-weeks-only, even-weeks-only"),
 	PVP_PROTECTION_OVERRIDES(
 			"pvp_protection_overrides",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -23,12 +23,15 @@ import org.jetbrains.annotations.Nullable;
 public class SiegeWarSettings {
 	
 	private static List<DayOfWeek> allowedDaysList = null;
-	private static String allowedWeeks = null;
+	private static String allowedWeeksStartSiege = null;
+	private static String allowedWeeksBattleSession = null;
 	private static List<Material> siegeZoneWildernessForbiddenBlockMaterials = null;
 	private static List<Material> siegeZoneWildernessForbiddenBucketMaterials = null;
 	private static List<EntityType> siegeZoneWildernessForbiddenExplodeEntityTypes = null;
 	protected static void resetCachedSettings() {
 		allowedDaysList = null;
+		allowedWeeksStartSiege = null;
+		allowedWeeksBattleSession = null;
 		siegeZoneWildernessForbiddenBlockMaterials = null;
 		siegeZoneWildernessForbiddenBucketMaterials = null;
 		siegeZoneWildernessForbiddenExplodeEntityTypes = null;
@@ -397,6 +400,10 @@ public class SiegeWarSettings {
 		return Settings.getString(ConfigNodes.SIEGE_START_DAY_LIMITER_ALLOWED_WEEKS);
 	}
 
+	public static String getBattleSessionSchedulerAllowedWeeks() {
+		return Settings.getString(ConfigNodes.BATTLE_SESSION_SCHEDULER_ALLOWED_WEEKS);
+	}
+
 	public static List<DayOfWeek> getSiegeStartDayLimiterAllowedDays() {
 		List<DayOfWeek> allowedDaysList = new ArrayList<>();
 		String[] allowedDaysStringArray = Settings.getString(ConfigNodes.SIEGE_START_DAY_LIMITER_ALLOWED_DAYS).toUpperCase(Locale.ROOT).replaceAll(" ", "").split(",");
@@ -411,13 +418,9 @@ public class SiegeWarSettings {
 	}
 
 	public static boolean doesTodayAllowASiegeToStart() {
-		//Check week of year
-		if(allowedWeeks == null)
-			allowedWeeks = getSiegeStartDayLimiterAllowedWeeks();
-		int weekOfYear = LocalDate.now().get(WeekFields.ISO.weekOfWeekBasedYear());
-		if(allowedWeeks.equalsIgnoreCase("even-weeks-only") && weekOfYear %2 != 0)
-			return false;
-		if(allowedWeeks.equalsIgnoreCase("odd-weeks-only") && weekOfYear %2 != 1)
+		if(allowedWeeksStartSiege == null)
+			allowedWeeksStartSiege = getSiegeStartDayLimiterAllowedWeeks();
+		if(!doesDateIsAllowedWeeks(LocalDate.now(), allowedWeeksStartSiege))
 			return false;
 
 		//Check day of week
@@ -427,6 +430,23 @@ public class SiegeWarSettings {
 			return false;
 
 		return true;
+	}
+
+	private static boolean doesDateIsAllowedWeeks(LocalDate date, String allowedWeeks) {
+		int weekOfYear = date.get(WeekFields.ISO.weekOfWeekBasedYear());
+		if(allowedWeeks.equalsIgnoreCase("even-weeks-only"))
+			return weekOfYear % 2 == 0;
+		if(allowedWeeks.equalsIgnoreCase("odd-weeks-only"))
+			return weekOfYear % 2 == 1;
+
+		return true;
+	}
+
+	private static int getBattleSessionSearchWindowDays() {
+		if (allowedWeeksBattleSession == null)
+			allowedWeeksBattleSession = getBattleSessionSchedulerAllowedWeeks();
+
+		return allowedWeeksBattleSession.equalsIgnoreCase("even-weeks-only") || allowedWeeksBattleSession.equalsIgnoreCase("odd-weeks-only") ? 14 : 7;
 	}
 
 	public static int getSiegeBalanceCapValue() {
@@ -452,8 +472,8 @@ public class SiegeWarSettings {
 	@Nullable
 	public static LocalDateTime getNextBattleSessionDaysInAdvance() {
 		LocalDateTime nextSession = null;
-		// Check the next 1-6 days for battle session start times. 
-		for (int i = 1 ; i < 7 ; i++) {
+		// Check the next 1-6 days for battle session start times. Or 1 to 13 days if even-weeks-only or odd-weeks-only.
+		for (int i = 1 ; i < getBattleSessionSearchWindowDays() ; i++) {
 			List<LocalDateTime> allBattleSessionStartTimesForDate = getAllBattleSessionStartTimesForDay(LocalDate.now().plusDays(i));
 			if (allBattleSessionStartTimesForDate.size() != 0) {
 				nextSession = allBattleSessionStartTimesForDate.get(0);
@@ -464,6 +484,12 @@ public class SiegeWarSettings {
 	}
 
 	private static List<LocalDateTime> getAllBattleSessionStartTimesForDay(LocalDate day) {
+		if(allowedWeeksBattleSession == null)
+			allowedWeeksBattleSession = getBattleSessionSchedulerAllowedWeeks();
+		
+		if(!doesDateIsAllowedWeeks(day, allowedWeeksBattleSession))
+			return new ArrayList<>();
+
 		//Get Start times for the given day
 		String startTimesAsString = "";
 		switch (day.getDayOfWeek()) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
This `battle_session_scheduler.allowed_siege_battle_session_weeks` option works as for `siege_start_day_limiter.allowed_siege_start_weeks` by allowing siege session to start only odd weeks or only even weeks.

I think some server would like to use allowed_siege_start_weeks to have war 2 weeks long with multiple battle session and other (like us) would like to use allowed_siege_start_weeks to have war every 2 weeks and no battle session during one of the week. This new settings try to make both possible, with the right display for `/sw nextsession`

Let me know if you think it should be edited somehow.

____
#### New Nodes/Commands/ConfigOptions: 
`battle_session_scheduler.allowed_siege_battle_session_weeks`
Permitted values: weekly, odd-weeks-only, even-weeks-only


____
#### Relevant Issue ticket:
No connected issue ticket.


____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.


ps: I also reseted to null allowedWeeks in resetCachedSettings. I think it was forgoten.
