### PR TITLE
Fix members of occupied towns bypassing military rank removal.

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -3,6 +3,7 @@ package com.gmail.goosius.siegewar.playeractions;
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
+import com.gmail.goosius.siegewar.TownOccupationController;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.enums.SiegeWarPermissionNodes;
@@ -62,7 +63,7 @@ public class PlayerDeath {
 		try {
 			Resident deadResident = TownyUniverse.getInstance().getResident(deadPlayer.getUniqueId());
 			// Weed out invalid residents, residents without a town, and players who cannot collect Points in a Siege.
-			if (deadResident == null || !deadResident.hasTown() || playerIsMissingSiegePointsNodes(deadPlayer))
+			if (deadResident == null || !deadResident.hasTown() || playerIsMissingSiegePointsNodes(deadPlayer) || TownOccupationController.isResidentInAnOccupiedTown(deadResident))
 				return;
 
 			Town deadResidentTown = deadResident.getTownOrNull();

--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/PlayerDeath.java
@@ -63,7 +63,7 @@ public class PlayerDeath {
 		try {
 			Resident deadResident = TownyUniverse.getInstance().getResident(deadPlayer.getUniqueId());
 			// Weed out invalid residents, residents without a town, and players who cannot collect Points in a Siege.
-			if (deadResident == null || !deadResident.hasTown() || playerIsMissingSiegePointsNodes(deadPlayer) || TownOccupationController.isResidentInAnOccupiedTown(deadResident))
+			if (deadResident == null || !deadResident.hasTown() || playerIsMissingSiegePointsNodes(deadPlayer) || (SiegeWarSettings.getWarCommonOccupiedTownBattleParticipationDisabled() && TownOccupationController.isResidentInAnOccupiedTown(deadResident)))
 				return;
 
 			Town deadResidentTown = deadResident.getTownOrNull();

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -666,6 +666,13 @@ public enum ConfigNodes {
 			"",
 			"# If this value is true, then a town under occupation cannot unclaim.",
 			"#  This setting is recommended, to avoid occupation escape exploits."),
+	OCCUPIED_TOWN_BATTLE_PARTICIPATION_DISABLED(
+			"occupied_towns.occupied_town_battle_participation_disabled",
+			"true",
+			"",
+			"# By default, military ranks are removed from occupied residents, however mayors can still attend battle sessions, since they have permission siegewar.town.siege.battle.points.",
+			"# If this value is true, then all occupied residents cannot gain or lose points at battle sessions, regardless of whether or not they have battle points permissions.",
+			"#  This setting is recommended, to avoid occupation escape by purposeful war loss."),
 	PUNISH_NON_SIEGE_PARTICIPANTS_IN_SIEGE_ZONE(
 			"punish_non_siege_participants_in_siege_zones",
 			"",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -670,8 +670,8 @@ public enum ConfigNodes {
 			"occupied_towns.occupied_town_battle_participation_disabled",
 			"true",
 			"",
-			"# By default, military ranks are removed from occupied residents, however mayors can still attend battle sessions, since they have permission siegewar.town.siege.battle.points.",
-			"# If this value is true, then all occupied residents cannot gain or lose points at battle sessions, regardless of whether or not they have battle points permissions.",
+			"# SiegeWar removes military ranks from occupied residents, however mayors can still attend battle sessions, since they have permission siegewar.town.siege.battle.points. To keep this behaviour set this config setting to false.",
+			"# If this value is true, then all occupied residents (including the mayor,) cannot gain or lose points at battle sessions, regardless of whether or not they have battle points permissions.",
 			"#  This setting is recommended, to avoid occupation escape by purposeful war loss."),
 	PUNISH_NON_SIEGE_PARTICIPANTS_IN_SIEGE_ZONE(
 			"punish_non_siege_participants_in_siege_zones",

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -219,6 +219,10 @@ public class SiegeWarSettings {
 		return Settings.getBoolean(ConfigNodes.OCCUPIED_TOWN_UNCLAIMING_DISABLED);
 	}
 
+	public static boolean getWarCommonOccupiedTownBattleParticipationDisabled() {
+		return Settings.getBoolean(ConfigNodes.OCCUPIED_TOWN_BATTLE_PARTICIPATION_DISABLED);
+	}
+
 	public static boolean isWarSiegeCounterattackBoosterEnabled() {
 		return Settings.getBoolean(ConfigNodes.WAR_SIEGE_POINTS_BALANCING_COUNTERATTACK_BOOSTER_ENABLED);
 	}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -3,6 +3,7 @@ package com.gmail.goosius.siegewar.utils;
 import com.gmail.goosius.siegewar.Messaging;
 import com.gmail.goosius.siegewar.SiegeController;
 import com.gmail.goosius.siegewar.SiegeWar;
+import com.gmail.goosius.siegewar.TownOccupationController;
 import com.gmail.goosius.siegewar.enums.SiegeSide;
 import com.gmail.goosius.siegewar.enums.SiegeStatus;
 import com.gmail.goosius.siegewar.events.BannerControlSessionEndedEvent;
@@ -161,7 +162,10 @@ public class SiegeWarBannerControlUtil {
 			return false; //Player is a nomad
 
 		if (SiegeWarTownPeacefulnessUtil.isTownPeaceful(resident.getTownOrNull())) 
-			return false; //Player if from a peaceful town
+			return false; //Player is from a peaceful town
+
+		if (TownOccupationController.isResidentInAnOccupiedTown(resident)) 
+			return false; //Player is from an occupied town
 
 		if(player.isFlying() || player.isGliding())
 			return false;   // Player is flying

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBannerControlUtil.java
@@ -164,7 +164,7 @@ public class SiegeWarBannerControlUtil {
 		if (SiegeWarTownPeacefulnessUtil.isTownPeaceful(resident.getTownOrNull())) 
 			return false; //Player is from a peaceful town
 
-		if (TownOccupationController.isResidentInAnOccupiedTown(resident)) 
+		if (SiegeWarSettings.getWarCommonOccupiedTownBattleParticipationDisabled() && TownOccupationController.isResidentInAnOccupiedTown(resident)) 
 			return false; //Player is from an occupied town
 
 		if(player.isFlying() || player.isGliding())


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Military ranks are removed from members of occupied towns, but mayors still have permission `siegewar.town.siege.battle.points` by default.
This change prevents occupied mayors from attending battle sessions and gaining or losing points via banner control or death penalty.
It also acts as a failsafe to prevent occupied town war participation in case of strange permission or rank configs.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [x] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.
